### PR TITLE
docs: enable Mintlify contextual menu

### DIFF
--- a/apps/docs/docs.json
+++ b/apps/docs/docs.json
@@ -34,23 +34,15 @@
           },
           {
             "group": "Self Hosting",
-            "pages": [
-              "self-hosting/overview",
-              "self-hosting/railway"
-            ]
+            "pages": ["self-hosting/overview", "self-hosting/railway"]
           },
           {
             "group": "Guides",
-            "pages": [
-              "guides/use-with-react-email"
-            ]
+            "pages": ["guides/use-with-react-email"]
           },
           {
             "group": "Community SDKs",
-            "pages": [
-              "community-sdk/python",
-              "community-sdk/go"
-            ]
+            "pages": ["community-sdk/python", "community-sdk/go"]
           }
         ]
       },
@@ -59,9 +51,7 @@
         "groups": [
           {
             "group": "API Reference",
-            "pages": [
-              "api-reference/introduction"
-            ]
+            "pages": ["api-reference/introduction"]
           },
           {
             "group": "Emails",
@@ -144,5 +134,8 @@
       "x": "https://x.com/useSend_com",
       "github": "https://github.com/usesend"
     }
+  },
+  "contextual": {
+    "options": ["copy", "view", "chatgpt", "claude", "perplexity"]
   }
 }


### PR DESCRIPTION
## Summary
- enable contextual menu with copy, view, chatgpt, claude, and perplexity options in Mintlify docs
- remove MCP-related options (mcp, cursor, vscode)

## Testing
- `pnpm exec prettier apps/docs/docs.json --write`
- `pnpm lint` *(fails: ESLint found too many warnings in packages/ui)*
- `pnpm build` *(fails: ENETUNREACH while downloading pnpm)*

------
https://chatgpt.com/codex/tasks/task_e_68c71490540883298fe0614f055ad54e