### PR TITLE
feat: add waitlist rejection email option

### DIFF
--- a/apps/web/src/app/(dashboard)/admin/waitlist/page.tsx
+++ b/apps/web/src/app/(dashboard)/admin/waitlist/page.tsx
@@ -78,6 +78,15 @@ export default function AdminWaitlistPage() {
     },
   });
 
+  const rejectWaitlist = api.admin.rejectWaitlistUser.useMutation({
+    onSuccess: () => {
+      toast.success("Rejection email sent");
+    },
+    onError: (error) => {
+      toast.error(error.message ?? "Unable to send rejection email");
+    },
+  });
+
   const onSubmit = (values: SearchInput) => {
     setHasSearched(false);
     setUserResult(null);
@@ -87,6 +96,11 @@ export default function AdminWaitlistPage() {
   const handleToggle = (checked: boolean) => {
     if (!userResult) return;
     updateWaitlist.mutate({ userId: userResult.id, isWaitlisted: checked });
+  };
+
+  const handleReject = () => {
+    if (!userResult) return;
+    rejectWaitlist.mutate({ userId: userResult.id });
   };
 
   if (!isCloud()) {
@@ -166,22 +180,47 @@ export default function AdminWaitlistPage() {
             </div>
           </div>
 
-          <div className="flex flex-wrap items-center justify-between gap-4 border-t pt-4">
-            <div>
-              <p className="text-sm font-medium">Waitlist access</p>
-              <p className="text-sm text-muted-foreground">
-                Toggle to control whether the user remains on the waitlist.
-              </p>
+          <div className="space-y-4 border-t pt-4">
+            <div className="flex flex-wrap items-center justify-between gap-4">
+              <div>
+                <p className="text-sm font-medium">Waitlist access</p>
+                <p className="text-sm text-muted-foreground">
+                  Toggle to control whether the user remains on the waitlist.
+                </p>
+              </div>
+              <div className="flex items-center gap-2">
+                <Switch
+                  checked={userResult.isWaitlisted}
+                  onCheckedChange={handleToggle}
+                  disabled={updateWaitlist.isPending}
+                />
+                {updateWaitlist.isPending ? (
+                  <Spinner className="h-4 w-4" />
+                ) : null}
+              </div>
             </div>
-            <div className="flex items-center gap-2">
-              <Switch
-                checked={userResult.isWaitlisted}
-                onCheckedChange={handleToggle}
-                disabled={updateWaitlist.isPending}
-              />
-              {updateWaitlist.isPending ? (
-                <Spinner className="h-4 w-4" />
-              ) : null}
+
+            <div className="flex flex-wrap items-center justify-between gap-4">
+              <div>
+                <p className="text-sm font-medium">Reject waitlist request</p>
+                <p className="text-sm text-muted-foreground">
+                  Send the applicant a rejection email without changing their waitlist status.
+                </p>
+              </div>
+              <Button
+                type="button"
+                variant="destructive"
+                onClick={handleReject}
+                disabled={rejectWaitlist.isPending}
+              >
+                {rejectWaitlist.isPending ? (
+                  <>
+                    <Spinner className="mr-2 h-4 w-4" /> Sending...
+                  </>
+                ) : (
+                  "Send rejection email"
+                )}
+              </Button>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- add an admin router mutation to send the provided waitlist rejection email template
- expose the new mutation in the admin waitlist screen with a destructive button and spinner state
- keep the waitlist toggle UX while allowing admins to trigger the rejection email without changing status

## Testing
- pnpm lint *(fails: existing lint warnings in unrelated packages)*
- pnpm --filter web lint *(fails: existing lint warnings across the app)*

------
https://chatgpt.com/codex/tasks/task_e_68d0a5236d488329b2d40c2b6b38f5e8