### PR TITLE
Fix: update local development link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Check out the editor code for [here](https://github.com/usesend/usesend/tree/mai
 
 Follow our detailed guide to run useSend locally
 
-[https://usesend.com/docs/get-started/local](https://usesend.com/docs/get-started/local)
+[https://docs.usesend.com/get-started/local](https://docs.usesend.com/get-started/local)
 
 ## Docker
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Local Development link in the documentation to the new docs site (docs.usesend.com), replacing an outdated URL. This ensures developers follow the correct setup steps and avoids dead links during onboarding. No functional changes to the product or APIs. Improves clarity for new contributors and reduces confusion when configuring the environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->