### PR TITLE
feat: add Go SDK

### DIFF
--- a/packages/go-sdk/README.md
+++ b/packages/go-sdk/README.md
@@ -1,0 +1,46 @@
+# UseSend Go SDK
+
+A Go client for the [UseSend](https://app.usesend.com) API.
+
+## Installation
+
+```bash
+go get github.com/usesend/go-sdk
+```
+
+## Usage
+
+```go
+package main
+
+import (
+    "context"
+    "log"
+
+    usesend "github.com/usesend/go-sdk"
+)
+
+func main() {
+    client, err := usesend.NewClient("us_123")
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    resp, errResp, err := client.Emails.Send(context.Background(), usesend.SendEmailPayload{
+        To:   []string{"user@example.com"},
+        From: "no-reply@example.com",
+        Subject: "Hello",
+        HTML:    "<p>Hi there!</p>",
+    })
+    if err != nil {
+        log.Fatal(err)
+    }
+    if errResp != nil {
+        log.Fatalf("api error: %s", errResp.Message)
+    }
+
+    log.Printf("email queued with id %s", resp.EmailID)
+}
+```
+
+API keys can also be supplied via the `USESEND_API_KEY` environment variable.

--- a/packages/go-sdk/client.go
+++ b/packages/go-sdk/client.go
@@ -1,0 +1,122 @@
+package usesend
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"os"
+)
+
+const defaultBaseURL = "https://app.usesend.com/api/v1"
+
+type Client struct {
+	apiKey     string
+	baseURL    string
+	httpClient *http.Client
+
+	Emails   *EmailsService
+	Contacts *ContactsService
+}
+
+type ClientOption func(*Client)
+
+func WithBaseURL(url string) ClientOption {
+	return func(c *Client) {
+		c.baseURL = url
+	}
+}
+
+func WithHTTPClient(h *http.Client) ClientOption {
+	return func(c *Client) {
+		c.httpClient = h
+	}
+}
+
+func NewClient(apiKey string, opts ...ClientOption) (*Client, error) {
+	if apiKey == "" {
+		apiKey = os.Getenv("USESEND_API_KEY")
+		if apiKey == "" {
+			apiKey = os.Getenv("UNSEND_API_KEY")
+		}
+		if apiKey == "" {
+			return nil, errors.New("missing API key")
+		}
+	}
+
+	c := &Client{
+		apiKey:     apiKey,
+		baseURL:    defaultBaseURL,
+		httpClient: http.DefaultClient,
+	}
+
+	for _, opt := range opts {
+		opt(c)
+	}
+
+	c.Emails = &EmailsService{client: c}
+	c.Contacts = &ContactsService{client: c}
+
+	return c, nil
+}
+
+func (c *Client) doRequest(ctx context.Context, method, path string, body any, v any) (*ErrorResponse, error) {
+	var buf io.Reader
+	if body != nil {
+		b := &bytes.Buffer{}
+		if err := json.NewEncoder(b).Encode(body); err != nil {
+			return nil, err
+		}
+		buf = b
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, buf)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		if v != nil {
+			if err := json.NewDecoder(resp.Body).Decode(v); err != nil && err != io.EOF {
+				return nil, err
+			}
+		}
+		return nil, nil
+	}
+
+	errResp := &ErrorResponse{Message: resp.Status, Code: "INTERNAL_SERVER_ERROR"}
+	if err := json.NewDecoder(resp.Body).Decode(errResp); err != nil {
+		// use default errResp
+	}
+	return errResp, nil
+}
+
+func (c *Client) get(ctx context.Context, path string, out any) (*ErrorResponse, error) {
+	return c.doRequest(ctx, http.MethodGet, path, nil, out)
+}
+
+func (c *Client) post(ctx context.Context, path string, body any, out any) (*ErrorResponse, error) {
+	return c.doRequest(ctx, http.MethodPost, path, body, out)
+}
+
+func (c *Client) put(ctx context.Context, path string, body any, out any) (*ErrorResponse, error) {
+	return c.doRequest(ctx, http.MethodPut, path, body, out)
+}
+
+func (c *Client) patch(ctx context.Context, path string, body any, out any) (*ErrorResponse, error) {
+	return c.doRequest(ctx, http.MethodPatch, path, body, out)
+}
+
+func (c *Client) delete(ctx context.Context, path string, body any, out any) (*ErrorResponse, error) {
+	return c.doRequest(ctx, http.MethodDelete, path, body, out)
+}

