### PR TITLE
ui-fix ReputationMetrics

### DIFF
--- a/apps/web/src/app/(dashboard)/dashboard/reputation-metrics.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/reputation-metrics.tsx
@@ -90,8 +90,8 @@ export function ReputationMetrics({ days, domain }: ReputationMetricsProps) {
 
   return (
     <TooltipProvider>
-      <div className="flex gap-10 w-full">
-        <div className="w-1/2 border rounded-xl shadow p-4">
+      <div className="flex flex-col sm:flex-row gap-10 w-full">
+        <div className="w-full sm:w-1/2 border rounded-xl shadow p-4">
           <div className="flex justify-between">
             <div className=" flex items-center gap-2">
               <div className="text-muted-foreground font-mono">Bounce Rate</div>
@@ -240,7 +240,7 @@ export function ReputationMetrics({ days, domain }: ReputationMetricsProps) {
             </BarChart>
           </ResponsiveContainer>
         </div>
-        <div className="w-1/2 border rounded-xl shadow p-4">
+        <div className="w-full sm:w-1/2 border rounded-xl shadow p-4">
           <div className=" flex items-center gap-2">
             <div className=" text-muted-foreground font-mono">
               Complaint Rate


### PR DESCRIPTION
Fixed responsiveness of ReputationMetrics component


before 

<img width="543" height="580" alt="Screenshot 2025-09-21 at 12 17 45 PM" src="https://github.com/user-attachments/assets/45e7aecf-e119-419b-8703-41a06f936de0" />



after


<img width="543" height="580" alt="Screenshot 2025-09-21 at 12 16 39 PM" src="https://github.com/user-attachments/assets/0a188271-bbe4-48d4-8443-f9adca3bc609" />
