### PR TITLE
fix: clear email attachments after send

### DIFF
--- a/apps/web/src/server/service/email-queue-service.ts
+++ b/apps/web/src/server/service/email-queue-service.ts
@@ -7,7 +7,6 @@ import { db } from "../db";
 import { sendRawEmail } from "../aws/ses";
 import { getRedis } from "../redis";
 import { DEFAULT_QUEUE_OPTIONS } from "../queue/queue-constants";
-import { Prisma } from "@prisma/client";
 import { logger } from "../logger/log";
 import { createWorkerHandler, TeamJob } from "../queue/bullmq-context";
 import { LimitService } from "./limit-service";
@@ -418,7 +417,7 @@ async function executeEmail(job: QueueEmailJob) {
     // Delete attachments after sending the email
     await db.email.update({
       where: { id: email.id },
-      data: { sesEmailId: messageId, text, attachments: undefined },
+      data: { sesEmailId: messageId, text, attachments: null },
     });
   } catch (error: any) {
     await db.emailEvent.create({


### PR DESCRIPTION
## Summary
- ensure sent emails clear their attachments column by persisting `null`
- remove the unused Prisma import from the email queue service

## Linked Issues
- N/A

## Screenshots
- N/A (not a UI change)

## Migration Notes
- N/A

## Verification
- `pnpm lint` *(fails: repository currently has lint warnings in other packages)*
- `pnpm --filter web lint` *(fails: repository currently has lint warnings across the web app)*

------
https://chatgpt.com/codex/tasks/task_e_68d1c8f91be88329bb94c6856a3fba42

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of sent emails by consistently setting the attachments status, preventing inconsistencies in email history and integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->