### PR TITLE
ui-fix emailchart

### DIFF
--- a/apps/web/src/app/(dashboard)/dashboard/email-chart.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/email-chart.tsx
@@ -67,7 +67,7 @@ export default function EmailChart({ days, domain }: EmailChartProps) {
     <div className="flex flex-col gap-16">
       {!statusQuery.isLoading && statusQuery.data ? (
         <div className="w-full h-[450px] border shadow rounded-xl p-4">
-          <div>
+          <div className="p-2 overflow-x-auto">
             {/* <div className="mb-4 text-sm">Emails</div> */}
 
             <div className="flex gap-10">


### PR DESCRIPTION
fixed responsiveness of emailChart


before
<img width="551" height="757" alt="Screenshot 2025-09-20 at 5 12 17 PM" src="https://github.com/user-attachments/assets/27197070-f348-4506-ada8-1f6713e26f06" />


after
<img width="511" height="422" alt="Screenshot 2025-09-20 at 5 23 25 PM" src="https://github.com/user-attachments/assets/43397ead-8a19-4f26-a9d7-4fd943ef6c9c" />
