### PR TITLE
feat: include bounce reason in export

### DIFF
--- a/apps/web/src/app/(dashboard)/emails/email-list.tsx
+++ b/apps/web/src/app/(dashboard)/emails/email-list.tsx
@@ -122,9 +122,17 @@ export default function EmailsList() {
         return /[",\r\n]/.test(safe) ? `"${safe}"` : safe;
       };
 
-      const header = ["To", "Status", "Subject", "Sent At"].join(",");
+      const header = [
+        "To",
+        "Status",
+        "Subject",
+        "Sent At",
+        "Bounce Reason",
+      ].join(",");
       const rows = resp.data.map((e) =>
-        [e.to, e.status, e.subject, e.sentAt].map(escape).join(","),
+        [e.to, e.status, e.subject, e.sentAt, e.bounceReason]
+          .map(escape)
+          .join(","),
       );
       const csv = [header, ...rows].join("\n");
 

--- a/apps/web/src/app/(dashboard)/emails/email-list.tsx
+++ b/apps/web/src/app/(dashboard)/emails/email-list.tsx
@@ -127,10 +127,20 @@ export default function EmailsList() {
         "Status",
         "Subject",
         "Sent At",
+        "Bounce Type",
+        "Bounce Subtype",
         "Bounce Reason",
       ].join(",");
       const rows = resp.data.map((e) =>
-        [e.to, e.status, e.subject, e.sentAt, e.bounceReason]
+        [
+          e.to,
+          e.status,
+          e.subject,
+          e.sentAt,
+          e.bounceType,
+          e.bounceSubType,
+          e.bounceReason,
+        ]
           .map(escape)
           .join(","),
       );


### PR DESCRIPTION
## Summary
- include bounce reason in email export data
- add bounce reason column to CSV export

## Testing
- `pnpm lint` *(fails: ESLint found too many warnings)*
- `pnpm build` *(fails: ENETUNREACH connect errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c1deb51ea48329bf90b2c717a68ae0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CSV export now includes Bounce Type, Bounce Subtype, and Bounce Reason columns; Bounce Reason may be empty if unavailable.
  * Exported email rows now include bounce type/subtype for clearer diagnostics.

* **Chores / API**
  * Export endpoint now returns optional bounceType, bounceSubType, and bounceReason.
  * Exported "to" is a semicolon-separated string and sentAt is returned as a string.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->