--- a/packages/go-sdk/contacts.go
+++ b/packages/go-sdk/contacts.go
@@ -1,0 +1,72 @@
+package usesend
+
+import "context"
+
+type Contact struct {
+	ID            string            `json:"id"`
+	FirstName     string            `json:"firstName,omitempty"`
+	LastName      string            `json:"lastName,omitempty"`
+	Email         string            `json:"email"`
+	Subscribed    bool              `json:"subscribed"`
+	Properties    map[string]string `json:"properties"`
+	ContactBookID string            `json:"contactBookId"`
+	CreatedAt     string            `json:"createdAt"`
+	UpdatedAt     string            `json:"updatedAt"`
+}
+
+type CreateContactPayload struct {
+	Email      string            `json:"email"`
+	FirstName  string            `json:"firstName,omitempty"`
+	LastName   string            `json:"lastName,omitempty"`
+	Properties map[string]string `json:"properties,omitempty"`
+	Subscribed bool              `json:"subscribed,omitempty"`
+}
+
+type UpdateContactPayload struct {
+	FirstName  string            `json:"firstName,omitempty"`
+	LastName   string            `json:"lastName,omitempty"`
+	Properties map[string]string `json:"properties,omitempty"`
+	Subscribed bool              `json:"subscribed,omitempty"`
+}
+
+type CreateContactResponse struct {
+	ContactID string `json:"contactId"`
+}
+
+type DeleteContactResponse struct {
+	Success bool `json:"success"`
+}
+
+type ContactsService struct {
+	client *Client
+}
+
+func (c *ContactsService) Create(ctx context.Context, contactBookID string, payload CreateContactPayload) (CreateContactResponse, *ErrorResponse, error) {
+	var resp CreateContactResponse
+	errResp, err := c.client.post(ctx, "/contactBooks/"+contactBookID+"/contacts", payload, &resp)
+	return resp, errResp, err
+}
+
+func (c *ContactsService) Get(ctx context.Context, contactBookID, contactID string) (Contact, *ErrorResponse, error) {
+	var resp Contact
+	errResp, err := c.client.get(ctx, "/contactBooks/"+contactBookID+"/contacts/"+contactID, &resp)
+	return resp, errResp, err
+}
+
+func (c *ContactsService) Update(ctx context.Context, contactBookID, contactID string, payload UpdateContactPayload) (CreateContactResponse, *ErrorResponse, error) {
+	var resp CreateContactResponse
+	errResp, err := c.client.patch(ctx, "/contactBooks/"+contactBookID+"/contacts/"+contactID, payload, &resp)
+	return resp, errResp, err
+}
+
+func (c *ContactsService) Upsert(ctx context.Context, contactBookID, contactID string, payload CreateContactPayload) (CreateContactResponse, *ErrorResponse, error) {
+	var resp CreateContactResponse
+	errResp, err := c.client.put(ctx, "/contactBooks/"+contactBookID+"/contacts/"+contactID, payload, &resp)
+	return resp, errResp, err
+}
+
+func (c *ContactsService) Delete(ctx context.Context, contactBookID, contactID string) (DeleteContactResponse, *ErrorResponse, error) {
+	var resp DeleteContactResponse
+	errResp, err := c.client.delete(ctx, "/contactBooks/"+contactBookID+"/contacts/"+contactID, nil, &resp)
+	return resp, errResp, err
+}

