### PR TITLE
docs: add Railway self-hosting guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,9 +96,11 @@ For detailed instructions on how to configure and run the Docker container, plea
 
 ## Self Hosting
 
-Checkout the [Self hosting](https://docs.usesend.com/get-started/self-hosting) guide to learn how to self-host useSend.
+Checkout the [self-hosting guide](https://docs.usesend.com/self-hosting/overview) to learn how to run useSend on your own infrastructure.
 
-Also
+## Self Hosting with Railway
+
+Railway provides the quickest way to spin up useSend. Read the [Railway self-hosting guide](https://docs.usesend.com/self-hosting/railway) or deploy directly:
 
 [![Deploy on Railway](https://railway.app/button.svg)](https://railway.app/template/QbMnwX?referralCode=oaAwvp)
 

--- a/apps/docs/docs.json
+++ b/apps/docs/docs.json
@@ -29,8 +29,14 @@
               "get-started/nodejs",
               "get-started/python",
               "get-started/local",
-              "get-started/self-hosting",
               "get-started/smtp"
+            ]
+          },
+          {
+            "group": "Self Hosting",
+            "pages": [
+              "self-hosting/overview",
+              "self-hosting/railway"
             ]
           },
           {

--- a/apps/docs/self-hosting/overview.mdx
+++ b/apps/docs/self-hosting/overview.mdx
@@ -53,7 +53,7 @@ GITHUB_SECRET="<your-github-client-secret>"
   <Step title="Database & Redis">
   useSend uses Postgres as a database and Redis as a queue. You need to create a new database and add the following environment variables.
 
-If you're using docker-compose or our railway template, it's all automatically done for you.
+If you're using docker-compose, it's all automatically done for you.
 
 ```env
 DATABASE_URL="postgres://<username>:<password>@<host>:<port>/<database-name>"
@@ -80,23 +80,13 @@ Add the following environment variables.
 
 ## Step 2: Setting up the app
 
-You can use any platforms that supports docker. You can also use the railway template. In this example I'll be using railway. If you have any questions drop in the [discord channel](https://discord.gg/gbsvjb9MqV) and i'll try to help you out
+You can use any platform that supports Docker to host useSend. If you have any questions drop in the [discord channel](https://discord.gg/gbsvjb9MqV) and we'll try to help you out.
 
 ### Docker
 
 Follow this guide to setup your docker instance: [Set up docker](/get-started/set-up-docker)
 
 [![Docker image](https://img.shields.io/badge/dockerhub-images-important.svg?logo=Docker)](https://hub.docker.com/r/usesend/usesend)
-
-### Railway
-
-This option is very easy. Click on the below button and click "Deploy now". Add a custom domain etc.
-
-Updating image is easy, click on the 3 dots and redeploy. This will pull the latest image.
-
-[![Deploy on Railway](https://railway.app/button.svg)](https://railway.app/template/QbMnwX?referralCode=oaAwvp)
-
-Your useSend instance is now live now.
 
 ## Step 3: Setting up a region
 

--- a/apps/docs/self-hosting/railway.mdx
+++ b/apps/docs/self-hosting/railway.mdx
@@ -1,0 +1,16 @@
+---
+title: Self hosting with Railway
+description: Deploy useSend on Railway with one click.
+icon: server
+---
+
+Railway offers the quickest way to get a useSend instance running.
+
+1. Click the button below and choose **Deploy now**.
+2. Wait for the build to finish and open the service.
+3. Add any required environment variables and a custom domain if needed.
+4. Redeploy from the dashboard whenever you want to pull the latest image.
+
+[![Deploy on Railway](https://railway.app/button.svg)](https://railway.app/template/QbMnwX?referralCode=oaAwvp)
+
+Once the service is up, your useSend instance is ready to use.


### PR DESCRIPTION
## Summary
- reorganize docs navigation with dedicated Self Hosting section
- add Railway self-hosting guide
- clarify self-hosting instructions in README

## Testing
- `pnpm lint` *(fails: no-unused-vars warnings in packages/ui)*
- `pnpm build` *(fails: ENETUNREACH during db:generate)*

------
https://chatgpt.com/codex/tasks/task_e_68c3a1cd24c08329bbd11d201d7c0022