### PR TITLE
fix:ui suppresion page

### DIFF
--- a/apps/web/src/app/(dashboard)/suppressions/page.tsx
+++ b/apps/web/src/app/(dashboard)/suppressions/page.tsx
@@ -16,7 +16,7 @@ export default function SuppressionsPage() {
   return (
     <div>
       {/* Header */}
-      <div className="flex justify-between items-center mb-10">
+      <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-4 mb-10">
         <H1>Suppression List</H1>
         <div className="flex gap-2">
           <Button variant="outline" onClick={() => setShowBulkAddDialog(true)}>


### PR DESCRIPTION
Fixede ui responsiveness for suppressions page 

Before.
<img width="454" height="128" alt="Screenshot 2025-09-21 at 4 18 07 PM" src="https://github.com/user-attachments/assets/6a3d3c52-6b70-467d-b5c1-f4c5ec82a2e6" />

After.
<img width="428" height="146" alt="Screenshot 2025-09-21 at 4 18 31 PM" src="https://github.com/user-attachments/assets/038deb28-45e5-4788-8cd7-2b386b7a2609" />