--- a/packages/go-sdk/emails.go
+++ b/packages/go-sdk/emails.go
@@ -1,0 +1,97 @@
+package usesend
+
+import "context"
+
+type Attachment struct {
+	Filename string `json:"filename"`
+	Content  string `json:"content"`
+}
+
+type SendEmailPayload struct {
+	To          []string          `json:"to"`
+	From        string            `json:"from"`
+	Subject     string            `json:"subject,omitempty"`
+	TemplateID  string            `json:"templateId,omitempty"`
+	Variables   map[string]string `json:"variables,omitempty"`
+	ReplyTo     []string          `json:"replyTo,omitempty"`
+	CC          []string          `json:"cc,omitempty"`
+	BCC         []string          `json:"bcc,omitempty"`
+	Text        string            `json:"text,omitempty"`
+	HTML        string            `json:"html,omitempty"`
+	Attachments []Attachment      `json:"attachments,omitempty"`
+	ScheduledAt string            `json:"scheduledAt,omitempty"`
+	InReplyToID string            `json:"inReplyToId,omitempty"`
+}
+
+type CreateEmailResponse struct {
+	EmailID string `json:"emailId"`
+}
+
+type Email struct {
+	ID          string       `json:"id"`
+	TeamID      int          `json:"teamId"`
+	To          []string     `json:"to"`
+	ReplyTo     []string     `json:"replyTo,omitempty"`
+	CC          []string     `json:"cc,omitempty"`
+	BCC         []string     `json:"bcc,omitempty"`
+	From        string       `json:"from"`
+	Subject     string       `json:"subject"`
+	HTML        string       `json:"html"`
+	Text        string       `json:"text"`
+	CreatedAt   string       `json:"createdAt"`
+	UpdatedAt   string       `json:"updatedAt"`
+	EmailEvents []EmailEvent `json:"emailEvents"`
+}
+
+type EmailEvent struct {
+	EmailID   string `json:"emailId"`
+	Status    string `json:"status"`
+	CreatedAt string `json:"createdAt"`
+	Data      any    `json:"data,omitempty"`
+}
+
+type UpdateEmailPayload struct {
+	ScheduledAt string `json:"scheduledAt"`
+}
+
+type BatchEmailResponse struct {
+	Data []CreateEmailResponse `json:"data"`
+}
+
+type EmailsService struct {
+	client *Client
+}
+
+func (e *EmailsService) Create(ctx context.Context, payload SendEmailPayload) (CreateEmailResponse, *ErrorResponse, error) {
+	var resp CreateEmailResponse
+	errResp, err := e.client.post(ctx, "/emails", payload, &resp)
+	return resp, errResp, err
+}
+
+func (e *EmailsService) Send(ctx context.Context, payload SendEmailPayload) (CreateEmailResponse, *ErrorResponse, error) {
+	return e.Create(ctx, payload)
+}
+
+func (e *EmailsService) Batch(ctx context.Context, payload []SendEmailPayload) (BatchEmailResponse, *ErrorResponse, error) {
+	var resp BatchEmailResponse
+	errResp, err := e.client.post(ctx, "/emails/batch", payload, &resp)
+	return resp, errResp, err
+}
+
+func (e *EmailsService) Get(ctx context.Context, id string) (Email, *ErrorResponse, error) {
+	var resp Email
+	errResp, err := e.client.get(ctx, "/emails/"+id, &resp)
+	return resp, errResp, err
+}
+
+func (e *EmailsService) Update(ctx context.Context, id string, payload UpdateEmailPayload) (CreateEmailResponse, *ErrorResponse, error) {
+	var resp CreateEmailResponse
+	errResp, err := e.client.patch(ctx, "/emails/"+id, payload, &resp)
+	return resp, errResp, err
+}
+
+func (e *EmailsService) Cancel(ctx context.Context, id string) (CreateEmailResponse, *ErrorResponse, error) {
+	var resp CreateEmailResponse
+	errResp, err := e.client.post(ctx, "/emails/"+id+"/cancel", nil, &resp)
+	return resp, errResp, err
+}

--- a/packages/go-sdk/go.mod
+++ b/packages/go-sdk/go.mod
@@ -1,0 +1,3 @@
+module github.com/usesend/go-sdk
+
+go 1.21

--- a/packages/go-sdk/types.go
+++ b/packages/go-sdk/types.go
@@ -1,0 +1,6 @@
+package usesend
+
+type ErrorResponse struct {
+	Message string `json:"message"`
+	Code    string `json:"code"`
+}


### PR DESCRIPTION
## Summary
- add initial Go client for UseSend API
- support email and contact operations with typed helpers
- document installation and usage

## Testing
- `pnpm lint` (fails: ESLint found too many warnings in @usesend/ui)
- `pnpm build` (fails: ENETUNREACH during db:generate)
- `(cd packages/go-sdk && go vet ./...)` (hangs, terminated)


------
https://chatgpt.com/codex/tasks/task_e_68baaf4a4e448329acd685868bdc2712