### PR TITLE
docs: update railway deploy links

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Checkout the [self-hosting guide](https://docs.usesend.com/self-hosting/overview
 
 Railway provides the quickest way to spin up useSend. Read the [Railway self-hosting guide](https://docs.usesend.com/self-hosting/railway) or deploy directly:
 
-[![Deploy on Railway](https://railway.app/button.svg)](https://railway.app/template/QbMnwX?referralCode=oaAwvp)
+[![Deploy on Railway](https://railway.app/button.svg)](https://railway.com/deploy/usesend?utm_medium=integration&utm_source=docs&utm_campaign=usesend)
 
 ## Star History
 

--- a/apps/docs/self-hosting/railway.mdx
+++ b/apps/docs/self-hosting/railway.mdx
@@ -3,9 +3,9 @@ title: Self hosting with Railway
 description: Deploy useSend on Railway with one click.
 ---
 
-useSend is a [Railway Partner](https://railway.app/partners) and Railway offers the quickest way to get a useSend instance running.
+useSend is a [Railway Partner](https://railway.app/partners?utm_medium=integration&utm_source=docs&utm_campaign=usesend) and Railway offers the quickest way to get a useSend instance running.
 
-[![Deploy on Railway](https://railway.app/button.svg)](https://railway.app/template/QbMnwX?referralCode=oaAwvp)
+[![Deploy on Railway](https://railway.app/button.svg)](https://railway.com/deploy/usesend?utm_medium=integration&utm_source=docs&utm_campaign=usesend)
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary
- update the Railway deploy button links to the new `railway.com/deploy/usesend` endpoint while preserving the UTM parameters
- keep the Railway partner reference in the self-hosting docs using the same tracking parameters
- keep the Railway deploy button image source using the standard SVG without UTM parameters

## Testing
- pnpm lint *(fails: existing lint warnings in packages/ui)*

------
https://chatgpt.com/codex/tasks/task_e_68c87d0a4210832993272e570f12a663