### PR TITLE
feat: add domain-based access control for API keys

### DIFF
--- a/apps/web/prisma/migrations/20250822125136_add_domain_access_to_api_keys/migration.sql
+++ b/apps/web/prisma/migrations/20250822125136_add_domain_access_to_api_keys/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "ApiKey" ADD COLUMN     "domainId" INTEGER;
+
+-- AddForeignKey
+ALTER TABLE "ApiKey" ADD CONSTRAINT "ApiKey_domainId_fkey" FOREIGN KEY ("domainId") REFERENCES "Domain"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -216,7 +216,7 @@ model ApiKey {
   lastUsed     DateTime?
   teamId       Int
   team         Team          @relation(fields: [teamId], references: [id], onDelete: Cascade)
-  domain       Domain?       @relation(fields: [domainId], references: [id], onDelete: Cascade)
+  domain       Domain?       @relation(fields: [domainId], references: [id], onDelete: SetNull, onUpdate: Cascade)
 }
 
 enum EmailStatus {

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -195,6 +195,7 @@ model Domain {
   createdAt     DateTime     @default(now())
   updatedAt     DateTime     @updatedAt
   team          Team         @relation(fields: [teamId], references: [id], onDelete: Cascade)
+  apiKeys       ApiKey[]
 }
 
 enum ApiPermission {
@@ -209,11 +210,13 @@ model ApiKey {
   partialToken String
   name         String
   permission   ApiPermission @default(SENDING)
+  domainId     Int?
   createdAt    DateTime      @default(now())
   updatedAt    DateTime      @updatedAt
   lastUsed     DateTime?
   teamId       Int
   team         Team          @relation(fields: [teamId], references: [id], onDelete: Cascade)
+  domain       Domain?       @relation(fields: [domainId], references: [id], onDelete: Cascade)
 }
 
 enum EmailStatus {

--- a/apps/web/src/app/(dashboard)/dev-settings/api-keys/add-api-key.tsx
+++ b/apps/web/src/app/(dashboard)/dev-settings/api-keys/add-api-key.tsx
@@ -27,11 +27,20 @@ import {
   FormLabel,
   FormMessage,
 } from "@usesend/ui/src/form";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@unsend/ui/src/select";
+
 
 const apiKeySchema = z.object({
   name: z.string({ required_error: "Name is required" }).min(1, {
     message: "Name is required",
   }),
+  domainId: z.string().optional(),
 });
 
 export default function AddApiKey() {
@@ -40,6 +49,8 @@ export default function AddApiKey() {
   const createApiKeyMutation = api.apiKey.createToken.useMutation();
   const [isCopied, setIsCopied] = useState(false);
   const [showApiKey, setShowApiKey] = useState(false);
+  
+  const domainsQuery = api.domain.domains.useQuery();
 
   const utils = api.useUtils();
 
@@ -47,6 +58,7 @@ export default function AddApiKey() {
     resolver: zodResolver(apiKeySchema),
     defaultValues: {
       name: "",
+      domainId: "all",
     },
   });
 
@@ -55,6 +67,7 @@ export default function AddApiKey() {
       {
         name: values.name,
         permission: "FULL",
+        domainId: values.domainId === "all" ? undefined : Number(values.domainId),
       },
       {
         onSuccess: (data) => {
@@ -177,6 +190,33 @@ export default function AddApiKey() {
                           Use a name to easily identify this API key.
                         </FormDescription>
                       )}
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={apiKeyForm.control}
+                  name="domainId"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Domain access</FormLabel>
+                      <Select onValueChange={field.onChange} defaultValue={field.value}>
+                        <FormControl>
+                          <SelectTrigger>
+                            <SelectValue placeholder="Select domain access" />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          <SelectItem value="all">All Domains</SelectItem>
+                          {domainsQuery.data?.map((domain: { id: number; name: string }) => (
+                            <SelectItem key={domain.id} value={domain.id.toString()}>
+                              {domain.name}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <FormDescription>
+                        Choose which domain this API key can send emails from.
+                      </FormDescription>
                     </FormItem>
                   )}
                 />

--- a/apps/web/src/app/(dashboard)/dev-settings/api-keys/add-api-key.tsx
+++ b/apps/web/src/app/(dashboard)/dev-settings/api-keys/add-api-key.tsx
@@ -33,8 +33,7 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from "@unsend/ui/src/select";
-
+} from "@usesend/ui/src/select";
 
 const apiKeySchema = z.object({
   name: z.string({ required_error: "Name is required" }).min(1, {
@@ -49,7 +48,7 @@ export default function AddApiKey() {
   const createApiKeyMutation = api.apiKey.createToken.useMutation();
   const [isCopied, setIsCopied] = useState(false);
   const [showApiKey, setShowApiKey] = useState(false);
-  
+
   const domainsQuery = api.domain.domains.useQuery();
 
   const utils = api.useUtils();
@@ -67,7 +66,8 @@ export default function AddApiKey() {
       {
         name: values.name,
         permission: "FULL",
-        domainId: values.domainId === "all" ? undefined : Number(values.domainId),
+        domainId:
+          values.domainId === "all" ? undefined : Number(values.domainId),
       },
       {
         onSuccess: (data) => {
@@ -75,7 +75,7 @@ export default function AddApiKey() {
           setApiKey(data);
           apiKeyForm.reset();
         },
-      },
+      }
     );
   }
 
@@ -199,7 +199,10 @@ export default function AddApiKey() {
                   render={({ field }) => (
                     <FormItem>
                       <FormLabel>Domain access</FormLabel>
-                      <Select onValueChange={field.onChange} defaultValue={field.value}>
+                      <Select
+                        onValueChange={field.onChange}
+                        defaultValue={field.value}
+                      >
                         <FormControl>
                           <SelectTrigger>
                             <SelectValue placeholder="Select domain access" />
@@ -207,11 +210,16 @@ export default function AddApiKey() {
                         </FormControl>
                         <SelectContent>
                           <SelectItem value="all">All Domains</SelectItem>
-                          {domainsQuery.data?.map((domain: { id: number; name: string }) => (
-                            <SelectItem key={domain.id} value={domain.id.toString()}>
-                              {domain.name}
-                            </SelectItem>
-                          ))}
+                          {domainsQuery.data?.map(
+                            (domain: { id: number; name: string }) => (
+                              <SelectItem
+                                key={domain.id}
+                                value={domain.id.toString()}
+                              >
+                                {domain.name}
+                              </SelectItem>
+                            )
+                          )}
                         </SelectContent>
                       </Select>
                       <FormDescription>

--- a/apps/web/src/app/(dashboard)/dev-settings/api-keys/api-list.tsx
+++ b/apps/web/src/app/(dashboard)/dev-settings/api-keys/api-list.tsx
@@ -25,6 +25,7 @@ export default function ApiList() {
               <TableHead className="rounded-tl-xl">Name</TableHead>
               <TableHead>Token</TableHead>
               <TableHead>Permission</TableHead>
+              <TableHead>Domain Access</TableHead>
               <TableHead>Last used</TableHead>
               <TableHead>Created at</TableHead>
               <TableHead className="rounded-tr-xl">Action</TableHead>
@@ -33,7 +34,7 @@ export default function ApiList() {
           <TableBody>
             {apiKeysQuery.isLoading ? (
               <TableRow className="h-32">
-                <TableCell colSpan={6} className="text-center py-4">
+                <TableCell colSpan={7} className="text-center py-4">
                   <Spinner
                     className="w-6 h-6 mx-auto"
                     innerSvgClass="stroke-primary"
@@ -42,7 +43,7 @@ export default function ApiList() {
               </TableRow>
             ) : apiKeysQuery.data?.length === 0 ? (
               <TableRow className="h-32">
-                <TableCell colSpan={6} className="text-center py-4">
+                <TableCell colSpan={7} className="text-center py-4">
                   <p>No API keys added</p>
                 </TableCell>
               </TableRow>
@@ -53,8 +54,13 @@ export default function ApiList() {
                   <TableCell>{apiKey.partialToken}</TableCell>
                   <TableCell>{apiKey.permission}</TableCell>
                   <TableCell>
+                    {apiKey.domainId
+                      ? apiKey.domain?.name ?? "Domain removed"
+                      : "All domains"}
+                  </TableCell>
+                  <TableCell>
                     {apiKey.lastUsed
-                      ? formatDistanceToNow(apiKey.lastUsed)
+                      ? formatDistanceToNow(apiKey.lastUsed, { addSuffix: true })
                       : "Never"}
                   </TableCell>
                   <TableCell>

--- a/apps/web/src/server/api/routers/api.ts
+++ b/apps/web/src/server/api/routers/api.ts
@@ -1,4 +1,6 @@
 import { z } from "zod";
+import { ApiPermission } from "@prisma/client";
+import { TRPCError } from "@trpc/server";
 
 import {
   apiKeyProcedure,
@@ -10,13 +12,18 @@ import { addApiKey, deleteApiKey } from "~/server/service/api-service";
 export const apiRouter = createTRPCRouter({
   createToken: teamProcedure
     .input(
-      z.object({ name: z.string(), permission: z.enum(["FULL", "SENDING"]) })
+      z.object({
+        name: z.string(),
+        permission: z.nativeEnum(ApiPermission),
+        domainId: z.number().int().positive().optional(),
+      })
     )
     .mutation(async ({ ctx, input }) => {
-      return addApiKey({
+      return await addApiKey({
         name: input.name,
         permission: input.permission,
         teamId: ctx.team.id,
+        domainId: input.domainId,
       });
     }),
 
@@ -32,6 +39,12 @@ export const apiRouter = createTRPCRouter({
         partialToken: true,
         lastUsed: true,
         createdAt: true,
+        domainId: true,
+        domain: {
+          select: {
+            name: true,
+          },
+        },
       },
     });
 

--- a/apps/web/src/server/public-api/api-utils.ts
+++ b/apps/web/src/server/public-api/api-utils.ts
@@ -33,3 +33,26 @@ export const checkIsValidEmailId = async (emailId: string, teamId: number) => {
     throw new UnsendApiError({ code: "NOT_FOUND", message: "Email not found" });
   }
 };
+
+export const checkIsValidEmailIdWithDomainRestriction = async (
+  emailId: string, 
+  teamId: number, 
+  apiKeyDomainId?: number
+) => {
+  const whereClause: { id: string; teamId: number; domainId?: number } = {
+    id: emailId,
+    teamId,
+  };
+
+  if (apiKeyDomainId !== undefined) {
+    whereClause.domainId = apiKeyDomainId;
+  }
+
+  const email = await db.email.findUnique({ where: whereClause });
+
+  if (!email) {
+    throw new UnsendApiError({ code: "NOT_FOUND", message: "Email not found" });
+  }
+
+  return email;
+};

--- a/apps/web/src/server/public-api/api/emails/cancel-email.ts
+++ b/apps/web/src/server/public-api/api/emails/cancel-email.ts
@@ -2,7 +2,7 @@ import { createRoute, z } from "@hono/zod-openapi";
 import { PublicAPIApp } from "~/server/public-api/hono";
 import { getTeamFromToken } from "~/server/public-api/auth";
 import { cancelEmail } from "~/server/service/email-service";
-import { checkIsValidEmailId } from "../../api-utils";
+import { checkIsValidEmailIdWithDomainRestriction } from "../../api-utils";
 
 const route = createRoute({
   method: "post",
@@ -37,7 +37,7 @@ function cancelScheduledEmail(app: PublicAPIApp) {
   app.openapi(route, async (c) => {
     const team = c.var.team;
     const emailId = c.req.param("emailId");
-    await checkIsValidEmailId(emailId, team.id);
+    await checkIsValidEmailIdWithDomainRestriction(emailId, team.id, team.apiKey.domainId);
 
     await cancelEmail(emailId);
 

--- a/apps/web/src/server/public-api/api/emails/cancel-email.ts
+++ b/apps/web/src/server/public-api/api/emails/cancel-email.ts
@@ -37,7 +37,11 @@ function cancelScheduledEmail(app: PublicAPIApp) {
   app.openapi(route, async (c) => {
     const team = c.var.team;
     const emailId = c.req.param("emailId");
-    await checkIsValidEmailIdWithDomainRestriction(emailId, team.id, team.apiKey.domainId);
+    await checkIsValidEmailIdWithDomainRestriction(
+      emailId,
+      team.id,
+      team.apiKey.domainId ?? undefined
+    );
 
     await cancelEmail(emailId);
 

--- a/apps/web/src/server/public-api/api/emails/get-email.ts
+++ b/apps/web/src/server/public-api/api/emails/get-email.ts
@@ -58,14 +58,19 @@ const route = createRoute({
 function send(app: PublicAPIApp) {
   app.openapi(route, async (c) => {
     const team = c.var.team;
-
     const emailId = c.req.param("emailId");
 
+    const whereClause: { id: string; teamId: number; domainId?: number } = {
+      id: emailId,
+      teamId: team.id,
+    };
+
+    if (team.apiKey.domainId !== null) {
+      whereClause.domainId = team.apiKey.domainId;
+    }
+
     const email = await db.email.findUnique({
-      where: {
-        id: emailId,
-        teamId: team.id,
-      },
+      where: whereClause,
       select: {
         id: true,
         teamId: true,

--- a/apps/web/src/server/public-api/api/emails/get-email.ts
+++ b/apps/web/src/server/public-api/api/emails/get-email.ts
@@ -60,17 +60,12 @@ function send(app: PublicAPIApp) {
     const team = c.var.team;
     const emailId = c.req.param("emailId");
 
-    const whereClause: { id: string; teamId: number; domainId?: number } = {
-      id: emailId,
-      teamId: team.id,
-    };
-
-    if (team.apiKey.domainId !== null) {
-      whereClause.domainId = team.apiKey.domainId;
-    }
-
     const email = await db.email.findUnique({
-      where: whereClause,
+      where: {
+        id: emailId,
+        teamId: team.id,
+        domainId: team.apiKey.domainId ?? undefined,
+      },
       select: {
         id: true,
         teamId: true,

--- a/apps/web/src/server/public-api/api/emails/list-emails.ts
+++ b/apps/web/src/server/public-api/api/emails/list-emails.ts
@@ -123,7 +123,9 @@ function listEmails(app: PublicAPIApp) {
       };
     }
 
-    if (domainId && domainId.length > 0) {
+    if (team.apiKey.domainId !== null) {
+      whereClause.domainId = team.apiKey.domainId;
+    } else if (domainId && domainId.length > 0) {
       whereClause.domainId = { in: domainId };
     }
 

--- a/apps/web/src/server/public-api/api/emails/update-email.ts
+++ b/apps/web/src/server/public-api/api/emails/update-email.ts
@@ -2,7 +2,7 @@ import { createRoute, z } from "@hono/zod-openapi";
 import { PublicAPIApp } from "~/server/public-api/hono";
 import { getTeamFromToken } from "~/server/public-api/auth";
 import { updateEmail } from "~/server/service/email-service";
-import { checkIsValidEmailId } from "../../api-utils";
+import { checkIsValidEmailIdWithDomainRestriction } from "../../api-utils";
 
 const route = createRoute({
   method: "patch",
@@ -48,7 +48,7 @@ function updateEmailScheduledAt(app: PublicAPIApp) {
     const team = c.var.team;
     const emailId = c.req.param("emailId");
 
-    await checkIsValidEmailId(emailId, team.id);
+    await checkIsValidEmailIdWithDomainRestriction(emailId, team.id, team.apiKey.domainId);
 
     await updateEmail(emailId, {
       scheduledAt: c.req.valid("json").scheduledAt,

--- a/apps/web/src/server/public-api/api/emails/update-email.ts
+++ b/apps/web/src/server/public-api/api/emails/update-email.ts
@@ -48,7 +48,11 @@ function updateEmailScheduledAt(app: PublicAPIApp) {
     const team = c.var.team;
     const emailId = c.req.param("emailId");
 
-    await checkIsValidEmailIdWithDomainRestriction(emailId, team.id, team.apiKey.domainId);
+    await checkIsValidEmailIdWithDomainRestriction(
+      emailId,
+      team.id,
+      team.apiKey.domainId ?? undefined
+    );
 
     await updateEmail(emailId, {
       scheduledAt: c.req.valid("json").scheduledAt,

--- a/apps/web/src/server/public-api/auth.ts
+++ b/apps/web/src/server/public-api/auth.ts
@@ -59,5 +59,5 @@ export const getTeamFromToken = async (c: Context) => {
       logger.error({ err }, "Failed to update lastUsed on API key")
     );
 
-  return { ...team, apiKeyId: apiKey.id };
+  return { ...team, apiKeyId: apiKey.id, apiKey: { domainId: apiKey.domainId } };
 };

--- a/apps/web/src/server/public-api/hono.ts
+++ b/apps/web/src/server/public-api/hono.ts
@@ -7,13 +7,13 @@ import { getRedis } from "~/server/redis";
 import { getTeamFromToken } from "~/server/public-api/auth";
 import { isSelfHosted } from "~/utils/common";
 import { UnsendApiError } from "./api-error";
-import { Team } from "@prisma/client";
+import { Team, ApiKey } from "@prisma/client";
 import { logger } from "../logger/log";
 
 // Define AppEnv for Hono context
 export type AppEnv = {
   Variables: {
-    team: Team & { apiKeyId: number };
+    team: Team & { apiKeyId: number; apiKey: { domainId: number | null } };
   };
 };
 

--- a/apps/web/src/server/service/domain-service.ts
+++ b/apps/web/src/server/service/domain-service.ts
@@ -6,6 +6,7 @@ import { db } from "~/server/db";
 import { SesSettingsService } from "./ses-settings-service";
 import { UnsendApiError } from "../public-api/api-error";
 import { logger } from "../logger/log";
+import { ApiKey } from "@prisma/client";
 import { LimitService } from "./limit-service";
 
 const dnsResolveTxt = util.promisify(dns.resolveTxt);
@@ -34,7 +35,7 @@ export async function validateDomainFromEmail(email: string, teamId: number) {
     });
   }
 
-  const domain = await db.domain.findUnique({
+  const domain = await db.domain.findFirst({
     where: { name: fromDomain, teamId },
   });
 
@@ -52,6 +53,30 @@ export async function validateDomainFromEmail(email: string, teamId: number) {
     });
   }
 
+  return domain;
+}
+
+export async function validateApiKeyDomainAccess(
+  email: string,
+  teamId: number,
+  apiKey: ApiKey & { domain?: { name: string } | null }
+) {
+  // First validate the domain exists and is verified
+  const domain = await validateDomainFromEmail(email, teamId);
+  
+  // If API key has no domain restriction (domainId is null), allow all domains
+  if (!apiKey.domainId) {
+    return domain;
+  }
+  
+  // If API key is restricted to a specific domain, check if it matches
+  if (apiKey.domainId !== domain.id) {
+    throw new UnsendApiError({
+      code: "FORBIDDEN",
+      message: `API key does not have access to domain: ${domain.name}`,
+    });
+  }
+  
   return domain;
 }
 

--- a/apps/web/src/server/service/email-service.ts
+++ b/apps/web/src/server/service/email-service.ts
@@ -2,7 +2,7 @@ import { EmailContent } from "~/types";
 import { db } from "../db";
 import { UnsendApiError } from "~/server/public-api/api-error";
 import { EmailQueueService } from "./email-queue-service";
-import { validateDomainFromEmail } from "./domain-service";
+import { validateDomainFromEmail, validateApiKeyDomainAccess } from "./domain-service";
 import { EmailRenderer } from "@usesend/email-editor/src/renderer";
 import { logger } from "../logger/log";
 import { SuppressionService } from "./suppression-service";
@@ -70,7 +70,27 @@ export async function sendEmail(
   let subject = subjectFromApiCall;
   let html = htmlFromApiCall;
 
-  const domain = await validateDomainFromEmail(from, teamId);
+  let domain: Awaited<ReturnType<typeof validateDomainFromEmail>>;
+  
+  // If this is an API call with an API key, validate domain access
+  if (apiKeyId) {
+    const apiKey = await db.apiKey.findUnique({
+      where: { id: apiKeyId },
+      include: { domain: true },
+    });
+    
+    if (!apiKey) {
+      throw new UnsendApiError({
+        code: "BAD_REQUEST",
+        message: "Invalid API key",
+      });
+    }
+    
+    domain = await validateApiKeyDomainAccess(from, teamId, apiKey);
+  } else {
+    // For non-API calls (dashboard, etc.), use regular domain validation
+    domain = await validateDomainFromEmail(from, teamId);
+  }
 
   // Check for suppressed emails before sending
   const toEmails = Array.isArray(to) ? to : [to];


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Create API keys with Domain access: choose “All domains” or restrict to a specific domain.
  * API Keys list shows a Domain Access column and friendlier “Last used” times (e.g., “2 days ago”).
  * Public API and email flows enforce API-key domain scoping (list/get/update/cancel/verify) and return clear 403/404 errors when access is denied.
* **Other**
  * Added domain-scoped email validation to support the above.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->