### PR TITLE
docs: expand anti-spam enforcement clause

### DIFF
--- a/apps/marketing/src/app/terms/page.tsx
+++ b/apps/marketing/src/app/terms/page.tsx
@@ -47,6 +47,22 @@ export default function TermsPage() {
         </section>
 
         <section className="space-y-3 mb-8">
+          <h2 className="text-xl font-medium">Anti-Spam Enforcement</h2>
+          <p className="text-muted-foreground">
+            To protect our community, we may suspend or block access for any
+            user who sends unsolicited marketing emails or similar promotional
+            messages to other users through the platform. Enforcement actions
+            may include immediate account suspension or termination.
+          </p>
+          <p className="text-muted-foreground">
+            Marketing communications sent via useSend must employ double
+            opt-in verification. Accounts that bypass double opt-in or misuse
+            our transactional mail API for promotional campaigns may be
+            suspended or terminated without notice.
+          </p>
+        </section>
+
+        <section className="space-y-3 mb-8">
           <h2 className="text-xl font-medium">Intellectual Property</h2>
           <p className="text-muted-foreground">
             Content on the site, including trademarks, logos, text, and


### PR DESCRIPTION
## Summary
- require double opt-in for marketing communications in the Terms of Service
- clarify that misuse of the transactional mail API for marketing can trigger suspension

## Testing
- pnpm lint *(fails: existing warnings in packages/ui trigger max-warnings=0)*

------
https://chatgpt.com/codex/tasks/task_e_68cae4739a948329bd80bfd48d9580dd