### PR TITLE
fix: hard bounce not updated correctly

### DIFF
--- a/apps/web/src/server/service/ses-hook-parser.ts
+++ b/apps/web/src/server/service/ses-hook-parser.ts
@@ -205,6 +205,7 @@ export async function parseSesHook(data: SesEvent) {
       updateField === "delivered"
     ) {
       logger.info("Updating cumulated metrics");
+      const cumulatedField = isHardBounced ? "hardBounced" : updateField;
       await db.cumulatedMetrics.upsert({
         where: {
           teamId_domainId: {
@@ -213,14 +214,14 @@ export async function parseSesHook(data: SesEvent) {
           },
         },
         update: {
-          [updateField]: {
+          [cumulatedField]: {
             increment: BigInt(1),
           },
         },
         create: {
           teamId: email.teamId,
           domainId: email.domainId ?? 0,
-          [updateField]: BigInt(1),
+          [cumulatedField]: BigInt(1),
         },
       });
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Hard bounce events are now counted under the Hard Bounced metric instead of the general Bounced metric, improving accuracy of email analytics.
  * Existing statuses (delivered, opened, clicked, complained, sent) continue to be tracked as before.
  * Dashboards and reports will reflect corrected hard bounce counts, ensuring clearer insight into email deliverability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->