### PR TITLE
fix: avoid crash on billing page when payment method missing

### DIFF
--- a/apps/web/src/app/(dashboard)/settings/billing/page.tsx
+++ b/apps/web/src/app/(dashboard)/settings/billing/page.tsx
@@ -19,7 +19,7 @@ export default function SettingsPage() {
   const { data: subscription } = api.billing.getSubscriptionDetails.useQuery();
   const [isEditingEmail, setIsEditingEmail] = useState(false);
   const [billingEmail, setBillingEmail] = useState(
-    currentTeam?.billingEmail || ""
+    currentTeam?.billingEmail || "",
   );
 
   const apiUtils = api.useUtils();
@@ -46,7 +46,10 @@ export default function SettingsPage() {
     }
   };
 
-  const paymentMethod = JSON.parse(subscription?.paymentMethod || "{}");
+  const paymentMethod =
+    subscription?.paymentMethod && subscription.paymentMethod !== "null"
+      ? JSON.parse(subscription.paymentMethod)
+      : {};
 
   if (!currentIsAdmin) {
     return null;
@@ -89,14 +92,15 @@ export default function SettingsPage() {
             {subscription ? (
               <div className="mt-2">
                 <div className="text-lg font-mono uppercase flex items-center gap-2">
-                  {subscription.paymentMethod ? (
+                  {subscription.paymentMethod &&
+                  subscription.paymentMethod !== "null" ? (
                     <>
                       <span>💳</span>
                       <span className="capitalize">
-                        {paymentMethod.card?.brand || ""} ••••{" "}
-                        {paymentMethod.card?.last4 || ""}
+                        {paymentMethod?.card?.brand || ""} ••••{" "}
+                        {paymentMethod?.card?.last4 || ""}
                       </span>
-                      {paymentMethod.card && (
+                      {paymentMethod?.card && (
                         <span className="text-sm text-muted-foreground lowercase">
                           (Expires: {paymentMethod.card.exp_month}/
                           {paymentMethod.card.exp_year})
@@ -112,7 +116,7 @@ export default function SettingsPage() {
                   {subscription.currentPeriodEnd
                     ? format(
                         new Date(subscription.currentPeriodEnd),
-                        "MMM dd, yyyy"
+                        "MMM dd, yyyy",
                       )
                     : "N/A"}
                 </div>


### PR DESCRIPTION
## Summary
- handle null Stripe payment method to prevent billing page crash
- guard rendering payment info when no method is present

## Testing
- `pnpm lint` *(fails: ESLint found too many warnings)*
- `pnpm build --filter=web` *(fails: Invalid environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68c00497dfe483298a646129f3e31bae

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Billing settings now handles missing or invalid payment methods gracefully, preventing errors and avoiding display of “null” values.
  * Payment Method section only appears when valid data exists.
  * Card details (brand, last 4, expiry) display more reliably without runtime issues.

* **Style**
  * Minor formatting adjustments with no user-visible impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->