### PR TITLE
feat: send founder welcome emails

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,7 @@ AWS_SNS_ENDPOINT="http://localhost:3003/api/sns"
 NEXTAUTH_SECRET=""
 
 FROM_EMAIL="hello@usesend.com"
+FOUNDER_EMAIL="founder@usesend.com"
 
 API_RATE_LIMIT=2
 AUTH_EMAIL_RATE_LIMIT=5

--- a/.env.selfhost.example
+++ b/.env.selfhost.example
@@ -15,6 +15,7 @@ NEXTAUTH_SECRET=
 #SMTP
 SMTP_HOST=smtp.mailtrap.io  # Example SMTP host
 SMTP_USER= "usesend" # Example SMTP user
+FOUNDER_EMAIL="founder@usesend.com"
 
 ## Auth providers any one is required
 # GitHub login - required

--- a/apps/web/src/env.js
+++ b/apps/web/src/env.js
@@ -49,6 +49,7 @@ export const env = createEnv({
       .default("0")
       .transform((str) => parseInt(str, 10)),
     FROM_EMAIL: z.string().optional(),
+    FOUNDER_EMAIL: z.string().optional(),
     ADMIN_EMAIL: z.string().optional(),
     DISCORD_WEBHOOK_URL: z.string().optional(),
     REDIS_URL: z.string(),
@@ -105,6 +106,7 @@ export const env = createEnv({
     DISCORD_WEBHOOK_URL: process.env.DISCORD_WEBHOOK_URL,
     REDIS_URL: process.env.REDIS_URL,
     FROM_EMAIL: process.env.FROM_EMAIL,
+    FOUNDER_EMAIL: process.env.FOUNDER_EMAIL,
     S3_COMPATIBLE_ACCESS_KEY: process.env.S3_COMPATIBLE_ACCESS_KEY,
     S3_COMPATIBLE_SECRET_KEY: process.env.S3_COMPATIBLE_SECRET_KEY,
     S3_COMPATIBLE_API_URL: process.env.S3_COMPATIBLE_API_URL,

--- a/apps/web/src/server/auth.ts
+++ b/apps/web/src/server/auth.ts
@@ -10,7 +10,7 @@ import EmailProvider from "next-auth/providers/email";
 import GoogleProvider from "next-auth/providers/google";
 import { Provider } from "next-auth/providers/index";
 
-import { sendSignUpEmail } from "~/server/mailer";
+import { sendSignUpEmail, sendWelcomeEmail } from "~/server/mailer";
 import { env } from "~/env";
 import { db } from "~/server/db";
 
@@ -58,7 +58,7 @@ function getProviders() {
             scope: "read:user user:email",
           },
         },
-      })
+      }),
     );
   }
 
@@ -68,7 +68,7 @@ function getProviders() {
         clientId: env.GOOGLE_CLIENT_ID,
         clientSecret: env.GOOGLE_CLIENT_SECRET,
         allowDangerousEmailAccountLinking: true,
-      })
+      }),
     );
   }
 
@@ -82,7 +82,7 @@ function getProviders() {
         async generateVerificationToken() {
           return Math.random().toString(36).substring(2, 7).toLowerCase();
         },
-      })
+      }),
     );
   }
 
@@ -130,6 +130,10 @@ export const authOptions: NextAuthOptions = {
         where: { id: user.id },
         data: { isBetaUser: true },
       });
+
+      if (user.email) {
+        await sendWelcomeEmail(user.email);
+      }
     },
   },
   providers: getProviders(),


### PR DESCRIPTION
## Summary
- add `FOUNDER_EMAIL` env variable
- send plain text welcome email on signup
- send plain text subscription confirmation email for first paid subscription

## Testing
- `pnpm lint` *(fails: ESLint found too many warnings)*
- `pnpm build` *(fails: Invalid environment variables / Prisma download blocked in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68c720599804832997842a572e1e59fe