### PR TITLE
feat: expose domain dns records via api

### DIFF
--- a/apps/docs/api-reference/domains/get-domain.mdx
+++ b/apps/docs/api-reference/domains/get-domain.mdx
@@ -1,3 +1,3 @@
 ---
-openapi: get /v1/domains
+openapi: get /v1/domains/{id}
 ---

--- a/apps/docs/api-reference/domains/list-domains.mdx
+++ b/apps/docs/api-reference/domains/list-domains.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /v1/domains
+---

--- a/apps/docs/api-reference/openapi.json
+++ b/apps/docs/api-reference/openapi.json
@@ -24,7 +24,7 @@
       "get": {
         "responses": {
           "200": {
-            "description": "Retrieve the user",
+            "description": "Retrieve domains accessible by the API key",
             "content": {
               "application/json": {
                 "schema": {
@@ -101,6 +101,73 @@
                       "subdomain": {
                         "type": "string",
                         "nullable": true
+                      },
+                      "verificationError": {
+                        "type": "string",
+                        "nullable": true
+                      },
+                      "lastCheckedTime": {
+                        "type": "string",
+                        "nullable": true
+                      },
+                      "dnsRecords": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "enum": [
+                                "MX",
+                                "TXT"
+                              ],
+                              "description": "DNS record type",
+                              "example": "TXT"
+                            },
+                            "name": {
+                              "type": "string",
+                              "description": "DNS record name",
+                              "example": "mail"
+                            },
+                            "value": {
+                              "type": "string",
+                              "description": "DNS record value",
+                              "example": "v=spf1 include:amazonses.com ~all"
+                            },
+                            "ttl": {
+                              "type": "string",
+                              "description": "DNS record TTL",
+                              "example": "Auto"
+                            },
+                            "priority": {
+                              "type": "string",
+                              "nullable": true,
+                              "description": "DNS record priority",
+                              "example": "10"
+                            },
+                            "status": {
+                              "type": "string",
+                              "enum": [
+                                "NOT_STARTED",
+                                "PENDING",
+                                "SUCCESS",
+                                "FAILED",
+                                "TEMPORARY_FAILURE"
+                              ]
+                            },
+                            "recommended": {
+                              "type": "boolean",
+                              "description": "Whether the record is recommended"
+                            }
+                          },
+                          "required": [
+                            "type",
+                            "name",
+                            "value",
+                            "ttl",
+                            "status"
+                          ]
+                        }
                       }
                     },
                     "required": [
@@ -110,7 +177,8 @@
                       "status",
                       "publicKey",
                       "createdAt",
-                      "updatedAt"
+                      "updatedAt",
+                      "dnsRecords"
                     ]
                   }
                 }
@@ -219,6 +287,73 @@
                     "subdomain": {
                       "type": "string",
                       "nullable": true
+                    },
+                    "verificationError": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "lastCheckedTime": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "dnsRecords": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "enum": [
+                              "MX",
+                              "TXT"
+                            ],
+                            "description": "DNS record type",
+                            "example": "TXT"
+                          },
+                          "name": {
+                            "type": "string",
+                            "description": "DNS record name",
+                            "example": "mail"
+                          },
+                          "value": {
+                            "type": "string",
+                            "description": "DNS record value",
+                            "example": "v=spf1 include:amazonses.com ~all"
+                          },
+                          "ttl": {
+                            "type": "string",
+                            "description": "DNS record TTL",
+                            "example": "Auto"
+                          },
+                          "priority": {
+                            "type": "string",
+                            "nullable": true,
+                            "description": "DNS record priority",
+                            "example": "10"
+                          },
+                          "status": {
+                            "type": "string",
+                            "enum": [
+                              "NOT_STARTED",
+                              "PENDING",
+                              "SUCCESS",
+                              "FAILED",
+                              "TEMPORARY_FAILURE"
+                            ]
+                          },
+                          "recommended": {
+                            "type": "boolean",
+                            "description": "Whether the record is recommended"
+                          }
+                        },
+                        "required": [
+                          "type",
+                          "name",
+                          "value",
+                          "ttl",
+                          "status"
+                        ]
+                      }
                     }
                   },
                   "required": [
@@ -228,7 +363,8 @@
                     "status",
                     "publicKey",
                     "createdAt",
-                    "updatedAt"
+                    "updatedAt",
+                    "dnsRecords"
                   ]
                 }
               }
@@ -253,7 +389,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Create a new domain",
+            "description": "Verify domain",
             "content": {
               "application/json": {
                 "schema": {
@@ -265,6 +401,219 @@
                   },
                   "required": [
                     "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden - API key doesn't have access to this domain",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Domain not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/domains/{id}": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "number",
+              "nullable": true,
+              "example": 1
+            },
+            "required": false,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieve the domain",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "number",
+                      "description": "The ID of the domain",
+                      "example": 1
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "The name of the domain",
+                      "example": "example.com"
+                    },
+                    "teamId": {
+                      "type": "number",
+                      "description": "The ID of the team",
+                      "example": 1
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "NOT_STARTED",
+                        "PENDING",
+                        "SUCCESS",
+                        "FAILED",
+                        "TEMPORARY_FAILURE"
+                      ]
+                    },
+                    "region": {
+                      "type": "string",
+                      "default": "us-east-1"
+                    },
+                    "clickTracking": {
+                      "type": "boolean",
+                      "default": false
+                    },
+                    "openTracking": {
+                      "type": "boolean",
+                      "default": false
+                    },
+                    "publicKey": {
+                      "type": "string"
+                    },
+                    "dkimStatus": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "spfDetails": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "createdAt": {
+                      "type": "string"
+                    },
+                    "updatedAt": {
+                      "type": "string"
+                    },
+                    "dmarcAdded": {
+                      "type": "boolean",
+                      "default": false
+                    },
+                    "isVerifying": {
+                      "type": "boolean",
+                      "default": false
+                    },
+                    "errorMessage": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "subdomain": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "verificationError": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "lastCheckedTime": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "dnsRecords": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "enum": [
+                              "MX",
+                              "TXT"
+                            ],
+                            "description": "DNS record type",
+                            "example": "TXT"
+                          },
+                          "name": {
+                            "type": "string",
+                            "description": "DNS record name",
+                            "example": "mail"
+                          },
+                          "value": {
+                            "type": "string",
+                            "description": "DNS record value",
+                            "example": "v=spf1 include:amazonses.com ~all"
+                          },
+                          "ttl": {
+                            "type": "string",
+                            "description": "DNS record TTL",
+                            "example": "Auto"
+                          },
+                          "priority": {
+                            "type": "string",
+                            "nullable": true,
+                            "description": "DNS record priority",
+                            "example": "10"
+                          },
+                          "status": {
+                            "type": "string",
+                            "enum": [
+                              "NOT_STARTED",
+                              "PENDING",
+                              "SUCCESS",
+                              "FAILED",
+                              "TEMPORARY_FAILURE"
+                            ]
+                          },
+                          "recommended": {
+                            "type": "boolean",
+                            "description": "Whether the record is recommended"
+                          }
+                        },
+                        "required": [
+                          "type",
+                          "name",
+                          "value",
+                          "ttl",
+                          "status"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "name",
+                    "teamId",
+                    "status",
+                    "publicKey",
+                    "createdAt",
+                    "updatedAt",
+                    "dnsRecords"
                   ]
                 }
               }
@@ -396,7 +745,8 @@
                               "CLICKED",
                               "COMPLAINED",
                               "FAILED",
-                              "CANCELLED"
+                              "CANCELLED",
+                              "SUPPRESSED"
                             ]
                           },
                           "createdAt": {
@@ -659,7 +1009,8 @@
                               "CLICKED",
                               "COMPLAINED",
                               "FAILED",
-                              "CANCELLED"
+                              "CANCELLED",
+                              "SUPPRESSED"
                             ]
                           },
                           "scheduledAt": {
@@ -743,14 +1094,12 @@
                   "replyTo": {
                     "anyOf": [
                       {
-                        "type": "string",
-                        "format": "email"
+                        "type": "string"
                       },
                       {
                         "type": "array",
                         "items": {
-                          "type": "string",
-                          "format": "email"
+                          "type": "string"
                         }
                       }
                     ]
@@ -758,14 +1107,12 @@
                   "cc": {
                     "anyOf": [
                       {
-                        "type": "string",
-                        "format": "email"
+                        "type": "string"
                       },
                       {
                         "type": "array",
                         "items": {
-                          "type": "string",
-                          "format": "email"
+                          "type": "string"
                         }
                       }
                     ]
@@ -773,14 +1120,12 @@
                   "bcc": {
                     "anyOf": [
                       {
-                        "type": "string",
-                        "format": "email"
+                        "type": "string"
                       },
                       {
                         "type": "array",
                         "items": {
-                          "type": "string",
-                          "format": "email"
+                          "type": "string"
                         }
                       }
                     ]
@@ -897,14 +1242,12 @@
                     "replyTo": {
                       "anyOf": [
                         {
-                          "type": "string",
-                          "format": "email"
+                          "type": "string"
                         },
                         {
                           "type": "array",
                           "items": {
-                            "type": "string",
-                            "format": "email"
+                            "type": "string"
                           }
                         }
                       ]
@@ -912,14 +1255,12 @@
                     "cc": {
                       "anyOf": [
                         {
-                          "type": "string",
-                          "format": "email"
+                          "type": "string"
                         },
                         {
                           "type": "array",
                           "items": {
-                            "type": "string",
-                            "format": "email"
+                            "type": "string"
                           }
                         }
                       ]
@@ -927,14 +1268,12 @@
                     "bcc": {
                       "anyOf": [
                         {
-                          "type": "string",
-                          "format": "email"
+                          "type": "string"
                         },
                         {
                           "type": "array",
                           "items": {
-                            "type": "string",
-                            "format": "email"
+                            "type": "string"
                           }
                         }
                       ]

--- a/apps/docs/docs.json
+++ b/apps/docs/docs.json
@@ -34,15 +34,23 @@
           },
           {
             "group": "Self Hosting",
-            "pages": ["self-hosting/overview", "self-hosting/railway"]
+            "pages": [
+              "self-hosting/overview",
+              "self-hosting/railway"
+            ]
           },
           {
             "group": "Guides",
-            "pages": ["guides/use-with-react-email"]
+            "pages": [
+              "guides/use-with-react-email"
+            ]
           },
           {
             "group": "Community SDKs",
-            "pages": ["community-sdk/python", "community-sdk/go"]
+            "pages": [
+              "community-sdk/python",
+              "community-sdk/go"
+            ]
           }
         ]
       },
@@ -51,7 +59,9 @@
         "groups": [
           {
             "group": "API Reference",
-            "pages": ["api-reference/introduction"]
+            "pages": [
+              "api-reference/introduction"
+            ]
           },
           {
             "group": "Emails",
@@ -79,6 +89,7 @@
             "group": "Domains",
             "pages": [
               "api-reference/domains/get-domain",
+              "api-reference/domains/list-domains",
               "api-reference/domains/create-domain",
               "api-reference/domains/verify-domain"
             ]
@@ -136,6 +147,12 @@
     }
   },
   "contextual": {
-    "options": ["copy", "view", "chatgpt", "claude", "perplexity"]
+    "options": [
+      "copy",
+      "view",
+      "chatgpt",
+      "claude",
+      "perplexity"
+    ]
   }
 }

--- a/apps/web/src/app/(dashboard)/domains/[domainId]/send-test-mail.tsx
+++ b/apps/web/src/app/(dashboard)/domains/[domainId]/send-test-mail.tsx
@@ -3,12 +3,14 @@
 import { Button } from "@usesend/ui/src/button";
 import { api } from "~/trpc/react";
 import React from "react";
-import { Domain } from "@prisma/client";
 import { toast } from "@usesend/ui/src/toaster";
 import { SendHorizonal } from "lucide-react";
+import type { DomainWithDnsRecords } from "~/types/domain";
 // Removed dialog and example code. Clicking the button now sends the email directly.
 
-export const SendTestMail: React.FC<{ domain: Domain }> = ({ domain }) => {
+export const SendTestMail: React.FC<{ domain: DomainWithDnsRecords }> = ({
+  domain,
+}) => {
   const sendTestEmailFromDomainMutation =
     api.domain.sendTestEmailFromDomain.useMutation();
 

--- a/apps/web/src/lib/zod/domain-schema.ts
+++ b/apps/web/src/lib/zod/domain-schema.ts
@@ -3,6 +3,34 @@ import { z } from "zod";
 
 export const DomainStatusSchema = z.nativeEnum(DomainStatus);
 
+export const DomainDnsRecordSchema = z.object({
+  type: z.enum(["MX", "TXT"]).openapi({
+    description: "DNS record type",
+    example: "TXT",
+  }),
+  name: z
+    .string()
+    .openapi({ description: "DNS record name", example: "mail" }),
+  value: z
+    .string()
+    .openapi({
+      description: "DNS record value",
+      example: "v=spf1 include:amazonses.com ~all",
+    }),
+  ttl: z
+    .string()
+    .openapi({ description: "DNS record TTL", example: "Auto" }),
+  priority: z
+    .string()
+    .nullish()
+    .openapi({ description: "DNS record priority", example: "10" }),
+  status: DomainStatusSchema,
+  recommended: z
+    .boolean()
+    .optional()
+    .openapi({ description: "Whether the record is recommended" }),
+});
+
 export const DomainSchema = z.object({
   id: z.number().openapi({ description: "The ID of the domain", example: 1 }),
   name: z
@@ -22,4 +50,7 @@ export const DomainSchema = z.object({
   isVerifying: z.boolean().default(false),
   errorMessage: z.string().optional().nullish(),
   subdomain: z.string().optional().nullish(),
+  verificationError: z.string().optional().nullish(),
+  lastCheckedTime: z.string().optional().nullish(),
+  dnsRecords: z.array(DomainDnsRecordSchema),
 });

--- a/apps/web/src/server/api/routers/domain.ts
+++ b/apps/web/src/server/api/routers/domain.ts
@@ -30,7 +30,7 @@ export const domainRouter = createTRPCRouter({
         ctx.team.id,
         input.name,
         input.region,
-        ctx.team.sesTenantId ?? undefined,
+        ctx.team.sesTenantId ?? undefined
       );
     }),
 
@@ -45,8 +45,8 @@ export const domainRouter = createTRPCRouter({
     return getDomains(ctx.team.id);
   }),
 
-  getDomain: domainProcedure.query(async ({ input }) => {
-    return getDomain(input.id);
+  getDomain: domainProcedure.query(async ({ input, ctx }) => {
+    return getDomain(input.id, ctx.team.id);
   }),
 
   updateDomain: domainProcedure
@@ -54,7 +54,7 @@ export const domainRouter = createTRPCRouter({
       z.object({
         clickTracking: z.boolean().optional(),
         openTracking: z.boolean().optional(),
-      }),
+      })
     )
     .mutation(async ({ input }) => {
       return updateDomain(input.id, {
@@ -96,6 +96,6 @@ export const domainRouter = createTRPCRouter({
         text: "hello,\n\nuseSend is the best open source sending platform\n\ncheck out https://usesend.com",
         html: "<p>hello,</p><p>useSend is the best open source sending platform<p><p>check out <a href='https://usesend.com'>usesend.com</a>",
       });
-    },
+    }
   ),
 });

--- a/apps/web/src/server/api/routers/domain.ts
+++ b/apps/web/src/server/api/routers/domain.ts
@@ -11,6 +11,7 @@ import {
   createDomain,
   deleteDomain,
   getDomain,
+  getDomains,
   updateDomain,
 } from "~/server/service/domain-service";
 import { sendEmail } from "~/server/service/email-service";
@@ -41,16 +42,7 @@ export const domainRouter = createTRPCRouter({
   }),
 
   domains: teamProcedure.query(async ({ ctx }) => {
-    const domains = await db.domain.findMany({
-      where: {
-        teamId: ctx.team.id,
-      },
-      orderBy: {
-        createdAt: "desc",
-      },
-    });
-
-    return domains;
+    return getDomains(ctx.team.id);
   }),
 
   getDomain: domainProcedure.query(async ({ input }) => {

--- a/apps/web/src/server/public-api/api/domains/create-domain.ts
+++ b/apps/web/src/server/public-api/api/domains/create-domain.ts
@@ -2,7 +2,6 @@ import { createRoute, z } from "@hono/zod-openapi";
 import { DomainSchema } from "~/lib/zod/domain-schema";
 import { PublicAPIApp } from "~/server/public-api/hono";
 import { createDomain as createDomainService } from "~/server/service/domain-service";
-import { getTeamFromToken } from "~/server/public-api/auth";
 
 const route = createRoute({
   method: "post",

--- a/apps/web/src/server/public-api/api/domains/get-domain.ts
+++ b/apps/web/src/server/public-api/api/domains/get-domain.ts
@@ -1,0 +1,59 @@
+import { createRoute, z } from "@hono/zod-openapi";
+import { DomainSchema } from "~/lib/zod/domain-schema";
+import { PublicAPIApp } from "~/server/public-api/hono";
+import { UnsendApiError } from "../../api-error";
+import { db } from "~/server/db";
+import { getDomain as getDomainService } from "~/server/service/domain-service";
+
+const route = createRoute({
+  method: "get",
+  path: "/v1/domains/{id}",
+  request: {
+    params: z.object({
+      id: z.coerce.number().openapi({
+        param: { name: "id", in: "path" },
+        example: 1,
+      }),
+    }),
+  },
+  responses: {
+    200: {
+      content: {
+        "application/json": {
+          schema: DomainSchema,
+        },
+      },
+      description: "Retrieve the domain",
+    },
+  },
+});
+
+function getDomain(app: PublicAPIApp) {
+  app.openapi(route, async (c) => {
+    const team = c.var.team;
+    const id = c.req.valid("param").id;
+
+    // Enforce API key domain restriction (if any)
+    if (team.apiKey.domainId && team.apiKey.domainId !== id) {
+      throw new UnsendApiError({
+        code: "NOT_FOUND",
+        message: "Domain not found",
+      });
+    }
+
+    // Re-use service logic to enrich domain (verification status, DNS records, etc.)
+    let enriched;
+    try {
+      enriched = await getDomainService(id, team.id);
+    } catch (e) {
+      throw new UnsendApiError({
+        code: "NOT_FOUND",
+        message: "Domain not found",
+      });
+    }
+
+    return c.json(enriched);
+  });
+}
+
+export default getDomain;

--- a/apps/web/src/server/public-api/api/domains/get-domain.ts
+++ b/apps/web/src/server/public-api/api/domains/get-domain.ts
@@ -47,8 +47,8 @@ function getDomain(app: PublicAPIApp) {
       enriched = await getDomainService(id, team.id);
     } catch (e) {
       throw new UnsendApiError({
-        code: "NOT_FOUND",
-        message: "Domain not found",
+        code: "INTERNAL_SERVER_ERROR",
+        message: e instanceof Error ? e.message : "Internal server error",
       });
     }
 

--- a/apps/web/src/server/public-api/api/domains/get-domains.ts
+++ b/apps/web/src/server/public-api/api/domains/get-domains.ts
@@ -1,7 +1,7 @@
 import { createRoute, z } from "@hono/zod-openapi";
 import { DomainSchema } from "~/lib/zod/domain-schema";
 import { PublicAPIApp } from "~/server/public-api/hono";
-import { db } from "~/server/db";
+import { getDomains as getDomainsService } from "~/server/service/domain-service";
 
 const route = createRoute({
   method: "get",
@@ -23,11 +23,9 @@ function getDomains(app: PublicAPIApp) {
     const team = c.var.team;
 
     // If API key is restricted to a specific domain, only return that domain; else return all team domains
-    const domains = team.apiKey.domainId
-      ? await db.domain.findMany({
-          where: { teamId: team.id, id: team.apiKey.domainId },
-        })
-      : await db.domain.findMany({ where: { teamId: team.id } });
+    const domains = await getDomainsService(team.id, {
+      domainId: team.apiKey.domainId ?? undefined,
+    });
 
     return c.json(domains);
   });

--- a/apps/web/src/server/public-api/index.ts
+++ b/apps/web/src/server/public-api/index.ts
@@ -13,6 +13,7 @@ import upsertContact from "./api/contacts/upsert-contact";
 import createDomain from "./api/domains/create-domain";
 import deleteContact from "./api/contacts/delete-contact";
 import verifyDomain from "./api/domains/verify-domain";
+import getDomain from "./api/domains/get-domain";
 import sendBatch from "./api/emails/batch-email";
 
 export const app = getApp();
@@ -21,6 +22,7 @@ export const app = getApp();
 getDomains(app);
 createDomain(app);
 verifyDomain(app);
+getDomain(app);
 
 /**Email related APIs */
 getEmail(app);

--- a/apps/web/src/server/service/domain-service.ts
+++ b/apps/web/src/server/service/domain-service.ts
@@ -6,11 +6,7 @@ import { db } from "~/server/db";
 import { SesSettingsService } from "./ses-settings-service";
 import { UnsendApiError } from "../public-api/api-error";
 import { logger } from "../logger/log";
-import {
-  ApiKey,
-  DomainStatus,
-  type Domain,
-} from "@prisma/client";
+import { ApiKey, DomainStatus, type Domain } from "@prisma/client";
 import { LimitService } from "./limit-service";
 import type { DomainDnsRecord } from "~/types/domain";
 
@@ -76,7 +72,7 @@ function buildDnsRecords(domain: Domain): DomainDnsRecord[] {
 }
 
 function withDnsRecords<T extends Domain>(
-  domain: T,
+  domain: T
 ): T & { dnsRecords: DomainDnsRecord[] } {
   return {
     ...domain,
@@ -138,12 +134,12 @@ export async function validateApiKeyDomainAccess(
 ) {
   // First validate the domain exists and is verified
   const domain = await validateDomainFromEmail(email, teamId);
-  
+
   // If API key has no domain restriction (domainId is null), allow all domains
   if (!apiKey.domainId) {
     return domain;
   }
-  
+
   // If API key is restricted to a specific domain, check if it matches
   if (apiKey.domainId !== domain.id) {
     throw new UnsendApiError({
@@ -151,7 +147,7 @@ export async function validateApiKeyDomainAccess(
       message: `API key does not have access to domain: ${domain.name}`,
     });
   }
-  
+
   return domain;
 }
 
@@ -203,18 +199,19 @@ export async function createDomain(
       region,
       sesTenantId,
       dkimSelector,
-      dkimStatus: DomainStatus.PENDING,
-      spfDetails: DomainStatus.PENDING,
+      dkimStatus: DomainStatus.NOT_STARTED,
+      spfDetails: DomainStatus.NOT_STARTED,
     },
   });
 
   return withDnsRecords(domain);
 }
 
-export async function getDomain(id: number) {
+export async function getDomain(id: number, teamId: number) {
   let domain = await db.domain.findUnique({
     where: {
       id,
+      teamId,
     },
   });
 
@@ -266,7 +263,7 @@ export async function getDomain(id: number) {
     const normalizedLastCheckedTime =
       lastCheckedTime instanceof Date
         ? lastCheckedTime.toISOString()
-        : lastCheckedTime ?? null;
+        : (lastCheckedTime ?? null);
 
     return {
       ...domainWithDns,

--- a/apps/web/src/server/service/domain-service.ts
+++ b/apps/web/src/server/service/domain-service.ts
@@ -216,7 +216,10 @@ export async function getDomain(id: number, teamId: number) {
   });
 
   if (!domain) {
-    throw new Error("Domain not found");
+    throw new UnsendApiError({
+      code: "NOT_FOUND",
+      message: "Domain not found",
+    });
   }
 
   if (domain.isVerifying) {

--- a/apps/web/src/types/domain.ts
+++ b/apps/web/src/types/domain.ts
@@ -1,0 +1,17 @@
+import type { Domain, DomainStatus } from "@prisma/client";
+
+export type DomainDnsRecord = {
+  type: "MX" | "TXT";
+  name: string;
+  value: string;
+  ttl: string;
+  priority?: string | null;
+  status: DomainStatus;
+  recommended?: boolean;
+};
+
+export type DomainWithDnsRecords = Domain & {
+  dnsRecords: DomainDnsRecord[];
+  verificationError?: string | null;
+  lastCheckedTime?: Date | string | null;
+};

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@usesend/eslint-config": "workspace:*",
     "@usesend/typescript-config": "workspace:*",
     "dotenv-cli": "^8.0.0",
-    "mintlify": "4.0.510",
+    "mintlify": "4.2.128",
     "prettier": "^3.5.3"
   },
   "packageManager": "pnpm@8.9.0",

--- a/packages/python-sdk/pyproject.toml
+++ b/packages/python-sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "usesend"
-version = "0.2.3"
+version = "0.2.4"
 description = "Python SDK for the UseSend API"
 authors = ["UseSend"]
 license = "MIT"

--- a/packages/python-sdk/usesend/__init__.py
+++ b/packages/python-sdk/usesend/__init__.py
@@ -1,6 +1,7 @@
 """Python client for the UseSend API."""
 
 from .usesend import UseSend, UseSendHTTPError
+from .domains import Domains  # type: ignore
 from . import types
 
-__all__ = ["UseSend", "UseSendHTTPError", "types"]
+__all__ = ["UseSend", "UseSendHTTPError", "types", "Domains"]

--- a/packages/python-sdk/usesend/domains.py
+++ b/packages/python-sdk/usesend/domains.py
@@ -1,0 +1,37 @@
+"""Domain resource client using TypedDict shapes (no Pydantic)."""
+from __future__ import annotations
+
+from typing import Optional, Tuple, List
+
+from .types import (
+    APIError,
+    Domain,
+    DomainCreate,
+    DomainCreateResponse,
+    DomainVerifyResponse,
+)
+
+
+class Domains:
+    """Client for `/domains` endpoints."""
+
+    def __init__(self, usesend: "UseSend") -> None:
+        self.usesend = usesend
+
+    def list(self) -> Tuple[Optional[List[Domain]], Optional[APIError]]:
+        data, err = self.usesend.get("/domains")
+        return (data, err)  # type: ignore[return-value]
+
+    def create(self, payload: DomainCreate) -> Tuple[Optional[DomainCreateResponse], Optional[APIError]]:
+        data, err = self.usesend.post("/domains", payload)
+        return (data, err)  # type: ignore[return-value]
+
+    def verify(self, domain_id: int) -> Tuple[Optional[DomainVerifyResponse], Optional[APIError]]:
+        data, err = self.usesend.put(f"/domains/{domain_id}/verify", {})
+        return (data, err)  # type: ignore[return-value]
+
+    def get(self, domain_id: int) -> Tuple[Optional[Domain], Optional[APIError]]:
+        data, err = self.usesend.get(f"/domains/{domain_id}")
+        return (data, err)  # type: ignore[return-value]
+
+from .usesend import UseSend  # noqa: E402  pylint: disable=wrong-import-position

--- a/packages/python-sdk/usesend/types.py
+++ b/packages/python-sdk/usesend/types.py
@@ -22,6 +22,21 @@ DomainStatus = Literal[
     'TEMPORARY_FAILURE',
 ]
 
+DNSRecordType = Literal['MX', 'TXT']
+
+
+class DNSRecord(TypedDict, total=False):
+    type: DNSRecordType
+    name: str
+    value: str
+    ttl: str
+    priority: Optional[str]
+    status: DomainStatus
+    recommended: Optional[bool]
+
+
+DNSRecords = List[DNSRecord]
+
 
 class Domain(TypedDict, total=False):
     id: float
@@ -40,6 +55,9 @@ class Domain(TypedDict, total=False):
     isVerifying: bool
     errorMessage: Optional[str]
     subdomain: Optional[str]
+    verificationError: Optional[str]
+    lastCheckedTime: Optional[str]
+    dnsRecords: DNSRecords
 
 
 DomainList = List[Domain]
@@ -67,6 +85,9 @@ class DomainCreateResponse(TypedDict, total=False):
     isVerifying: bool
     errorMessage: Optional[str]
     subdomain: Optional[str]
+    verificationError: Optional[str]
+    lastCheckedTime: Optional[str]
+    dnsRecords: DNSRecords
 
 
 class DomainVerifyResponse(TypedDict):

--- a/packages/python-sdk/usesend/usesend.py
+++ b/packages/python-sdk/usesend/usesend.py
@@ -71,6 +71,7 @@ class UseSend:
         # Lazily initialise resource clients.
         self.emails = Emails(self)
         self.contacts = Contacts(self)
+        self.domains = Domains(self)
 
     # ------------------------------------------------------------------
     # Internal request helper
@@ -123,3 +124,4 @@ class UseSend:
 # Import here to avoid circular dependency during type checking
 from .emails import Emails  # noqa: E402  pylint: disable=wrong-import-position
 from .contacts import Contacts  # noqa: E402  pylint: disable=wrong-import-position
+from .domains import Domains  # type: ignore  # noqa: E402

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "usesend-js",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/sdk/src/domain.ts
+++ b/packages/sdk/src/domain.ts
@@ -29,6 +29,14 @@ type VerifyDomainResponse = {
 type VerifyDomainResponseSuccess =
   paths["/v1/domains/{id}/verify"]["put"]["responses"]["200"]["content"]["application/json"];
 
+type GetDomainResponse = {
+  data: GetDomainResponseSuccess | null;
+  error: ErrorResponse | null;
+};
+
+type GetDomainResponseSuccess =
+  paths["/v1/domains/{id}"]["get"]["responses"]["200"]["content"]["application/json"];
+
 export class Domains {
   constructor(private readonly usesend: UseSend) {
     this.usesend = usesend;
@@ -52,6 +60,14 @@ export class Domains {
       `/domains/${id}/verify`,
       {}
     );
+    return data;
+  }
+
+  async get(id: number): Promise<GetDomainResponse> {
+    const data = await this.usesend.get<GetDomainResponseSuccess>(
+      `/domains/${id}`
+    );
+
     return data;
   }
 }

--- a/packages/sdk/src/email.ts
+++ b/packages/sdk/src/email.ts
@@ -112,6 +112,7 @@ export class Emails {
     const data = await this.usesend.get<GetEmailResponseSuccess>(
       `/emails/${id}`
     );
+
     return data;
   }
 

--- a/packages/sdk/types/schema.d.ts
+++ b/packages/sdk/types/schema.d.ts
@@ -20,7 +20,7 @@ export interface paths {
             };
             requestBody?: never;
             responses: {
-                /** @description Retrieve the user */
+                /** @description Retrieve domains accessible by the API key */
                 200: {
                     headers: {
                         [name: string]: unknown;
@@ -61,6 +61,40 @@ export interface paths {
                             isVerifying: boolean;
                             errorMessage?: string | null;
                             subdomain?: string | null;
+                            verificationError?: string | null;
+                            lastCheckedTime?: string | null;
+                            dnsRecords: {
+                                /**
+                                 * @description DNS record type
+                                 * @example TXT
+                                 * @enum {string}
+                                 */
+                                type: "MX" | "TXT";
+                                /**
+                                 * @description DNS record name
+                                 * @example mail
+                                 */
+                                name: string;
+                                /**
+                                 * @description DNS record value
+                                 * @example v=spf1 include:amazonses.com ~all
+                                 */
+                                value: string;
+                                /**
+                                 * @description DNS record TTL
+                                 * @example Auto
+                                 */
+                                ttl: string;
+                                /**
+                                 * @description DNS record priority
+                                 * @example 10
+                                 */
+                                priority?: string | null;
+                                /** @enum {string} */
+                                status: "NOT_STARTED" | "PENDING" | "SUCCESS" | "FAILED" | "TEMPORARY_FAILURE";
+                                /** @description Whether the record is recommended */
+                                recommended?: boolean;
+                            }[];
                         }[];
                     };
                 };
@@ -124,6 +158,40 @@ export interface paths {
                             isVerifying: boolean;
                             errorMessage?: string | null;
                             subdomain?: string | null;
+                            verificationError?: string | null;
+                            lastCheckedTime?: string | null;
+                            dnsRecords: {
+                                /**
+                                 * @description DNS record type
+                                 * @example TXT
+                                 * @enum {string}
+                                 */
+                                type: "MX" | "TXT";
+                                /**
+                                 * @description DNS record name
+                                 * @example mail
+                                 */
+                                name: string;
+                                /**
+                                 * @description DNS record value
+                                 * @example v=spf1 include:amazonses.com ~all
+                                 */
+                                value: string;
+                                /**
+                                 * @description DNS record TTL
+                                 * @example Auto
+                                 */
+                                ttl: string;
+                                /**
+                                 * @description DNS record priority
+                                 * @example 10
+                                 */
+                                priority?: string | null;
+                                /** @enum {string} */
+                                status: "NOT_STARTED" | "PENDING" | "SUCCESS" | "FAILED" | "TEMPORARY_FAILURE";
+                                /** @description Whether the record is recommended */
+                                recommended?: boolean;
+                            }[];
                         };
                     };
                 };
@@ -154,7 +222,7 @@ export interface paths {
             };
             requestBody?: never;
             responses: {
-                /** @description Create a new domain */
+                /** @description Verify domain */
                 200: {
                     headers: {
                         [name: string]: unknown;
@@ -165,8 +233,136 @@ export interface paths {
                         };
                     };
                 };
+                /** @description Forbidden - API key doesn't have access to this domain */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: string;
+                        };
+                    };
+                };
+                /** @description Domain not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: string;
+                        };
+                    };
+                };
             };
         };
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/domains/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: number | null;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Retrieve the domain */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /**
+                             * @description The ID of the domain
+                             * @example 1
+                             */
+                            id: number;
+                            /**
+                             * @description The name of the domain
+                             * @example example.com
+                             */
+                            name: string;
+                            /**
+                             * @description The ID of the team
+                             * @example 1
+                             */
+                            teamId: number;
+                            /** @enum {string} */
+                            status: "NOT_STARTED" | "PENDING" | "SUCCESS" | "FAILED" | "TEMPORARY_FAILURE";
+                            /** @default us-east-1 */
+                            region: string;
+                            /** @default false */
+                            clickTracking: boolean;
+                            /** @default false */
+                            openTracking: boolean;
+                            publicKey: string;
+                            dkimStatus?: string | null;
+                            spfDetails?: string | null;
+                            createdAt: string;
+                            updatedAt: string;
+                            /** @default false */
+                            dmarcAdded: boolean;
+                            /** @default false */
+                            isVerifying: boolean;
+                            errorMessage?: string | null;
+                            subdomain?: string | null;
+                            verificationError?: string | null;
+                            lastCheckedTime?: string | null;
+                            dnsRecords: {
+                                /**
+                                 * @description DNS record type
+                                 * @example TXT
+                                 * @enum {string}
+                                 */
+                                type: "MX" | "TXT";
+                                /**
+                                 * @description DNS record name
+                                 * @example mail
+                                 */
+                                name: string;
+                                /**
+                                 * @description DNS record value
+                                 * @example v=spf1 include:amazonses.com ~all
+                                 */
+                                value: string;
+                                /**
+                                 * @description DNS record TTL
+                                 * @example Auto
+                                 */
+                                ttl: string;
+                                /**
+                                 * @description DNS record priority
+                                 * @example 10
+                                 */
+                                priority?: string | null;
+                                /** @enum {string} */
+                                status: "NOT_STARTED" | "PENDING" | "SUCCESS" | "FAILED" | "TEMPORARY_FAILURE";
+                                /** @description Whether the record is recommended */
+                                recommended?: boolean;
+                            }[];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
         post?: never;
         delete?: never;
         options?: never;
@@ -214,7 +410,7 @@ export interface paths {
                             emailEvents: {
                                 emailId: string;
                                 /** @enum {string} */
-                                status: "SCHEDULED" | "QUEUED" | "SENT" | "DELIVERY_DELAYED" | "BOUNCED" | "REJECTED" | "RENDERING_FAILURE" | "DELIVERED" | "OPENED" | "CLICKED" | "COMPLAINED" | "FAILED" | "CANCELLED";
+                                status: "SCHEDULED" | "QUEUED" | "SENT" | "DELIVERY_DELAYED" | "BOUNCED" | "REJECTED" | "RENDERING_FAILURE" | "DELIVERED" | "OPENED" | "CLICKED" | "COMPLAINED" | "FAILED" | "CANCELLED" | "SUPPRESSED";
                                 createdAt: string;
                                 data?: unknown;
                             }[];
@@ -268,7 +464,52 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        get?: never;
+        get: {
+            parameters: {
+                query?: {
+                    page?: string;
+                    limit?: string;
+                    startDate?: string;
+                    endDate?: string;
+                    domainId?: string | string[];
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Retrieve a list of emails */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            data: {
+                                id: string;
+                                to: string | string[];
+                                replyTo?: string | string[] | unknown;
+                                cc?: string | string[] | unknown;
+                                bcc?: string | string[] | unknown;
+                                from: string;
+                                subject: string;
+                                html: string | null;
+                                text: string | null;
+                                createdAt: string;
+                                updatedAt: string;
+                                /** @enum {string|null} */
+                                latestStatus: "SCHEDULED" | "QUEUED" | "SENT" | "DELIVERY_DELAYED" | "BOUNCED" | "REJECTED" | "RENDERING_FAILURE" | "DELIVERED" | "OPENED" | "CLICKED" | "COMPLAINED" | "FAILED" | "CANCELLED" | "SUPPRESSED" | null;
+                                /** Format: date-time */
+                                scheduledAt: string | null;
+                                domainId: number | null;
+                            }[];
+                            count: number;
+                        };
+                    };
+                };
+            };
+        };
         put?: never;
         post: {
             parameters: {
@@ -281,7 +522,6 @@ export interface paths {
                 content: {
                     "application/json": {
                         to: string | string[];
-                        /** Format: email */
                         from: string;
                         /** @description Optional when templateId is provided */
                         subject?: string;
@@ -345,7 +585,6 @@ export interface paths {
                 content: {
                     "application/json": {
                         to: string | string[];
-                        /** Format: email */
                         from: string;
                         /** @description Optional when templateId is provided */
                         subject?: string;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,8 +22,8 @@ importers:
         specifier: ^8.0.0
         version: 8.0.0
       mintlify:
-        specifier: 4.0.510
-        version: 4.0.510(@types/react@19.1.12)(react-dom@18.3.1)(react@18.3.1)
+        specifier: 4.2.128
+        version: 4.2.128(@radix-ui/react-popover@1.1.15)(@types/react@19.1.14)(react-dom@18.3.1)(typescript@5.8.3)
       prettier:
         specifier: ^3.5.3
         version: 3.5.3
@@ -32,7 +32,7 @@ importers:
     dependencies:
       '@mdx-js/loader':
         specifier: ^3.1.1
-        version: 3.1.1(acorn@8.14.1)
+        version: 3.1.1(acorn@8.15.0)
       '@mdx-js/react':
         specifier: ^3.1.1
         version: 3.1.1(@types/react@19.1.2)(react@19.1.0)
@@ -504,7 +504,7 @@ importers:
         version: 10.1.2(eslint@8.57.1)
       eslint-config-turbo:
         specifier: ^2.5.2
-        version: 2.5.2(eslint@8.57.1)(turbo@2.5.6)
+        version: 2.5.2(eslint@8.57.1)(turbo@2.5.8)
       eslint-plugin-only-warn:
         specifier: ^1.1.0
         version: 1.1.0
@@ -713,6 +713,14 @@ packages:
     resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
     dev: false
 
+  /@alcalzone/ansi-tokenize@0.2.0:
+    resolution: {integrity: sha512-qI/5TaaaCZE4yeSZ83lu0+xi1r88JSxUjnH4OP/iZF7+KKZ75u3ee5isd0LxX+6N8U0npL61YrpbthILHB6BnA==}
+    engines: {node: '>=18'}
+    dependencies:
+      ansi-styles: 6.2.1
+      is-fullwidth-code-point: 5.1.0
+    dev: true
+
   /@alloc/quick-lru@5.2.0:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
@@ -728,11 +736,9 @@ packages:
     resolution: {integrity: sha512-GphZBLpW72iS0v4YkeUtV3YIno35Gimd7+ezbPO9GwEi9kzdUrPVjvf6aXSBAfHikaFc/9pqZOpv3pOXnC71tw==}
     dependencies:
       '@ark/util': 0.49.0
-    dev: false
 
   /@ark/util@0.49.0:
     resolution: {integrity: sha512-/BtnX7oCjNkxi2vi6y1399b+9xd1jnCrDYhZ61f0a+3X8x8DxlK52VgEEzyuC2UQMPACIfYrmHkhD3lGt2GaMA==}
-    dev: false
 
   /@asteasolutions/zod-to-openapi@7.3.0(zod@3.24.3):
     resolution: {integrity: sha512-7tE/r1gXwMIvGnXVUdIqUhCU1RevEFC4Jk6Bussa0fk1ecbnnINkZzj1EOAJyE/M3AI25DnHT/zKQL1/FPFi8Q==}
@@ -2809,14 +2815,23 @@ packages:
     resolution: {integrity: sha512-uMXCuQ3BItDUbAMhIXw7UPXRfAlOAvZzdK9BWpE60MCn+Svt3aLn9jsPTi/WNGlRUu2uI0v5S7JiIUsbsvh3fw==}
     dependencies:
       '@floating-ui/utils': 0.2.9
-    dev: false
 
   /@floating-ui/dom@1.6.13:
     resolution: {integrity: sha512-umqzocjDgNRGTuO7Q8CU32dkHkECqI8ZdMZ5Swb6QAM0t5rnlrN3lGo1hdpscRd3WS8T6DKYK4ephgIH9iRh3w==}
     dependencies:
       '@floating-ui/core': 1.6.9
       '@floating-ui/utils': 0.2.9
-    dev: false
+
+  /@floating-ui/react-dom@2.1.2(react-dom@18.3.1)(react@19.1.0):
+    resolution: {integrity: sha512-06okr5cgPzMNBy+Ycse2A6udMi4bqwW/zgBF/rwjcNqWkyr82Mcg8b0vjX8OJpZFy/FKjJmw6wV7t44kK6kW7A==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+    dependencies:
+      '@floating-ui/dom': 1.6.13
+      react: 19.1.0
+      react-dom: 18.3.1(react@19.1.0)
+    dev: true
 
   /@floating-ui/react-dom@2.1.2(react-dom@19.1.0)(react@19.1.0):
     resolution: {integrity: sha512-06okr5cgPzMNBy+Ycse2A6udMi4bqwW/zgBF/rwjcNqWkyr82Mcg8b0vjX8OJpZFy/FKjJmw6wV7t44kK6kW7A==}
@@ -2831,7 +2846,6 @@ packages:
 
   /@floating-ui/utils@0.2.9:
     resolution: {integrity: sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==}
-    dev: false
 
   /@hono/swagger-ui@0.5.1(hono@4.7.7):
     resolution: {integrity: sha512-XpUCfszLJ9b1rtFdzqOSHfdg9pfBiC2J5piEjuSanYpDDTIwpMz0ciiv5N3WWUaQpz9fEgH8lttQqL41vIFuDA==}
@@ -2892,6 +2906,13 @@ packages:
     resolution: {integrity: sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==}
     deprecated: Use @eslint/object-schema instead
 
+  /@img/colour@1.0.0:
+    resolution: {integrity: sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==}
+    engines: {node: '>=18'}
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@img/sharp-darwin-arm64@0.33.5:
     resolution: {integrity: sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
@@ -2903,14 +2924,14 @@ packages:
     dev: true
     optional: true
 
-  /@img/sharp-darwin-arm64@0.34.3:
-    resolution: {integrity: sha512-ryFMfvxxpQRsgZJqBd4wsttYQbCxsJksrv9Lw/v798JcQ8+w84mBWuXwl+TT0WJ/WrYOLaYpwQXi3sA9nTIaIg==}
+  /@img/sharp-darwin-arm64@0.34.4:
+    resolution: {integrity: sha512-sitdlPzDVyvmINUdJle3TNHl+AG9QcwiAMsXmccqsCOMZNIdW2/7S26w0LyU8euiLVzFBL3dXPwVCq/ODnf2vA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
     optionalDependencies:
-      '@img/sharp-libvips-darwin-arm64': 1.2.0
+      '@img/sharp-libvips-darwin-arm64': 1.2.3
     dev: false
     optional: true
 
@@ -2925,14 +2946,14 @@ packages:
     dev: true
     optional: true
 
-  /@img/sharp-darwin-x64@0.34.3:
-    resolution: {integrity: sha512-yHpJYynROAj12TA6qil58hmPmAwxKKC7reUqtGLzsOHfP7/rniNGTL8tjWX6L3CTV4+5P4ypcS7Pp+7OB+8ihA==}
+  /@img/sharp-darwin-x64@0.34.4:
+    resolution: {integrity: sha512-rZheupWIoa3+SOdF/IcUe1ah4ZDpKBGWcsPX6MT0lYniH9micvIU7HQkYTfrx5Xi8u+YqwLtxC/3vl8TQN6rMg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
     optionalDependencies:
-      '@img/sharp-libvips-darwin-x64': 1.2.0
+      '@img/sharp-libvips-darwin-x64': 1.2.3
     dev: false
     optional: true
 
@@ -2944,8 +2965,8 @@ packages:
     dev: true
     optional: true
 
-  /@img/sharp-libvips-darwin-arm64@1.2.0:
-    resolution: {integrity: sha512-sBZmpwmxqwlqG9ueWFXtockhsxefaV6O84BMOrhtg/YqbTaRdqDE7hxraVE3y6gVM4eExmfzW4a8el9ArLeEiQ==}
+  /@img/sharp-libvips-darwin-arm64@1.2.3:
+    resolution: {integrity: sha512-QzWAKo7kpHxbuHqUC28DZ9pIKpSi2ts2OJnoIGI26+HMgq92ZZ4vk8iJd4XsxN+tYfNJxzH6W62X5eTcsBymHw==}
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
@@ -2960,8 +2981,8 @@ packages:
     dev: true
     optional: true
 
-  /@img/sharp-libvips-darwin-x64@1.2.0:
-    resolution: {integrity: sha512-M64XVuL94OgiNHa5/m2YvEQI5q2cl9d/wk0qFTDVXcYzi43lxuiFTftMR1tOnFQovVXNZJ5TURSDK2pNe9Yzqg==}
+  /@img/sharp-libvips-darwin-x64@1.2.3:
+    resolution: {integrity: sha512-Ju+g2xn1E2AKO6YBhxjj+ACcsPQRHT0bhpglxcEf+3uyPY+/gL8veniKoo96335ZaPo03bdDXMv0t+BBFAbmRA==}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
@@ -2976,8 +2997,8 @@ packages:
     dev: true
     optional: true
 
-  /@img/sharp-libvips-linux-arm64@1.2.0:
-    resolution: {integrity: sha512-RXwd0CgG+uPRX5YYrkzKyalt2OJYRiJQ8ED/fi1tq9WQW2jsQIn0tqrlR5l5dr/rjqq6AHAxURhj2DVjyQWSOA==}
+  /@img/sharp-libvips-linux-arm64@1.2.3:
+    resolution: {integrity: sha512-I4RxkXU90cpufazhGPyVujYwfIm9Nk1QDEmiIsaPwdnm013F7RIceaCc87kAH+oUB1ezqEvC6ga4m7MSlqsJvQ==}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
@@ -2992,16 +3013,16 @@ packages:
     dev: true
     optional: true
 
-  /@img/sharp-libvips-linux-arm@1.2.0:
-    resolution: {integrity: sha512-mWd2uWvDtL/nvIzThLq3fr2nnGfyr/XMXlq8ZJ9WMR6PXijHlC3ksp0IpuhK6bougvQrchUAfzRLnbsen0Cqvw==}
+  /@img/sharp-libvips-linux-arm@1.2.3:
+    resolution: {integrity: sha512-x1uE93lyP6wEwGvgAIV0gP6zmaL/a0tGzJs/BIDDG0zeBhMnuUPm7ptxGhUbcGs4okDJrk4nxgrmxpib9g6HpA==}
     cpu: [arm]
     os: [linux]
     requiresBuild: true
     dev: false
     optional: true
 
-  /@img/sharp-libvips-linux-ppc64@1.2.0:
-    resolution: {integrity: sha512-Xod/7KaDDHkYu2phxxfeEPXfVXFKx70EAFZ0qyUdOjCcxbjqyJOEUpDe6RIyaunGxT34Anf9ue/wuWOqBW2WcQ==}
+  /@img/sharp-libvips-linux-ppc64@1.2.3:
+    resolution: {integrity: sha512-Y2T7IsQvJLMCBM+pmPbM3bKT/yYJvVtLJGfCs4Sp95SjvnFIjynbjzsa7dY1fRJX45FTSfDksbTp6AGWudiyCg==}
     cpu: [ppc64]
     os: [linux]
     requiresBuild: true
@@ -3016,8 +3037,8 @@ packages:
     dev: true
     optional: true
 
-  /@img/sharp-libvips-linux-s390x@1.2.0:
-    resolution: {integrity: sha512-eMKfzDxLGT8mnmPJTNMcjfO33fLiTDsrMlUVcp6b96ETbnJmd4uvZxVJSKPQfS+odwfVaGifhsB07J1LynFehw==}
+  /@img/sharp-libvips-linux-s390x@1.2.3:
+    resolution: {integrity: sha512-RgWrs/gVU7f+K7P+KeHFaBAJlNkD1nIZuVXdQv6S+fNA6syCcoboNjsV2Pou7zNlVdNQoQUpQTk8SWDHUA3y/w==}
     cpu: [s390x]
     os: [linux]
     requiresBuild: true
@@ -3032,8 +3053,8 @@ packages:
     dev: true
     optional: true
 
-  /@img/sharp-libvips-linux-x64@1.2.0:
-    resolution: {integrity: sha512-ZW3FPWIc7K1sH9E3nxIGB3y3dZkpJlMnkk7z5tu1nSkBoCgw2nSRTFHI5pB/3CQaJM0pdzMF3paf9ckKMSE9Tg==}
+  /@img/sharp-libvips-linux-x64@1.2.3:
+    resolution: {integrity: sha512-3JU7LmR85K6bBiRzSUc/Ff9JBVIFVvq6bomKE0e63UXGeRw2HPVEjoJke1Yx+iU4rL7/7kUjES4dZ/81Qjhyxg==}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
@@ -3048,8 +3069,8 @@ packages:
     dev: true
     optional: true
 
-  /@img/sharp-libvips-linuxmusl-arm64@1.2.0:
-    resolution: {integrity: sha512-UG+LqQJbf5VJ8NWJ5Z3tdIe/HXjuIdo4JeVNADXBFuG7z9zjoegpzzGIyV5zQKi4zaJjnAd2+g2nna8TZvuW9Q==}
+  /@img/sharp-libvips-linuxmusl-arm64@1.2.3:
+    resolution: {integrity: sha512-F9q83RZ8yaCwENw1GieztSfj5msz7GGykG/BA+MOUefvER69K/ubgFHNeSyUu64amHIYKGDs4sRCMzXVj8sEyw==}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
@@ -3064,8 +3085,8 @@ packages:
     dev: true
     optional: true
 
-  /@img/sharp-libvips-linuxmusl-x64@1.2.0:
-    resolution: {integrity: sha512-SRYOLR7CXPgNze8akZwjoGBoN1ThNZoqpOgfnOxmWsklTGVfJiGJoC/Lod7aNMGA1jSsKWM1+HRX43OP6p9+6Q==}
+  /@img/sharp-libvips-linuxmusl-x64@1.2.3:
+    resolution: {integrity: sha512-U5PUY5jbc45ANM6tSJpsgqmBF/VsL6LnxJmIf11kB7J5DctHgqm0SkuXzVWtIY90GnJxKnC/JT251TDnk1fu/g==}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
@@ -3083,14 +3104,14 @@ packages:
     dev: true
     optional: true
 
-  /@img/sharp-linux-arm64@0.34.3:
-    resolution: {integrity: sha512-QdrKe3EvQrqwkDrtuTIjI0bu6YEJHTgEeqdzI3uWJOH6G1O8Nl1iEeVYRGdj1h5I21CqxSvQp1Yv7xeU3ZewbA==}
+  /@img/sharp-linux-arm64@0.34.4:
+    resolution: {integrity: sha512-YXU1F/mN/Wu786tl72CyJjP/Ngl8mGHN1hST4BGl+hiW5jhCnV2uRVTNOcaYPs73NeT/H8Upm3y9582JVuZHrQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
     optionalDependencies:
-      '@img/sharp-libvips-linux-arm64': 1.2.0
+      '@img/sharp-libvips-linux-arm64': 1.2.3
     dev: false
     optional: true
 
@@ -3105,25 +3126,25 @@ packages:
     dev: true
     optional: true
 
-  /@img/sharp-linux-arm@0.34.3:
-    resolution: {integrity: sha512-oBK9l+h6KBN0i3dC8rYntLiVfW8D8wH+NPNT3O/WBHeW0OQWCjfWksLUaPidsrDKpJgXp3G3/hkmhptAW0I3+A==}
+  /@img/sharp-linux-arm@0.34.4:
+    resolution: {integrity: sha512-Xyam4mlqM0KkTHYVSuc6wXRmM7LGN0P12li03jAnZ3EJWZqj83+hi8Y9UxZUbxsgsK1qOEwg7O0Bc0LjqQVtxA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
     requiresBuild: true
     optionalDependencies:
-      '@img/sharp-libvips-linux-arm': 1.2.0
+      '@img/sharp-libvips-linux-arm': 1.2.3
     dev: false
     optional: true
 
-  /@img/sharp-linux-ppc64@0.34.3:
-    resolution: {integrity: sha512-GLtbLQMCNC5nxuImPR2+RgrviwKwVql28FWZIW1zWruy6zLgA5/x2ZXk3mxj58X/tszVF69KK0Is83V8YgWhLA==}
+  /@img/sharp-linux-ppc64@0.34.4:
+    resolution: {integrity: sha512-F4PDtF4Cy8L8hXA2p3TO6s4aDt93v+LKmpcYFLAVdkkD3hSxZzee0rh6/+94FpAynsuMpLX5h+LRsSG3rIciUQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
     requiresBuild: true
     optionalDependencies:
-      '@img/sharp-libvips-linux-ppc64': 1.2.0
+      '@img/sharp-libvips-linux-ppc64': 1.2.3
     dev: false
     optional: true
 
@@ -3138,14 +3159,14 @@ packages:
     dev: true
     optional: true
 
-  /@img/sharp-linux-s390x@0.34.3:
-    resolution: {integrity: sha512-3gahT+A6c4cdc2edhsLHmIOXMb17ltffJlxR0aC2VPZfwKoTGZec6u5GrFgdR7ciJSsHT27BD3TIuGcuRT0KmQ==}
+  /@img/sharp-linux-s390x@0.34.4:
+    resolution: {integrity: sha512-qVrZKE9Bsnzy+myf7lFKvng6bQzhNUAYcVORq2P7bDlvmF6u2sCmK2KyEQEBdYk+u3T01pVsPrkj943T1aJAsw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
     requiresBuild: true
     optionalDependencies:
-      '@img/sharp-libvips-linux-s390x': 1.2.0
+      '@img/sharp-libvips-linux-s390x': 1.2.3
     dev: false
     optional: true
 
@@ -3160,14 +3181,14 @@ packages:
     dev: true
     optional: true
 
-  /@img/sharp-linux-x64@0.34.3:
-    resolution: {integrity: sha512-8kYso8d806ypnSq3/Ly0QEw90V5ZoHh10yH0HnrzOCr6DKAPI6QVHvwleqMkVQ0m+fc7EH8ah0BB0QPuWY6zJQ==}
+  /@img/sharp-linux-x64@0.34.4:
+    resolution: {integrity: sha512-ZfGtcp2xS51iG79c6Vhw9CWqQC8l2Ot8dygxoDoIQPTat/Ov3qAa8qpxSrtAEAJW+UjTXc4yxCjNfxm4h6Xm2A==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
     optionalDependencies:
-      '@img/sharp-libvips-linux-x64': 1.2.0
+      '@img/sharp-libvips-linux-x64': 1.2.3
     dev: false
     optional: true
 
@@ -3182,14 +3203,14 @@ packages:
     dev: true
     optional: true
 
-  /@img/sharp-linuxmusl-arm64@0.34.3:
-    resolution: {integrity: sha512-vAjbHDlr4izEiXM1OTggpCcPg9tn4YriK5vAjowJsHwdBIdx0fYRsURkxLG2RLm9gyBq66gwtWI8Gx0/ov+JKQ==}
+  /@img/sharp-linuxmusl-arm64@0.34.4:
+    resolution: {integrity: sha512-8hDVvW9eu4yHWnjaOOR8kHVrew1iIX+MUgwxSuH2XyYeNRtLUe4VNioSqbNkB7ZYQJj9rUTT4PyRscyk2PXFKA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
     optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-arm64': 1.2.0
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.3
     dev: false
     optional: true
 
@@ -3204,14 +3225,14 @@ packages:
     dev: true
     optional: true
 
-  /@img/sharp-linuxmusl-x64@0.34.3:
-    resolution: {integrity: sha512-gCWUn9547K5bwvOn9l5XGAEjVTTRji4aPTqLzGXHvIr6bIDZKNTA34seMPgM0WmSf+RYBH411VavCejp3PkOeQ==}
+  /@img/sharp-linuxmusl-x64@0.34.4:
+    resolution: {integrity: sha512-lU0aA5L8QTlfKjpDCEFOZsTYGn3AEiO6db8W5aQDxj0nQkVrZWmN3ZP9sYKWJdtq3PWPhUNlqehWyXpYDcI9Sg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
     optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-x64': 1.2.0
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.3
     dev: false
     optional: true
 
@@ -3225,8 +3246,8 @@ packages:
     dev: true
     optional: true
 
-  /@img/sharp-wasm32@0.34.3:
-    resolution: {integrity: sha512-+CyRcpagHMGteySaWos8IbnXcHgfDn7pO2fiC2slJxvNq9gDipYBN42/RagzctVRKgxATmfqOSulgZv5e1RdMg==}
+  /@img/sharp-wasm32@0.34.4:
+    resolution: {integrity: sha512-33QL6ZO/qpRyG7woB/HUALz28WnTMI2W1jgX3Nu2bypqLIKx/QKMILLJzJjI+SIbvXdG9fUnmrxR7vbi1sTBeA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [wasm32]
     requiresBuild: true
@@ -3235,8 +3256,8 @@ packages:
     dev: false
     optional: true
 
-  /@img/sharp-win32-arm64@0.34.3:
-    resolution: {integrity: sha512-MjnHPnbqMXNC2UgeLJtX4XqoVHHlZNd+nPt1kRPmj63wURegwBhZlApELdtxM2OIZDRv/DFtLcNhVbd1z8GYXQ==}
+  /@img/sharp-win32-arm64@0.34.4:
+    resolution: {integrity: sha512-2Q250do/5WXTwxW3zjsEuMSv5sUU4Tq9VThWKlU2EYLm4MB7ZeMwF+SFJutldYODXF6jzc6YEOC+VfX0SZQPqA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [win32]
@@ -3253,8 +3274,8 @@ packages:
     dev: true
     optional: true
 
-  /@img/sharp-win32-ia32@0.34.3:
-    resolution: {integrity: sha512-xuCdhH44WxuXgOM714hn4amodJMZl3OEvf0GVTm0BEyMeA2to+8HEdRPShH0SLYptJY1uBw+SCFP9WVQi1Q/cw==}
+  /@img/sharp-win32-ia32@0.34.4:
+    resolution: {integrity: sha512-3ZeLue5V82dT92CNL6rsal6I2weKw1cYu+rGKm8fOCCtJTR2gYeUfY3FqUnIJsMUPIH68oS5jmZ0NiJ508YpEw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ia32]
     os: [win32]
@@ -3271,8 +3292,8 @@ packages:
     dev: true
     optional: true
 
-  /@img/sharp-win32-x64@0.34.3:
-    resolution: {integrity: sha512-OWwz05d++TxzLEv4VnsTz5CmZ6mI6S05sfQGEMrNrQcOEERbX46332IvE7pO/EUiw7jUrrS40z/M7kPyjfl04g==}
+  /@img/sharp-win32-x64@0.34.4:
+    resolution: {integrity: sha512-xIyj4wpYs8J18sVN3mSQjwrw7fKUqRw+Z5rnHNCy5fYTxigBz81u5mOMPmFumwjcn8+ld1ppptMBCLic1nz6ig==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [win32]
@@ -3617,7 +3638,7 @@ packages:
     resolution: {integrity: sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==}
     dev: true
 
-  /@mdx-js/loader@3.1.1(acorn@8.14.1):
+  /@mdx-js/loader@3.1.1(acorn@8.15.0):
     resolution: {integrity: sha512-0TTacJyZ9mDmY+VefuthVshaNIyCGZHJG2fMnGaDttCt8HmjUF7SizlHJpaCDoGnN635nK1wpzfpx/Xx5S4WnQ==}
     peerDependencies:
       webpack: '>=5'
@@ -3625,14 +3646,14 @@ packages:
       webpack:
         optional: true
     dependencies:
-      '@mdx-js/mdx': 3.1.0(acorn@8.14.1)
+      '@mdx-js/mdx': 3.1.0(acorn@8.15.0)
       source-map: 0.7.4
     transitivePeerDependencies:
       - acorn
       - supports-color
     dev: false
 
-  /@mdx-js/mdx@3.1.0(acorn@8.14.1):
+  /@mdx-js/mdx@3.1.0(acorn@8.15.0):
     resolution: {integrity: sha512-/QxEhPAvGwbQmy1Px8F899L5Uc2KZ6JtXwlCgJmjSTBedwOZkByYcBG4GceIGPXRDsmfxhHazuS+hlOShRLeDw==}
     dependencies:
       '@types/estree': 1.0.7
@@ -3647,7 +3668,7 @@ packages:
       hast-util-to-jsx-runtime: 2.3.6
       markdown-extensions: 2.0.0
       recma-build-jsx: 1.0.0
-      recma-jsx: 1.0.0(acorn@8.14.1)
+      recma-jsx: 1.0.0(acorn@8.15.0)
       recma-stringify: 1.0.0
       rehype-recma: 1.0.0
       remark-mdx: 3.1.0
@@ -3663,15 +3684,15 @@ packages:
       - acorn
       - supports-color
 
-  /@mdx-js/react@3.1.0(@types/react@19.1.12)(react@18.3.1):
-    resolution: {integrity: sha512-QjHtSaoameoalGnKDT3FoIl4+9RwyTmo9ZJGBdLOks/YOiWHoRDI3PUwEzOE7kEmGcV3AFcp9K6dYu9rEuKLAQ==}
+  /@mdx-js/react@3.1.1(@types/react@19.1.14)(react@19.1.0):
+    resolution: {integrity: sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==}
     peerDependencies:
       '@types/react': '>=16'
       react: '>=16'
     dependencies:
       '@types/mdx': 2.0.13
-      '@types/react': 19.1.12
-      react: 18.3.1
+      '@types/react': 19.1.14
+      react: 19.1.0
     dev: true
 
   /@mdx-js/react@3.1.1(@types/react@19.1.2)(react@19.1.0):
@@ -3698,68 +3719,79 @@ packages:
     resolution: {integrity: sha512-9b8mPpKrfeGRuhFH5iO1iwCLeIIsV6+H1sRfxbkoGXIyQE2BTsPd9zqSqQJ+pv5sJ/hT5M1zvOFL02MnEezFug==}
     dev: true
 
-  /@mintlify/cli@4.0.509(@types/react@19.1.12)(react-dom@18.3.1)(react@18.3.1):
-    resolution: {integrity: sha512-2EuldNBiweQKnMmd7q2mgqjTnydHJSGt3x7FoORz0LJFlzxnfaGYGGk68KYK1zLMKUprdh65yidENWsxkuIKHg==}
+  /@mintlify/cli@4.0.732(@radix-ui/react-popover@1.1.15)(@types/react@19.1.14)(react-dom@18.3.1)(typescript@5.8.3):
+    resolution: {integrity: sha512-t1RPfCMYVQhLxOZWV8XRPA6Er8DtAHjxDRCdiRdWDJT82qjgiiQEjEdVx51thaREiTuZk3rkuWOha2+DB852pw==}
     engines: {node: '>=18.0.0'}
     hasBin: true
     dependencies:
-      '@mintlify/common': 1.0.361(@types/react@19.1.12)(react-dom@18.3.1)(react@18.3.1)
-      '@mintlify/link-rot': 3.0.472(@types/react@19.1.12)(react-dom@18.3.1)(react@18.3.1)
-      '@mintlify/models': 0.0.188
-      '@mintlify/prebuild': 1.0.469(@types/react@19.1.12)(react-dom@18.3.1)(react@18.3.1)
-      '@mintlify/previewing': 4.0.500(@types/react@19.1.12)(react-dom@18.3.1)(react@18.3.1)
-      '@mintlify/validation': 0.1.354
+      '@mintlify/common': 1.0.542(@radix-ui/react-popover@1.1.15)(@types/react@19.1.14)(react-dom@18.3.1)(react@19.1.0)(typescript@5.8.3)
+      '@mintlify/link-rot': 3.0.679(@radix-ui/react-popover@1.1.15)(@types/react@19.1.14)(react-dom@18.3.1)(react@19.1.0)(typescript@5.8.3)
+      '@mintlify/models': 0.0.230
+      '@mintlify/prebuild': 1.0.666(@radix-ui/react-popover@1.1.15)(@types/react@19.1.14)(react-dom@18.3.1)(react@19.1.0)(typescript@5.8.3)
+      '@mintlify/previewing': 4.0.715(@radix-ui/react-popover@1.1.15)(@types/react@19.1.14)(react-dom@18.3.1)(typescript@5.8.3)
+      '@mintlify/validation': 0.1.474
       chalk: 5.4.1
       detect-port: 1.6.1
       fs-extra: 11.3.0
+      gray-matter: 4.0.3
+      ink: 6.3.1(@types/react@19.1.14)(react@19.1.0)
       inquirer: 12.6.0
       js-yaml: 4.1.0
-      ora: 6.3.1
+      react: 19.1.0
+      semver: 7.7.2
       yargs: 17.7.2
     transitivePeerDependencies:
+      - '@radix-ui/react-popover'
       - '@types/node'
       - '@types/react'
       - bare-buffer
       - bufferutil
       - debug
       - encoding
-      - react
+      - react-devtools-core
       - react-dom
       - supports-color
+      - ts-node
       - typescript
       - utf-8-validate
     dev: true
 
-  /@mintlify/common@1.0.361(@types/react@19.1.12)(react-dom@18.3.1)(react@18.3.1):
-    resolution: {integrity: sha512-RobxzW7n9TQsKqifXY9ArxACl/JAf02Rd7vTVlWS8nxnlLUgb0jDH90bMsDvA3ssoSKEJaELM7Ofc9t2FDIgxg==}
+  /@mintlify/common@1.0.542(@radix-ui/react-popover@1.1.15)(@types/react@19.1.14)(react-dom@18.3.1)(react@19.1.0)(typescript@5.8.3):
+    resolution: {integrity: sha512-Fd86uA+Jq1+MyV8VoDk3yJTBOCJ4YW2QW7G/jcjQB6mzbas1AhVFVy9BYHe5zLw1a9hRaBaNYoW3ZEF29vb1gQ==}
     dependencies:
       '@asyncapi/parser': 3.4.0
-      '@mintlify/mdx': 1.0.1(@types/react@19.1.12)(acorn@8.14.1)(react-dom@18.3.1)(react@18.3.1)
-      '@mintlify/models': 0.0.188
-      '@mintlify/openapi-parser': 0.0.7
-      '@mintlify/validation': 0.1.354
+      '@mintlify/mdx': 2.0.11(@radix-ui/react-popover@1.1.15)(@types/react@19.1.14)(acorn@8.15.0)(react-dom@18.3.1)(react@19.1.0)(typescript@5.8.3)
+      '@mintlify/models': 0.0.230
+      '@mintlify/openapi-parser': 0.0.8
+      '@mintlify/validation': 0.1.474
       '@sindresorhus/slugify': 2.2.1
-      acorn: 8.14.1
+      acorn: 8.15.0
+      acorn-jsx: 5.3.2(acorn@8.15.0)
       estree-util-to-js: 2.0.0
       estree-walker: 3.0.3
       gray-matter: 4.0.3
       hast-util-from-html: 2.0.3
       hast-util-to-html: 9.0.5
       hast-util-to-text: 4.0.2
-      is-absolute-url: 4.0.1
       js-yaml: 4.1.0
       lodash: 4.17.21
       mdast: 3.0.0
       mdast-util-from-markdown: 2.0.2
+      mdast-util-gfm: 3.1.0
       mdast-util-mdx: 3.0.0
       mdast-util-mdx-jsx: 3.2.0
+      micromark-extension-gfm: 3.0.0
       micromark-extension-mdx-jsx: 3.0.2
+      micromark-extension-mdxjs: 3.0.0
       openapi-types: 12.1.3
+      postcss: 8.5.6
       remark: 15.0.1
       remark-frontmatter: 5.0.0
       remark-gfm: 4.0.1
       remark-math: 6.0.0
       remark-mdx: 3.1.0
+      remark-stringify: 11.0.0
+      tailwindcss: 3.4.15
       unified: 11.0.5
       unist-builder: 4.0.0
       unist-util-map: 4.0.0
@@ -3769,63 +3801,77 @@ packages:
       unist-util-visit-parents: 6.0.1
       vfile: 6.0.3
     transitivePeerDependencies:
+      - '@radix-ui/react-popover'
       - '@types/react'
       - debug
       - encoding
       - react
       - react-dom
       - supports-color
+      - ts-node
+      - typescript
     dev: true
 
-  /@mintlify/link-rot@3.0.472(@types/react@19.1.12)(react-dom@18.3.1)(react@18.3.1):
-    resolution: {integrity: sha512-XVsauWAZe95lC1RDSkaqXl4mDIgiZlvDCW/uss08ZrI9f+nBx6RtYSIoqDIQACIgYvZwGmWNPmdNxZqerxs9JQ==}
+  /@mintlify/link-rot@3.0.679(@radix-ui/react-popover@1.1.15)(@types/react@19.1.14)(react-dom@18.3.1)(react@19.1.0)(typescript@5.8.3):
+    resolution: {integrity: sha512-gi6sSuFedzKCTOjetfTIHlLEWF8wIIdu9i5I+K1V5EKByBY/9eESwZP8/qX/TrfxS1QX5H+TR7KvmFjCGOwYjQ==}
     engines: {node: '>=18.0.0'}
     dependencies:
-      '@mintlify/common': 1.0.361(@types/react@19.1.12)(react-dom@18.3.1)(react@18.3.1)
-      '@mintlify/prebuild': 1.0.469(@types/react@19.1.12)(react-dom@18.3.1)(react@18.3.1)
+      '@mintlify/common': 1.0.542(@radix-ui/react-popover@1.1.15)(@types/react@19.1.14)(react-dom@18.3.1)(react@19.1.0)(typescript@5.8.3)
+      '@mintlify/prebuild': 1.0.666(@radix-ui/react-popover@1.1.15)(@types/react@19.1.14)(react-dom@18.3.1)(react@19.1.0)(typescript@5.8.3)
+      '@mintlify/previewing': 4.0.715(@radix-ui/react-popover@1.1.15)(@types/react@19.1.14)(react-dom@18.3.1)(typescript@5.8.3)
+      '@mintlify/validation': 0.1.474
       fs-extra: 11.3.0
-      is-absolute-url: 4.0.1
       unist-util-visit: 4.1.2
     transitivePeerDependencies:
+      - '@radix-ui/react-popover'
       - '@types/react'
       - bare-buffer
       - bufferutil
       - debug
       - encoding
       - react
+      - react-devtools-core
       - react-dom
       - supports-color
+      - ts-node
       - typescript
       - utf-8-validate
     dev: true
 
-  /@mintlify/mdx@1.0.1(@types/react@19.1.12)(acorn@8.14.1)(react-dom@18.3.1)(react@18.3.1):
-    resolution: {integrity: sha512-zrzt8nxoIgJeSUeuJaC8pbd5EHKjCq30qV2HMoqIHLjeE0l7hkMgjBPNWNde7CYDPig1ODS1kPuE5Bnt+/+PIg==}
+  /@mintlify/mdx@2.0.11(@radix-ui/react-popover@1.1.15)(@types/react@19.1.14)(acorn@8.15.0)(react-dom@18.3.1)(react@19.1.0)(typescript@5.8.3):
+    resolution: {integrity: sha512-yXwuM0BNCxNaJetPrh89c5Q2lhzU2al4QrOM3zLUdrPOdjOpPmv8ewcdiXV/qIhZDpl5Ll9k47dsz33bZjVWTg==}
     peerDependencies:
+      '@radix-ui/react-popover': ^1.1.15
       react: ^18.3.1
       react-dom: ^18.3.1
     dependencies:
-      '@types/hast': 3.0.4
-      '@types/unist': 3.0.3
+      '@radix-ui/react-popover': 1.1.15(@types/react@19.1.14)(react-dom@18.3.1)(react@19.1.0)
+      '@shikijs/transformers': 3.13.0
+      '@shikijs/twoslash': 3.13.0(typescript@5.8.3)
       hast-util-to-string: 3.0.1
-      next-mdx-remote-client: 1.1.0(@types/react@19.1.12)(acorn@8.14.1)(react-dom@18.3.1)(react@18.3.1)
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      refractor: 4.9.0
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-gfm: 3.1.0
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-to-hast: 13.2.0
+      next-mdx-remote-client: 1.1.0(@types/react@19.1.14)(acorn@8.15.0)(react-dom@18.3.1)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 18.3.1(react@19.1.0)
       rehype-katex: 7.0.1
       remark-gfm: 4.0.1
       remark-math: 6.0.0
       remark-smartypants: 3.0.2
+      shiki: 3.13.0
       unified: 11.0.5
       unist-util-visit: 5.0.0
     transitivePeerDependencies:
       - '@types/react'
       - acorn
       - supports-color
+      - typescript
     dev: true
 
-  /@mintlify/models@0.0.188:
-    resolution: {integrity: sha512-98sGznldqt21OrJ7d+D3JAc/sg5FkXb25rDO1wDH+h7oESdUA00zshLJvCLPJ9DXCTOSggzXaxUjowTXh8wkrg==}
+  /@mintlify/models@0.0.230:
+    resolution: {integrity: sha512-G/mg8TytxLn29zete+KXsFKFmi/N/C6a0HX15pN+qq1CWHP3hzi5mELUf7xID/w77bkzN1tVSFKgkwZVBr01OA==}
     engines: {node: '>=18.0.0'}
     dependencies:
       axios: 1.9.0
@@ -3834,8 +3880,8 @@ packages:
       - debug
     dev: true
 
-  /@mintlify/openapi-parser@0.0.7:
-    resolution: {integrity: sha512-3ecbkzPbsnkKVZJypVL0H5pCTR7a4iLv4cP7zbffzAwy+vpH70JmPxNVpPPP62yLrdZlfNcMxu5xKeT7fllgMg==}
+  /@mintlify/openapi-parser@0.0.8:
+    resolution: {integrity: sha512-9MBRq9lS4l4HITYCrqCL7T61MOb20q9IdU7HWhqYMNMM1jGO1nHjXasFy61yZ8V6gMZyyKQARGVoZ0ZrYN48Og==}
     engines: {node: '>=18'}
     dependencies:
       ajv: 8.17.1
@@ -3846,23 +3892,23 @@ packages:
       yaml: 2.7.1
     dev: true
 
-  /@mintlify/prebuild@1.0.469(@types/react@19.1.12)(react-dom@18.3.1)(react@18.3.1):
-    resolution: {integrity: sha512-bRqwrUtL6hu+PsdZq18EK5GwhpErZBv1s+7lAdrn5IeegMa0iH81ZJc+ifg4gO6OXXyurEIl5XTaM34FP0GWuA==}
+  /@mintlify/prebuild@1.0.666(@radix-ui/react-popover@1.1.15)(@types/react@19.1.14)(react-dom@18.3.1)(react@19.1.0)(typescript@5.8.3):
+    resolution: {integrity: sha512-qz4/AucI0CGOxKMywsueXfUZ/Hk9uXGz0jDTg0vPkRqOvo9s9RKkgEfRpGhhqU53nDkECIlTxtOAlCALRBmScA==}
     dependencies:
-      '@mintlify/common': 1.0.361(@types/react@19.1.12)(react-dom@18.3.1)(react@18.3.1)
-      '@mintlify/openapi-parser': 0.0.7
-      '@mintlify/scraping': 4.0.216(@types/react@19.1.12)(react-dom@18.3.1)(react@18.3.1)
-      '@mintlify/validation': 0.1.354
-      axios: 1.9.0
+      '@mintlify/common': 1.0.542(@radix-ui/react-popover@1.1.15)(@types/react@19.1.14)(react-dom@18.3.1)(react@19.1.0)(typescript@5.8.3)
+      '@mintlify/openapi-parser': 0.0.8
+      '@mintlify/scraping': 4.0.401(@radix-ui/react-popover@1.1.15)(@types/react@19.1.14)(react-dom@18.3.1)(react@19.1.0)(typescript@5.8.3)
+      '@mintlify/validation': 0.1.474
       chalk: 5.4.1
       favicons: 7.2.0
       fs-extra: 11.3.0
       gray-matter: 4.0.3
-      is-absolute-url: 4.0.1
       js-yaml: 4.1.0
+      mdast: 3.0.0
       openapi-types: 12.1.3
       unist-util-visit: 4.1.2
     transitivePeerDependencies:
+      - '@radix-ui/react-popover'
       - '@types/react'
       - bare-buffer
       - bufferutil
@@ -3871,17 +3917,18 @@ packages:
       - react
       - react-dom
       - supports-color
+      - ts-node
       - typescript
       - utf-8-validate
     dev: true
 
-  /@mintlify/previewing@4.0.500(@types/react@19.1.12)(react-dom@18.3.1)(react@18.3.1):
-    resolution: {integrity: sha512-hJHHoSITT2pWrOF044Zm85NN1eg6CJpNAA5QlLrT68aFM9hT2LQ0DKxlI6qGOb1AxdPgW3dFZUzTt1VEGhYbqQ==}
+  /@mintlify/previewing@4.0.715(@radix-ui/react-popover@1.1.15)(@types/react@19.1.14)(react-dom@18.3.1)(typescript@5.8.3):
+    resolution: {integrity: sha512-AKIcOYzi4EO7R1JGysy4xcJrOmipB717E80/HH08oA4j8ufKE1AoKe6l1i6NOHXA18ziB8qKduXhpvkeldLxXQ==}
     engines: {node: '>=18.0.0'}
     dependencies:
-      '@mintlify/common': 1.0.361(@types/react@19.1.12)(react-dom@18.3.1)(react@18.3.1)
-      '@mintlify/prebuild': 1.0.469(@types/react@19.1.12)(react-dom@18.3.1)(react@18.3.1)
-      '@mintlify/validation': 0.1.354
+      '@mintlify/common': 1.0.542(@radix-ui/react-popover@1.1.15)(@types/react@19.1.14)(react-dom@18.3.1)(react@19.1.0)(typescript@5.8.3)
+      '@mintlify/prebuild': 1.0.666(@radix-ui/react-popover@1.1.15)(@types/react@19.1.14)(react-dom@18.3.1)(react@19.1.0)(typescript@5.8.3)
+      '@mintlify/validation': 0.1.474
       better-opn: 3.0.2
       chalk: 5.4.1
       chokidar: 3.6.0
@@ -3889,41 +3936,45 @@ packages:
       fs-extra: 11.3.0
       got: 13.0.0
       gray-matter: 4.0.3
-      is-absolute-url: 4.0.1
+      ink: 6.3.1(@types/react@19.1.14)(react@19.1.0)
+      ink-spinner: 5.0.0(ink@6.3.1)(react@19.1.0)
       is-online: 10.0.0
       js-yaml: 4.1.0
+      mdast: 3.0.0
       openapi-types: 12.1.3
-      ora: 6.3.1
+      react: 19.1.0
       socket.io: 4.8.1
       tar: 6.2.1
       unist-util-visit: 4.1.2
       yargs: 17.7.2
     transitivePeerDependencies:
+      - '@radix-ui/react-popover'
       - '@types/react'
       - bare-buffer
       - bufferutil
       - debug
       - encoding
-      - react
+      - react-devtools-core
       - react-dom
       - supports-color
+      - ts-node
       - typescript
       - utf-8-validate
     dev: true
 
-  /@mintlify/scraping@4.0.216(@types/react@19.1.12)(react-dom@18.3.1)(react@18.3.1):
-    resolution: {integrity: sha512-L5pf3XKuy0XzFHDhw9nJIEhzTV7OoVtakQ5Us7kuN9Qt4F7Y/nXFklkDwDMvI+zP5fcrowbyCwET5e3mQ2OnUw==}
+  /@mintlify/scraping@4.0.401(@radix-ui/react-popover@1.1.15)(@types/react@19.1.14)(react-dom@18.3.1)(react@19.1.0)(typescript@5.8.3):
+    resolution: {integrity: sha512-Ovx1r+hEkOxE6g2t6qwD2+/7cg+rAXizGsOzRUUkmpMBdE/U/u8YZRMMP/UJm+O07LQAMTI68lOGU+dCSduIKg==}
     engines: {node: '>=18.0.0'}
     hasBin: true
     dependencies:
-      '@mintlify/common': 1.0.361(@types/react@19.1.12)(react-dom@18.3.1)(react@18.3.1)
-      '@mintlify/openapi-parser': 0.0.7
+      '@mintlify/common': 1.0.542(@radix-ui/react-popover@1.1.15)(@types/react@19.1.14)(react-dom@18.3.1)(react@19.1.0)(typescript@5.8.3)
+      '@mintlify/openapi-parser': 0.0.8
       fs-extra: 11.3.0
       hast-util-to-mdast: 10.1.2
       js-yaml: 4.1.0
       mdast-util-mdx-jsx: 3.2.0
       neotraverse: 0.6.18
-      puppeteer: 22.15.0
+      puppeteer: 22.15.0(typescript@5.8.3)
       rehype-parse: 9.0.1
       remark-gfm: 4.0.1
       remark-mdx: 3.1.0
@@ -3934,6 +3985,7 @@ packages:
       yargs: 17.7.2
       zod: 3.24.3
     transitivePeerDependencies:
+      - '@radix-ui/react-popover'
       - '@types/react'
       - bare-buffer
       - bufferutil
@@ -3942,15 +3994,16 @@ packages:
       - react
       - react-dom
       - supports-color
+      - ts-node
       - typescript
       - utf-8-validate
     dev: true
 
-  /@mintlify/validation@0.1.354:
-    resolution: {integrity: sha512-UsANZZyW5Roc0SsbrE7rRhl8ttemRnPZQ7VF/iVpT2pFcm60ybWN7NcXQgxhcVXgTBbeRbU0IHEv40UtcMOElg==}
+  /@mintlify/validation@0.1.474:
+    resolution: {integrity: sha512-jP9q0Fd1CRrBxc4SelDc0PQj+Z7d5E+kuySRxXMSp122Js9Hd0jMb588O1n7dLmedId3fRVauhNSf48FFFUPYQ==}
     dependencies:
-      '@mintlify/models': 0.0.188
-      is-absolute-url: 4.0.1
+      '@mintlify/models': 0.0.230
+      arktype: 2.1.22
       lcm: 0.0.3
       lodash: 4.17.21
       openapi-types: 12.1.3
@@ -4014,7 +4067,7 @@ packages:
     dependencies:
       '@emnapi/core': 1.5.0
       '@emnapi/runtime': 1.5.0
-      '@tybys/wasm-util': 0.10.0
+      '@tybys/wasm-util': 0.10.1
     dev: true
     optional: true
 
@@ -4039,7 +4092,7 @@ packages:
       '@mdx-js/react':
         optional: true
     dependencies:
-      '@mdx-js/loader': 3.1.1(acorn@8.14.1)
+      '@mdx-js/loader': 3.1.1(acorn@8.15.0)
       '@mdx-js/react': 3.1.1(@types/react@19.1.2)(react@19.1.0)
       source-map: 0.7.4
     dev: false
@@ -4408,6 +4461,10 @@ packages:
     resolution: {integrity: sha512-XnbHrrprsNqZKQhStrSwgRUQzoCI1glLzdw79xiZPoofhGICeZRSQ3dIxAKH1gb3OHfNf4d6f+vAv3kil2eggA==}
     dev: false
 
+  /@radix-ui/primitive@1.1.3:
+    resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
+    dev: true
+
   /@radix-ui/react-accordion@1.2.8(@types/react-dom@19.1.2)(@types/react@19.1.2)(react-dom@19.1.0)(react@19.1.0):
     resolution: {integrity: sha512-c7OKBvO36PfQIUGIjj1Wko0hH937pYFU2tR5zbIJDUsmTzHoZVHHt4bmb7OOJbzTaWJtVELKWojBHa7OcnUHmQ==}
     peerDependencies:
@@ -4475,6 +4532,25 @@ packages:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
     dev: false
+
+  /@radix-ui/react-arrow@1.1.7(@types/react@19.1.14)(react-dom@18.3.1)(react@19.1.0):
+    resolution: {integrity: sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react@19.1.14)(react-dom@18.3.1)(react@19.1.0)
+      '@types/react': 19.1.14
+      react: 19.1.0
+      react-dom: 18.3.1(react@19.1.0)
+    dev: true
 
   /@radix-ui/react-avatar@1.1.9(@types/react-dom@19.1.2)(@types/react@19.1.2)(react-dom@19.1.0)(react@19.1.0):
     resolution: {integrity: sha512-10tQokfvZdFvnvDkcOJPjm2pWiP8A0R4T83MoD7tb15bC/k2GU7B1YBuzJi8lNQ8V1QqhP8ocNqp27ByZaNagQ==}
@@ -4613,6 +4689,19 @@ packages:
       react: 19.1.0
     dev: false
 
+  /@radix-ui/react-compose-refs@1.1.2(@types/react@19.1.14)(react@19.1.0):
+    resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@types/react': 19.1.14
+      react: 19.1.0
+    dev: true
+
   /@radix-ui/react-compose-refs@1.1.2(@types/react@19.1.2)(react@19.1.0):
     resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
     peerDependencies:
@@ -4651,6 +4740,19 @@ packages:
       '@types/react': 19.1.2
       react: 19.1.0
     dev: false
+
+  /@radix-ui/react-context@1.1.2(@types/react@19.1.14)(react@19.1.0):
+    resolution: {integrity: sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@types/react': 19.1.14
+      react: 19.1.0
+    dev: true
 
   /@radix-ui/react-context@1.1.2(@types/react@19.1.2)(react@19.1.0):
     resolution: {integrity: sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==}
@@ -4748,6 +4850,29 @@ packages:
       react-dom: 19.1.0(react@19.1.0)
     dev: false
 
+  /@radix-ui/react-dismissable-layer@1.1.11(@types/react@19.1.14)(react-dom@18.3.1)(react@19.1.0):
+    resolution: {integrity: sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.14)(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react@19.1.14)(react-dom@18.3.1)(react@19.1.0)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.14)(react@19.1.0)
+      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.1.14)(react@19.1.0)
+      '@types/react': 19.1.14
+      react: 19.1.0
+      react-dom: 18.3.1(react@19.1.0)
+    dev: true
+
   /@radix-ui/react-dismissable-layer@1.1.7(@types/react-dom@19.1.2)(@types/react@19.1.2)(react-dom@19.1.0)(react@19.1.0):
     resolution: {integrity: sha512-j5+WBUdhccJsmH5/H0K6RncjDtoALSEr6jbkaZu+bjw6hOPOhHycr6vEUujl+HBK8kjUfWcoCJXxP6e4lUlMZw==}
     peerDependencies:
@@ -4824,6 +4949,19 @@ packages:
       react: 19.1.0
     dev: false
 
+  /@radix-ui/react-focus-guards@1.1.3(@types/react@19.1.14)(react@19.1.0):
+    resolution: {integrity: sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@types/react': 19.1.14
+      react: 19.1.0
+    dev: true
+
   /@radix-ui/react-focus-scope@1.1.0(@types/react-dom@19.1.2)(@types/react@19.1.2)(react-dom@19.1.0)(react@19.1.0):
     resolution: {integrity: sha512-200UD8zylvEyL8Bx+z76RJnASR2gRMuxlgFCPAe/Q/679a/r0eK3MBVYMb7vZODZcffZBdob1EGnky78xmVvcA==}
     peerDependencies:
@@ -4868,6 +5006,27 @@ packages:
       react-dom: 19.1.0(react@19.1.0)
     dev: false
 
+  /@radix-ui/react-focus-scope@1.1.7(@types/react@19.1.14)(react-dom@18.3.1)(react@19.1.0):
+    resolution: {integrity: sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.14)(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react@19.1.14)(react-dom@18.3.1)(react@19.1.0)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.14)(react@19.1.0)
+      '@types/react': 19.1.14
+      react: 19.1.0
+      react-dom: 18.3.1(react@19.1.0)
+    dev: true
+
   /@radix-ui/react-icons@1.3.2(react@19.1.0):
     resolution: {integrity: sha512-fyQIhGDhzfc9pK2kH6Pl9c4BDJGfMkPqkyIgYDthyNYoNg3wVhoJMMh19WS4Up/1KMPFVpNsT2q3WmXn2N1m6g==}
     peerDependencies:
@@ -4889,6 +5048,20 @@ packages:
       '@types/react': 19.1.2
       react: 19.1.0
     dev: false
+
+  /@radix-ui/react-id@1.1.1(@types/react@19.1.14)(react@19.1.0):
+    resolution: {integrity: sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.14)(react@19.1.0)
+      '@types/react': 19.1.14
+      react: 19.1.0
+    dev: true
 
   /@radix-ui/react-id@1.1.1(@types/react@19.1.2)(react@19.1.0):
     resolution: {integrity: sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==}
@@ -4995,6 +5168,39 @@ packages:
       react-remove-scroll: 2.6.3(@types/react@19.1.2)(react@19.1.0)
     dev: false
 
+  /@radix-ui/react-popover@1.1.15(@types/react@19.1.14)(react-dom@18.3.1)(react@19.1.0):
+    resolution: {integrity: sha512-kr0X2+6Yy/vJzLYJUPCZEc8SfQcf+1COFoAqauJm74umQhta9M7lNJHP7QQS3vkvcGLQUbWpMzwrXYwrYztHKA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.14)(react@19.1.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.14)(react@19.1.0)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react@19.1.14)(react-dom@18.3.1)(react@19.1.0)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.1.14)(react@19.1.0)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react@19.1.14)(react-dom@18.3.1)(react@19.1.0)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.1.14)(react@19.1.0)
+      '@radix-ui/react-popper': 1.2.8(@types/react@19.1.14)(react-dom@18.3.1)(react@19.1.0)
+      '@radix-ui/react-portal': 1.1.9(@types/react@19.1.14)(react-dom@18.3.1)(react@19.1.0)
+      '@radix-ui/react-presence': 1.1.5(@types/react@19.1.14)(react-dom@18.3.1)(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react@19.1.14)(react-dom@18.3.1)(react@19.1.0)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.1.14)(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.14)(react@19.1.0)
+      '@types/react': 19.1.14
+      aria-hidden: 1.2.4
+      react: 19.1.0
+      react-dom: 18.3.1(react@19.1.0)
+      react-remove-scroll: 2.6.3(@types/react@19.1.14)(react@19.1.0)
+    dev: true
+
   /@radix-ui/react-popover@1.1.2(@types/react-dom@19.1.2)(@types/react@19.1.2)(react-dom@19.1.0)(react@19.1.0):
     resolution: {integrity: sha512-u2HRUyWW+lOiA2g0Le0tMmT55FGOEWHwPFt1EPfbLly7uXQExFo5duNKqG2DzmFXIdqOeNd+TpE8baHWJCyP9w==}
     peerDependencies:
@@ -5087,6 +5293,34 @@ packages:
       react-dom: 19.1.0(react@19.1.0)
     dev: false
 
+  /@radix-ui/react-popper@1.2.8(@types/react@19.1.14)(react-dom@18.3.1)(react@19.1.0):
+    resolution: {integrity: sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@floating-ui/react-dom': 2.1.2(react-dom@18.3.1)(react@19.1.0)
+      '@radix-ui/react-arrow': 1.1.7(@types/react@19.1.14)(react-dom@18.3.1)(react@19.1.0)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.14)(react@19.1.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.14)(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react@19.1.14)(react-dom@18.3.1)(react@19.1.0)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.14)(react@19.1.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.14)(react@19.1.0)
+      '@radix-ui/react-use-rect': 1.1.1(@types/react@19.1.14)(react@19.1.0)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.1.14)(react@19.1.0)
+      '@radix-ui/rect': 1.1.1
+      '@types/react': 19.1.14
+      react: 19.1.0
+      react-dom: 18.3.1(react@19.1.0)
+    dev: true
+
   /@radix-ui/react-portal@1.1.2(@types/react-dom@19.1.2)(@types/react@19.1.2)(react-dom@19.1.0)(react@19.1.0):
     resolution: {integrity: sha512-WeDYLGPxJb/5EGBoedyJbT0MpoULmwnIPMJMSldkuiMsBAv7N1cRdsTWZWht9vpPOiN3qyiGAtbK2is47/uMFg==}
     peerDependencies:
@@ -5129,6 +5363,26 @@ packages:
       react-dom: 19.1.0(react@19.1.0)
     dev: false
 
+  /@radix-ui/react-portal@1.1.9(@types/react@19.1.14)(react-dom@18.3.1)(react@19.1.0):
+    resolution: {integrity: sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react@19.1.14)(react-dom@18.3.1)(react@19.1.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.14)(react@19.1.0)
+      '@types/react': 19.1.14
+      react: 19.1.0
+      react-dom: 18.3.1(react@19.1.0)
+    dev: true
+
   /@radix-ui/react-presence@1.1.1(@types/react-dom@19.1.2)(@types/react@19.1.2)(react-dom@19.1.0)(react@19.1.0):
     resolution: {integrity: sha512-IeFXVi4YS1K0wVZzXNrbaaUvIJ3qdY+/Ih4eHFhWA9SwGR9UDX7Ck8abvL57C4cv3wwMvUE0OG69Qc3NCcTe/A==}
     peerDependencies:
@@ -5170,6 +5424,26 @@ packages:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
     dev: false
+
+  /@radix-ui/react-presence@1.1.5(@types/react@19.1.14)(react-dom@18.3.1)(react@19.1.0):
+    resolution: {integrity: sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.14)(react@19.1.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.14)(react@19.1.0)
+      '@types/react': 19.1.14
+      react: 19.1.0
+      react-dom: 18.3.1(react@19.1.0)
+    dev: true
 
   /@radix-ui/react-primitive@2.0.0(@types/react-dom@19.1.2)(@types/react@19.1.2)(react-dom@19.1.0)(react@19.1.0):
     resolution: {integrity: sha512-ZSpFm0/uHa8zTvKBDjLFWLo8dkr4MBsiDLz0g3gMUwqgLHz9rTaRRGYDgvZPtBJgYCBKXkS9fzmoySgr8CO6Cw==}
@@ -5230,6 +5504,25 @@ packages:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
     dev: false
+
+  /@radix-ui/react-primitive@2.1.3(@types/react@19.1.14)(react-dom@18.3.1)(react@19.1.0):
+    resolution: {integrity: sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.1.14)(react@19.1.0)
+      '@types/react': 19.1.14
+      react: 19.1.0
+      react-dom: 18.3.1(react@19.1.0)
+    dev: true
 
   /@radix-ui/react-progress@1.1.4(@types/react-dom@19.1.2)(@types/react@19.1.2)(react-dom@19.1.0)(react@19.1.0):
     resolution: {integrity: sha512-8rl9w7lJdcVPor47Dhws9mUHRHLE+8JEgyJRdNWCpGPa6HIlr3eh+Yn9gyx1CnCLbw5naHsI2gaO9dBWO50vzw==}
@@ -5410,6 +5703,20 @@ packages:
       react: 19.1.0
     dev: false
 
+  /@radix-ui/react-slot@1.2.3(@types/react@19.1.14)(react@19.1.0):
+    resolution: {integrity: sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.14)(react@19.1.0)
+      '@types/react': 19.1.14
+      react: 19.1.0
+    dev: true
+
   /@radix-ui/react-switch@1.2.2(@types/react-dom@19.1.2)(@types/react@19.1.2)(react-dom@19.1.0)(react@19.1.0):
     resolution: {integrity: sha512-7Z8n6L+ifMIIYZ83f28qWSceUpkXuslI2FJ34+kDMTiyj91ENdpdQ7VCidrzj5JfwfZTeano/BnGBbu/jqa5rQ==}
     peerDependencies:
@@ -5555,6 +5862,19 @@ packages:
       react: 19.1.0
     dev: false
 
+  /@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.1.14)(react@19.1.0):
+    resolution: {integrity: sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@types/react': 19.1.14
+      react: 19.1.0
+    dev: true
+
   /@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.1.2)(react@19.1.0):
     resolution: {integrity: sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==}
     peerDependencies:
@@ -5582,6 +5902,21 @@ packages:
       react: 19.1.0
     dev: false
 
+  /@radix-ui/react-use-controllable-state@1.2.2(@types/react@19.1.14)(react@19.1.0):
+    resolution: {integrity: sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.1.14)(react@19.1.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.14)(react@19.1.0)
+      '@types/react': 19.1.14
+      react: 19.1.0
+    dev: true
+
   /@radix-ui/react-use-controllable-state@1.2.2(@types/react@19.1.2)(react@19.1.0):
     resolution: {integrity: sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==}
     peerDependencies:
@@ -5596,6 +5931,20 @@ packages:
       '@types/react': 19.1.2
       react: 19.1.0
     dev: false
+
+  /@radix-ui/react-use-effect-event@0.0.2(@types/react@19.1.14)(react@19.1.0):
+    resolution: {integrity: sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.14)(react@19.1.0)
+      '@types/react': 19.1.14
+      react: 19.1.0
+    dev: true
 
   /@radix-ui/react-use-effect-event@0.0.2(@types/react@19.1.2)(react@19.1.0):
     resolution: {integrity: sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==}
@@ -5624,6 +5973,20 @@ packages:
       '@types/react': 19.1.2
       react: 19.1.0
     dev: false
+
+  /@radix-ui/react-use-escape-keydown@1.1.1(@types/react@19.1.14)(react@19.1.0):
+    resolution: {integrity: sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.14)(react@19.1.0)
+      '@types/react': 19.1.14
+      react: 19.1.0
+    dev: true
 
   /@radix-ui/react-use-escape-keydown@1.1.1(@types/react@19.1.2)(react@19.1.0):
     resolution: {integrity: sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==}
@@ -5666,6 +6029,19 @@ packages:
       react: 19.1.0
     dev: false
 
+  /@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.1.14)(react@19.1.0):
+    resolution: {integrity: sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@types/react': 19.1.14
+      react: 19.1.0
+    dev: true
+
   /@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.1.2)(react@19.1.0):
     resolution: {integrity: sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==}
     peerDependencies:
@@ -5706,6 +6082,20 @@ packages:
       react: 19.1.0
     dev: false
 
+  /@radix-ui/react-use-rect@1.1.1(@types/react@19.1.14)(react@19.1.0):
+    resolution: {integrity: sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@radix-ui/rect': 1.1.1
+      '@types/react': 19.1.14
+      react: 19.1.0
+    dev: true
+
   /@radix-ui/react-use-rect@1.1.1(@types/react@19.1.2)(react@19.1.0):
     resolution: {integrity: sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==}
     peerDependencies:
@@ -5733,6 +6123,20 @@ packages:
       '@types/react': 19.1.2
       react: 19.1.0
     dev: false
+
+  /@radix-ui/react-use-size@1.1.1(@types/react@19.1.14)(react@19.1.0):
+    resolution: {integrity: sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.14)(react@19.1.0)
+      '@types/react': 19.1.14
+      react: 19.1.0
+    dev: true
 
   /@radix-ui/react-use-size@1.1.1(@types/react@19.1.2)(react@19.1.0):
     resolution: {integrity: sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==}
@@ -5774,7 +6178,6 @@ packages:
 
   /@radix-ui/rect@1.1.1:
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
-    dev: false
 
   /@react-email/render@1.0.6(react-dom@19.1.0)(react@19.1.0):
     resolution: {integrity: sha512-zNueW5Wn/4jNC1c5LFgXzbUdv5Lhms+FWjOvWAhal7gx5YVf0q6dPJ0dnR70+ifo59gcMLwCZEaTS9EEuUhKvQ==}
@@ -5990,6 +6393,15 @@ packages:
       hast-util-to-html: 9.0.5
     dev: false
 
+  /@shikijs/core@3.13.0:
+    resolution: {integrity: sha512-3P8rGsg2Eh2qIHekwuQjzWhKI4jV97PhvYjYUzGqjvJfqdQPz+nMlfWahU24GZAyW1FxFI1sYjyhfh5CoLmIUA==}
+    dependencies:
+      '@shikijs/types': 3.13.0
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+      hast-util-to-html: 9.0.5
+    dev: true
+
   /@shikijs/core@3.3.0:
     resolution: {integrity: sha512-CovkFL2WVaHk6PCrwv6ctlmD4SS1qtIfN8yEyDXDYWh4ONvomdM9MaFw20qHuqJOcb8/xrkqoWQRJ//X10phOQ==}
     dependencies:
@@ -6007,6 +6419,14 @@ packages:
       oniguruma-to-es: 2.3.0
     dev: false
 
+  /@shikijs/engine-javascript@3.13.0:
+    resolution: {integrity: sha512-Ty7xv32XCp8u0eQt8rItpMs6rU9Ki6LJ1dQOW3V/56PKDcpvfHPnYFbsx5FFUP2Yim34m/UkazidamMNVR4vKg==}
+    dependencies:
+      '@shikijs/types': 3.13.0
+      '@shikijs/vscode-textmate': 10.0.2
+      oniguruma-to-es: 4.3.3
+    dev: true
+
   /@shikijs/engine-javascript@3.3.0:
     resolution: {integrity: sha512-XlhnFGv0glq7pfsoN0KyBCz9FJU678LZdQ2LqlIdAj6JKsg5xpYKay3DkazXWExp3DTJJK9rMOuGzU2911pg7Q==}
     dependencies:
@@ -6022,6 +6442,13 @@ packages:
       '@shikijs/vscode-textmate': 10.0.2
     dev: false
 
+  /@shikijs/engine-oniguruma@3.13.0:
+    resolution: {integrity: sha512-O42rBGr4UDSlhT2ZFMxqM7QzIU+IcpoTMzb3W7AlziI1ZF7R8eS2M0yt5Ry35nnnTX/LTLXFPUjRFCIW+Operg==}
+    dependencies:
+      '@shikijs/types': 3.13.0
+      '@shikijs/vscode-textmate': 10.0.2
+    dev: true
+
   /@shikijs/engine-oniguruma@3.3.0:
     resolution: {integrity: sha512-l0vIw+GxeNU7uGnsu6B+Crpeqf+WTQ2Va71cHb5ZYWEVEPdfYwY5kXwYqRJwHrxz9WH+pjSpXQz+TJgAsrkA5A==}
     dependencies:
@@ -6035,6 +6462,12 @@ packages:
       '@shikijs/types': 1.29.2
     dev: false
 
+  /@shikijs/langs@3.13.0:
+    resolution: {integrity: sha512-672c3WAETDYHwrRP0yLy3W1QYB89Hbpj+pO4KhxK6FzIrDI2FoEXNiNCut6BQmEApYLfuYfpgOZaqbY+E9b8wQ==}
+    dependencies:
+      '@shikijs/types': 3.13.0
+    dev: true
+
   /@shikijs/langs@3.3.0:
     resolution: {integrity: sha512-zt6Kf/7XpBQKSI9eqku+arLkAcDQ3NHJO6zFjiChI8w0Oz6Jjjay7pToottjQGjSDCFk++R85643WbyINcuL+g==}
     dependencies:
@@ -6047,11 +6480,37 @@ packages:
       '@shikijs/types': 1.29.2
     dev: false
 
+  /@shikijs/themes@3.13.0:
+    resolution: {integrity: sha512-Vxw1Nm1/Od8jyA7QuAenaV78BG2nSr3/gCGdBkLpfLscddCkzkL36Q5b67SrLLfvAJTOUzW39x4FHVCFriPVgg==}
+    dependencies:
+      '@shikijs/types': 3.13.0
+    dev: true
+
   /@shikijs/themes@3.3.0:
     resolution: {integrity: sha512-tXeCvLXBnqq34B0YZUEaAD1lD4lmN6TOHAhnHacj4Owh7Ptb/rf5XCDeROZt2rEOk5yuka3OOW2zLqClV7/SOg==}
     dependencies:
       '@shikijs/types': 3.3.0
     dev: false
+
+  /@shikijs/transformers@3.13.0:
+    resolution: {integrity: sha512-833lcuVzcRiG+fXvgslWsM2f4gHpjEgui1ipIknSizRuTgMkNZupiXE5/TVJ6eSYfhNBFhBZKkReKWO2GgYmqA==}
+    dependencies:
+      '@shikijs/core': 3.13.0
+      '@shikijs/types': 3.13.0
+    dev: true
+
+  /@shikijs/twoslash@3.13.0(typescript@5.8.3):
+    resolution: {integrity: sha512-OmNKNoZ8Hevt4VKQHfJL+hrsrqLSnW/Nz7RMutuBqXBCIYZWk80HnF9pcXEwRmy9MN0MGRmZCW2rDDP8K7Bxkw==}
+    peerDependencies:
+      typescript: '>=5.5.0'
+    dependencies:
+      '@shikijs/core': 3.13.0
+      '@shikijs/types': 3.13.0
+      twoslash: 0.3.4(typescript@5.8.3)
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
 
   /@shikijs/types@1.29.2:
     resolution: {integrity: sha512-VJjK0eIijTZf0QSTODEXCqinjBn0joAHQ+aPSBzrv4O2d/QSbsMw+ZeSRx03kV34Hy7NzUvV/7NqfYGRLrASmw==}
@@ -6059,6 +6518,13 @@ packages:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
     dev: false
+
+  /@shikijs/types@3.13.0:
+    resolution: {integrity: sha512-oM9P+NCFri/mmQ8LoFGVfVyemm5Hi27330zuOBp0annwJdKH1kOLndw3zCtAVDehPLg9fKqoEx3Ht/wNZxolfw==}
+    dependencies:
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+    dev: true
 
   /@shikijs/types@3.3.0:
     resolution: {integrity: sha512-KPCGnHG6k06QG/2pnYGbFtFvpVJmC3uIpXrAiPrawETifujPBv0Se2oUxm5qYgjCvGJS9InKvjytOdN+bGuX+Q==}
@@ -6069,7 +6535,6 @@ packages:
 
   /@shikijs/vscode-textmate@10.0.2:
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
-    dev: false
 
   /@sindresorhus/is@5.6.0:
     resolution: {integrity: sha512-TV7t8GKYaJWsn00tFDqBw8+Uqmr8A0fRU1tvTQhyZzGv0sJCGRQL3JGMI3ucuKo3XIZdUP+Lx7/gh2t3lewy7g==}
@@ -6917,7 +7382,7 @@ packages:
     resolution: {integrity: sha512-nty0tHUq2f1IKuFYsLM4CXLZGHdMn+X/IwEUIpeSOXt0QjMUbL0Em57iJUDzz+2MkWG83smIigNZ3fauGjqgdQ==}
     engines: {node: '>=8.3.0'}
     dependencies:
-      node-fetch: 2.6.7
+      node-fetch: 2.7.0
       tslib: 1.14.1
     transitivePeerDependencies:
       - encoding
@@ -7578,8 +8043,8 @@ packages:
       typescript: 5.8.3
     dev: false
 
-  /@tybys/wasm-util@0.10.0:
-    resolution: {integrity: sha512-VyyPYFlOMNylG45GoAe0xDoLwWuowvf92F9kySqzYh8vmYm7D2u4iUJKa1tOUpS70Ku13ASrOkS4ScXFsTaCNQ==}
+  /@tybys/wasm-util@0.10.1:
+    resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
     requiresBuild: true
     dependencies:
       tslib: 2.8.1
@@ -7693,12 +8158,6 @@ packages:
   /@types/estree@1.0.7:
     resolution: {integrity: sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==}
 
-  /@types/hast@2.3.10:
-    resolution: {integrity: sha512-McWspRw8xx8J9HurkVBfYj0xKoE25tOFlHGdx4MJ5xORQrMGZNqJhVQWaIbm6Oyla5kYOXtDiopzKRJzEOkwJw==}
-    dependencies:
-      '@types/unist': 2.0.11
-    dev: true
-
   /@types/hast@3.0.4:
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
     dependencies:
@@ -7788,10 +8247,6 @@ packages:
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
     dev: true
 
-  /@types/prismjs@1.26.5:
-    resolution: {integrity: sha512-AUZTa7hQ2KY5L7AmtSiqxlhWxb4ina0yd8hNbl4TWuqnv/pFP0nDMb3YrfSBf4hJVGLh2YEIBfKaBW/9UEl6IQ==}
-    dev: true
-
   /@types/react-dom@19.1.2(@types/react@19.1.2):
     resolution: {integrity: sha512-XGJkWF41Qq305SKWEILa1O8vzhb3aOo3ogBlSmiqNko/WmRb6QIaweuZCXjKygVDXpzXb5wyxKTSOsmkuqj+Qw==}
     peerDependencies:
@@ -7799,8 +8254,8 @@ packages:
     dependencies:
       '@types/react': 19.1.2
 
-  /@types/react@19.1.12:
-    resolution: {integrity: sha512-cMoR+FoAf/Jyq6+Df2/Z41jISvGZZ2eTlnsaJRptmZ76Caldwy1odD4xTr/gNV9VLj0AWgg/nmkevIyUfIIq5w==}
+  /@types/react@19.1.14:
+    resolution: {integrity: sha512-ukd93VGzaNPMAUPy0gRDSC57UuQbnH9Kussp7HBjM06YFi9uZTFhOvMSO2OKqXm1rSgzOE+pVx1k1PYHGwlc8Q==}
     dependencies:
       csstype: 3.1.3
     dev: true
@@ -8156,6 +8611,17 @@ packages:
       eslint-visitor-keys: 4.2.0
     dev: true
 
+  /@typescript/vfs@1.6.1(typescript@5.8.3):
+    resolution: {integrity: sha512-JwoxboBh7Oz1v38tPbkrZ62ZXNHAk9bJ7c9x0eI5zBfBnBYGhURdbnh7Z4smN/MV48Y5OCcZb58n972UtbazsA==}
+    peerDependencies:
+      typescript: '*'
+    dependencies:
+      debug: 4.4.0(supports-color@9.4.0)
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@ungap/structured-clone@1.3.0:
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
 
@@ -8458,8 +8924,20 @@ packages:
     dependencies:
       acorn: 8.14.1
 
+  /acorn-jsx@5.3.2(acorn@8.15.0):
+    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      acorn: 8.15.0
+
   /acorn@8.14.1:
     resolution: {integrity: sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  /acorn@8.15.0:
+    resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
 
@@ -8555,6 +9033,13 @@ packages:
       type-fest: 0.21.3
     dev: true
 
+  /ansi-escapes@7.1.1:
+    resolution: {integrity: sha512-Zhl0ErHcSRUaVfGUeUdDuLgpkEo8KIFjB4Y9uAc46ScOpdDiU1Dbyplh7qWJeJ/ZHpbyMSM26+X3BySgnIz40Q==}
+    engines: {node: '>=18'}
+    dependencies:
+      environment: 1.1.0
+    dev: true
+
   /ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
@@ -8600,7 +9085,6 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       tslib: 2.8.1
-    dev: false
 
   /aria-query@5.3.2:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
@@ -8612,7 +9096,6 @@ packages:
     dependencies:
       '@ark/schema': 0.49.0
       '@ark/util': 0.49.0
-    dev: false
 
   /array-buffer-byte-length@1.0.2:
     resolution: {integrity: sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==}
@@ -8744,6 +9227,11 @@ packages:
     engines: {node: '>=8.0.0'}
     dev: false
 
+  /auto-bind@5.0.1:
+    resolution: {integrity: sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dev: true
+
   /autoprefixer@10.4.21(postcss@8.5.3):
     resolution: {integrity: sha512-O+A6LWV5LDHSJD3LjHYoNi4VLsj/Whi7k6zG12xTYaU4cQ8oxQGckXNX8cRHK5yOZ/ppVHe0ZBXGzSV9jXdVbQ==}
     engines: {node: ^10 || ^12 || >=14}
@@ -8805,20 +9293,14 @@ packages:
     resolution: {integrity: sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==}
     dev: false
 
-  /bare-events@2.5.4:
-    resolution: {integrity: sha512-+gFfDkR8pj4/TrWCGUGWmJIkBwuxPS5F+a5yWjOHQt2hHvNZd5YLzadjmDUtFmMM4y429bnKLa8bYBMHcYdnQA==}
+  /bare-events@2.7.0:
+    resolution: {integrity: sha512-b3N5eTW1g7vXkw+0CXh/HazGTcO5KYuu/RCNaJbDMPI6LHDi+7qe8EmxKUVe1sUbY2KZOVZFyj62x0OEz9qyAA==}
     requiresBuild: true
     dev: true
     optional: true
 
-  /bare-events@2.6.1:
-    resolution: {integrity: sha512-AuTJkq9XmE6Vk0FJVNq5QxETrSA/vKHarWVBG5l/JbdCL1prJemiyJqUS0jrlXO0MftuPq4m3YVYhoNc5+aE/g==}
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /bare-fs@4.2.3:
-    resolution: {integrity: sha512-1aGs5pRVLToMQ79elP+7cc0u0s/wXAzfBv/7hDloT7WFggLqECCas5qqPky7WHCFdsBH5WDq6sD4fAoz5sJbtA==}
+  /bare-fs@4.4.4:
+    resolution: {integrity: sha512-Q8yxM1eLhJfuM7KXVP3zjhBvtMJCYRByoTT+wHXjpdMELv0xICFJX+1w4c7csa+WZEOsq4ItJ4RGwvzid6m/dw==}
     engines: {bare: '>=1.16.0'}
     requiresBuild: true
     peerDependencies:
@@ -8827,9 +9309,11 @@ packages:
       bare-buffer:
         optional: true
     dependencies:
-      bare-events: 2.5.4
+      bare-events: 2.7.0
       bare-path: 3.0.0
-      bare-stream: 2.6.5(bare-events@2.5.4)
+      bare-stream: 2.6.5(bare-events@2.7.0)
+      bare-url: 2.2.2
+      fast-fifo: 1.3.2
     dev: true
     optional: true
 
@@ -8848,7 +9332,7 @@ packages:
     dev: true
     optional: true
 
-  /bare-stream@2.6.5(bare-events@2.5.4):
+  /bare-stream@2.6.5(bare-events@2.7.0):
     resolution: {integrity: sha512-jSmxKJNJmHySi6hC42zlZnq00rga4jjxcgNZjY9N5WlOe/iOoGRtdwGsHzQv2RlH2KOYMwGUXhf2zXd32BA9RA==}
     requiresBuild: true
     peerDependencies:
@@ -8860,8 +9344,16 @@ packages:
       bare-events:
         optional: true
     dependencies:
-      bare-events: 2.5.4
+      bare-events: 2.7.0
       streamx: 2.22.0
+    dev: true
+    optional: true
+
+  /bare-url@2.2.2:
+    resolution: {integrity: sha512-g+ueNGKkrjMazDG3elZO1pNs3HY5+mMmOet1jtKyhOaCnkLzitxf26z7hoAEkDNgdNmnc1KIlt/dw6Po6xZMpA==}
+    requiresBuild: true
+    dependencies:
+      bare-path: 3.0.0
     dev: true
     optional: true
 
@@ -8898,14 +9390,6 @@ packages:
   /binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
-
-  /bl@5.1.0:
-    resolution: {integrity: sha512-tv1ZJHLfTDnXE6tMHv73YgSJaWR2AFuPwMntBe7XL/GBFHnT0CLnsHMogfk5+GzCDC5ZWarSCYaIGATZt9dNsQ==}
-    dependencies:
-      buffer: 6.0.3
-      inherits: 2.0.4
-      readable-stream: 3.6.2
-    dev: true
 
   /body-parser@1.20.3:
     resolution: {integrity: sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==}
@@ -8978,13 +9462,6 @@ packages:
 
   /buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
-    dependencies:
-      base64-js: 1.5.1
-      ieee754: 1.2.1
-    dev: true
-
-  /buffer@6.0.3:
-    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
@@ -9104,6 +9581,11 @@ packages:
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
     dev: true
 
+  /chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+    dev: true
+
   /change-case@5.4.4:
     resolution: {integrity: sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==}
     dev: true
@@ -9204,6 +9686,11 @@ packages:
       escape-string-regexp: 5.0.0
     dev: true
 
+  /cli-boxes@3.0.0:
+    resolution: {integrity: sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==}
+    engines: {node: '>=10'}
+    dev: true
+
   /cli-cursor@4.0.0:
     resolution: {integrity: sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -9214,6 +9701,14 @@ packages:
   /cli-spinners@2.9.2:
     resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
     engines: {node: '>=6'}
+    dev: true
+
+  /cli-truncate@4.0.0:
+    resolution: {integrity: sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==}
+    engines: {node: '>=18'}
+    dependencies:
+      slice-ansi: 5.0.0
+      string-width: 7.2.0
     dev: true
 
   /cli-width@4.1.0:
@@ -9232,11 +9727,6 @@ packages:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
-    dev: true
-
-  /clone@1.0.4:
-    resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
-    engines: {node: '>=0.8'}
     dev: true
 
   /clsx@2.1.1:
@@ -9266,6 +9756,13 @@ packages:
       - '@types/react-dom'
     dev: false
 
+  /code-excerpt@4.0.0:
+    resolution: {integrity: sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dependencies:
+      convert-to-spaces: 2.0.1
+    dev: true
+
   /collapse-white-space@2.1.0:
     resolution: {integrity: sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==}
 
@@ -9284,6 +9781,7 @@ packages:
     dependencies:
       color-name: 1.1.4
       simple-swizzle: 0.2.2
+    dev: true
 
   /color@4.2.3:
     resolution: {integrity: sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==}
@@ -9291,6 +9789,7 @@ packages:
     dependencies:
       color-convert: 2.0.1
       color-string: 1.9.1
+    dev: true
 
   /colorette@1.4.0:
     resolution: {integrity: sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==}
@@ -9362,6 +9861,11 @@ packages:
   /convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  /convert-to-spaces@2.0.1:
+    resolution: {integrity: sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dev: true
+
   /cookie-signature@1.0.6:
     resolution: {integrity: sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==}
     dev: true
@@ -9401,7 +9905,7 @@ packages:
       vary: 1.1.2
     dev: true
 
-  /cosmiconfig@9.0.0:
+  /cosmiconfig@9.0.0(typescript@5.8.3):
     resolution: {integrity: sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==}
     engines: {node: '>=14'}
     peerDependencies:
@@ -9414,6 +9918,7 @@ packages:
       import-fresh: 3.3.1
       js-yaml: 4.1.0
       parse-json: 5.2.0
+      typescript: 5.8.3
     dev: true
 
   /crelt@1.0.6:
@@ -9646,12 +10151,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
-  /defaults@1.0.4:
-    resolution: {integrity: sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==}
-    dependencies:
-      clone: 1.0.4
-    dev: true
-
   /defer-to-connect@2.0.1:
     resolution: {integrity: sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==}
     engines: {node: '>=10'}
@@ -9735,6 +10234,13 @@ packages:
   /detect-libc@2.0.4:
     resolution: {integrity: sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==}
     engines: {node: '>=8'}
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /detect-libc@2.1.1:
+    resolution: {integrity: sha512-ecqj/sy1jcK1uWrwpR67UhYrIFQ+5WlGxth34WquCbamhFA6hkkwiu37o6J5xCHdo1oixJRfVRw+ywV+Hq/0Aw==}
+    engines: {node: '>=8'}
 
   /detect-newline@4.0.1:
     resolution: {integrity: sha512-qE3Veg1YXzGHQhlA6jzebZN2qVf6NX+A7m7qlhCGG30dJixrAQhYOsJjsnBjJkCSmuOPpCk30145fr8FV0bzog==}
@@ -9743,7 +10249,6 @@ packages:
 
   /detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
-    dev: false
 
   /detect-port@1.6.1:
     resolution: {integrity: sha512-CmnVc+Hek2egPx1PeTFVta2W78xy2K/9Rkf6cC4T59S50tVnzKj+tnx5mmx5lwvCkujZ4uRrpRSuV+IVs3f90Q==}
@@ -9918,6 +10423,10 @@ packages:
     resolution: {integrity: sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==}
     dev: false
 
+  /emoji-regex@10.5.0:
+    resolution: {integrity: sha512-lb49vf1Xzfx080OKA0o6l8DQQpV+6Vg95zyCJX9VB/BqKYlhG7N4wgROUUHRA+ZPUefLnteQOad7z1kT2bV7bg==}
+    dev: true
+
   /emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
@@ -9980,6 +10489,11 @@ packages:
   /env-paths@2.2.1:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
     engines: {node: '>=6'}
+    dev: true
+
+  /environment@1.1.0:
+    resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
+    engines: {node: '>=18'}
     dev: true
 
   /error-ex@1.3.2:
@@ -10120,6 +10634,10 @@ packages:
       is-symbol: 1.1.1
     dev: true
 
+  /es-toolkit@1.39.10:
+    resolution: {integrity: sha512-E0iGnTtbDhkeczB0T+mxmoVlT4YNweEKBLq7oaU4p11mecdsZpNWOglI4895Vh4usbQ+LsJiuLuI2L0Vdmfm2w==}
+    dev: true
+
   /esast-util-from-estree@2.0.0:
     resolution: {integrity: sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ==}
     dependencies:
@@ -10256,6 +10774,11 @@ packages:
     engines: {node: '>=0.8.0'}
     dev: true
 
+  /escape-string-regexp@2.0.0:
+    resolution: {integrity: sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==}
+    engines: {node: '>=8'}
+    dev: true
+
   /escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
@@ -10322,15 +10845,15 @@ packages:
       eslint: 8.57.1
     dev: true
 
-  /eslint-config-turbo@2.5.2(eslint@8.57.1)(turbo@2.5.6):
+  /eslint-config-turbo@2.5.2(eslint@8.57.1)(turbo@2.5.8):
     resolution: {integrity: sha512-aZdMUCJE5sC9UHZPOu6GiqCijw0HzlcxTbGZeESMFanYShhxrO6mAZy02zYOYK+y184HnxAngcfmtgDt8cIUxw==}
     peerDependencies:
       eslint: '>6.6.0'
       turbo: '>2.0.0'
     dependencies:
       eslint: 8.57.1
-      eslint-plugin-turbo: 2.5.2(eslint@8.57.1)(turbo@2.5.6)
-      turbo: 2.5.6
+      eslint-plugin-turbo: 2.5.2(eslint@8.57.1)(turbo@2.5.8)
+      turbo: 2.5.8
     dev: true
 
   /eslint-import-resolver-alias@1.1.2(eslint-plugin-import@2.31.0):
@@ -10586,7 +11109,7 @@ packages:
       '@microsoft/tsdoc-config': 0.16.2
     dev: true
 
-  /eslint-plugin-turbo@2.5.2(eslint@8.57.1)(turbo@2.5.6):
+  /eslint-plugin-turbo@2.5.2(eslint@8.57.1)(turbo@2.5.8):
     resolution: {integrity: sha512-B+vdgOtBuDbRI3sIRayV3HZK1XcwlNuksmJJIgggkXTsNehMEbreJBkIda4qvA/STHnGAl2bUGev0Jx8Rijiwg==}
     peerDependencies:
       eslint: '>6.6.0'
@@ -10594,7 +11117,7 @@ packages:
     dependencies:
       dotenv: 16.0.3
       eslint: 8.57.1
-      turbo: 2.5.6
+      turbo: 2.5.8
     dev: true
 
   /eslint-plugin-unicorn@51.0.1(eslint@8.57.1):
@@ -11225,6 +11748,11 @@ packages:
     engines: {node: 6.* || 8.* || >= 10.*}
     dev: true
 
+  /get-east-asian-width@1.4.0:
+    resolution: {integrity: sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==}
+    engines: {node: '>=18'}
+    dev: true
+
   /get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
@@ -11243,7 +11771,6 @@ packages:
   /get-nonce@1.0.1:
     resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
     engines: {node: '>=6'}
-    dev: false
 
   /get-proto@1.0.1:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
@@ -11579,12 +12106,6 @@ packages:
       hast-util-whitespace: 3.0.0
       unist-util-is: 6.0.0
 
-  /hast-util-parse-selector@3.1.1:
-    resolution: {integrity: sha512-jdlwBjEexy1oGz0aJ2f4GKMaVKkA9jwjr4MjAAI22E5fM/TXVZHuS5OpONtdeIkRKqAaryQ2E9xNQxijoThSZA==}
-    dependencies:
-      '@types/hast': 2.3.10
-    dev: true
-
   /hast-util-parse-selector@4.0.0:
     resolution: {integrity: sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==}
     dependencies:
@@ -11715,16 +12236,6 @@ packages:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
     dependencies:
       '@types/hast': 3.0.4
-
-  /hastscript@7.2.0:
-    resolution: {integrity: sha512-TtYPq24IldU8iKoJQqvZOuhi5CyCQRAbvDOX0x1eW6rsHSxa/1i2CCiptNTotGHJ3VoHRGmqiv6/D3q113ikkw==}
-    dependencies:
-      '@types/hast': 2.3.10
-      comma-separated-tokens: 2.0.3
-      hast-util-parse-selector: 3.1.1
-      property-information: 6.5.0
-      space-separated-tokens: 2.0.2
-    dev: true
 
   /hastscript@9.0.1:
     resolution: {integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==}
@@ -11906,6 +12417,61 @@ packages:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
     dev: false
 
+  /ink-spinner@5.0.0(ink@6.3.1)(react@19.1.0):
+    resolution: {integrity: sha512-EYEasbEjkqLGyPOUc8hBJZNuC5GvXGMLu0w5gdTNskPc7Izc5vO3tdQEYnzvshucyGCBXc86ig0ujXPMWaQCdA==}
+    engines: {node: '>=14.16'}
+    peerDependencies:
+      ink: '>=4.0.0'
+      react: '>=18.0.0'
+    dependencies:
+      cli-spinners: 2.9.2
+      ink: 6.3.1(@types/react@19.1.14)(react@19.1.0)
+      react: 19.1.0
+    dev: true
+
+  /ink@6.3.1(@types/react@19.1.14)(react@19.1.0):
+    resolution: {integrity: sha512-3wGwITGrzL6rkWsi2gEKzgwdafGn4ZYd3u4oRp+sOPvfoxEHlnoB5Vnk9Uy5dMRUhDOqF3hqr4rLQ4lEzBc2sQ==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@types/react': '>=19.0.0'
+      react: '>=19.0.0'
+      react-devtools-core: ^6.1.2
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      react-devtools-core:
+        optional: true
+    dependencies:
+      '@alcalzone/ansi-tokenize': 0.2.0
+      '@types/react': 19.1.14
+      ansi-escapes: 7.1.1
+      ansi-styles: 6.2.1
+      auto-bind: 5.0.1
+      chalk: 5.6.2
+      cli-boxes: 3.0.0
+      cli-cursor: 4.0.0
+      cli-truncate: 4.0.0
+      code-excerpt: 4.0.0
+      es-toolkit: 1.39.10
+      indent-string: 5.0.0
+      is-in-ci: 2.0.0
+      patch-console: 2.0.0
+      react: 19.1.0
+      react-reconciler: 0.32.0(react@19.1.0)
+      signal-exit: 3.0.7
+      slice-ansi: 7.1.2
+      stack-utils: 2.0.6
+      string-width: 7.2.0
+      type-fest: 4.40.1
+      widest-line: 5.0.0
+      wrap-ansi: 9.0.2
+      ws: 8.18.1
+      yoga-layout: 3.2.1
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+    dev: true
+
   /inline-style-parser@0.2.4:
     resolution: {integrity: sha512-0aO8FkhNZlj/ZIbNi7Lxxr12obT7cL1moPfE4tg1LkX7LlLfC6DeX4l2ZEud1ukP9jNQyNnfzQVqwbwmAATY4Q==}
 
@@ -11990,11 +12556,6 @@ packages:
     resolution: {integrity: sha512-Bm6H79i01DjgGTCWjUuCjJ6QDo1HB96PT/xCYuyJUP9WFbVDrLSbG4EZCvOCun2rNswZb0c3e4Jt/ws795esHA==}
     dev: false
 
-  /is-absolute-url@4.0.1:
-    resolution: {integrity: sha512-/51/TKE88Lmm7Gc4/8btclNXWS+g50wXhYJq8HWIBAGUBnoAdRu1aXeh364t/O7wXDAcTJDP8PNuNKWUDWie+A==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-    dev: true
-
   /is-alphabetical@2.0.1:
     resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
 
@@ -12020,6 +12581,7 @@ packages:
   /is-arrayish@0.3.2:
     resolution: {integrity: sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==}
     requiresBuild: true
+    dev: true
 
   /is-async-function@2.1.1:
     resolution: {integrity: sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==}
@@ -12126,6 +12688,18 @@ packages:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
 
+  /is-fullwidth-code-point@4.0.0:
+    resolution: {integrity: sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==}
+    engines: {node: '>=12'}
+    dev: true
+
+  /is-fullwidth-code-point@5.1.0:
+    resolution: {integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==}
+    engines: {node: '>=18'}
+    dependencies:
+      get-east-asian-width: 1.4.0
+    dev: true
+
   /is-generator-function@1.1.0:
     resolution: {integrity: sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ==}
     engines: {node: '>= 0.4'}
@@ -12145,9 +12719,10 @@ packages:
   /is-hexadecimal@2.0.1:
     resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
 
-  /is-interactive@2.0.0:
-    resolution: {integrity: sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==}
-    engines: {node: '>=12'}
+  /is-in-ci@2.0.0:
+    resolution: {integrity: sha512-cFeerHriAnhrQSbpAxL37W1wcJKUUX07HyLWZCW1URJT/ra3GyUTzBgUnh24TMVfNTV2Hij2HLxkPHFZfOZy5w==}
+    engines: {node: '>=20'}
+    hasBin: true
     dev: true
 
   /is-ip@3.1.0:
@@ -12240,11 +12815,6 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       which-typed-array: 1.1.19
-    dev: true
-
-  /is-unicode-supported@1.3.0:
-    resolution: {integrity: sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==}
-    engines: {node: '>=12'}
     dev: true
 
   /is-weakmap@2.0.2:
@@ -12682,14 +13252,6 @@ packages:
 
   /lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
-
-  /log-symbols@5.1.0:
-    resolution: {integrity: sha512-l0x2DvrW294C9uDCoQe1VSU4gf529FkSZ6leBl4TiqZH/e+0R7hSfHQBNut2mNygDgHwvYHfFLn6Oxb3VWj2rA==}
-    engines: {node: '>=12'}
-    dependencies:
-      chalk: 5.4.1
-      is-unicode-supported: 1.3.0
-    dev: true
 
   /loglevelnext@6.0.0:
     resolution: {integrity: sha512-FDl1AI2sJGjHHG3XKJd6sG3/6ncgiGCQ0YkW46nxe7SfqQq6hujd9CvFXIXtkGBUN83KPZ2KSOJK8q5P0bSSRQ==}
@@ -13485,22 +14047,24 @@ packages:
       yallist: 4.0.0
     dev: true
 
-  /mintlify@4.0.510(@types/react@19.1.12)(react-dom@18.3.1)(react@18.3.1):
-    resolution: {integrity: sha512-0V7ijaTjaFAOG93V8SMx9+LuD5dMGyzaOWUABi7gGNy2SW7WVLb+QcBNY6XgWr6G4A1J9Y4sZC44mMOPPNxrow==}
+  /mintlify@4.2.128(@radix-ui/react-popover@1.1.15)(@types/react@19.1.14)(react-dom@18.3.1)(typescript@5.8.3):
+    resolution: {integrity: sha512-jkx7HXg6uyAM9VfSXykKRvUwrRRTR7JcQ82y1rJkOOnDysCRgsY3eriglCyNxFBvetD6y5ipfDKzciqWmU0szw==}
     engines: {node: '>=18.0.0'}
     hasBin: true
     dependencies:
-      '@mintlify/cli': 4.0.509(@types/react@19.1.12)(react-dom@18.3.1)(react@18.3.1)
+      '@mintlify/cli': 4.0.732(@radix-ui/react-popover@1.1.15)(@types/react@19.1.14)(react-dom@18.3.1)(typescript@5.8.3)
     transitivePeerDependencies:
+      - '@radix-ui/react-popover'
       - '@types/node'
       - '@types/react'
       - bare-buffer
       - bufferutil
       - debug
       - encoding
-      - react
+      - react-devtools-core
       - react-dom
       - supports-color
+      - ts-node
       - typescript
       - utf-8-validate
     dev: true
@@ -13635,7 +14199,7 @@ packages:
       uuid: 8.3.2
     dev: false
 
-  /next-mdx-remote-client@1.1.0(@types/react@19.1.12)(acorn@8.14.1)(react-dom@18.3.1)(react@18.3.1):
+  /next-mdx-remote-client@1.1.0(@types/react@19.1.14)(acorn@8.15.0)(react-dom@18.3.1)(react@19.1.0):
     resolution: {integrity: sha512-RuKP5Xe/cdgpeQOw1OqY6/t29DgjPQxvSUXpjr5OXB6gZpCnXrrruT6c+OwF2sskOA2jGjUbxVoavrB8CbGmQQ==}
     engines: {node: '>=18.18.0'}
     peerDependencies:
@@ -13643,10 +14207,10 @@ packages:
       react-dom: '>= 18.3.0 < 19.0.0'
     dependencies:
       '@babel/code-frame': 7.26.2
-      '@mdx-js/mdx': 3.1.0(acorn@8.14.1)
-      '@mdx-js/react': 3.1.0(@types/react@19.1.12)(react@18.3.1)
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
+      '@mdx-js/mdx': 3.1.0(acorn@8.15.0)
+      '@mdx-js/react': 3.1.1(@types/react@19.1.14)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 18.3.1(react@19.1.0)
       remark-mdx-remove-esm: 1.1.0
       serialize-error: 12.0.0
       vfile: 6.0.3
@@ -13706,7 +14270,7 @@ packages:
       '@next/swc-linux-x64-musl': 15.3.1
       '@next/swc-win32-arm64-msvc': 15.3.1
       '@next/swc-win32-x64-msvc': 15.3.1
-      sharp: 0.34.3
+      sharp: 0.34.4
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
@@ -13944,6 +14508,10 @@ packages:
     resolution: {integrity: sha512-fD9o5ebCmEAA9dLysajdQvuKzLL7cj+w7DQjuO3Cb6IwafENfx6iL+RGkmyW82pVRsvgzixsWinHvgxTMJvdIA==}
     dev: false
 
+  /oniguruma-parser@0.12.1:
+    resolution: {integrity: sha512-8Unqkvk1RYc6yq2WBYRj4hdnsAxVze8i7iPfQr8e4uSP3tRv0rpZcbGUDvxfQQcdwHt/e9PrMvGCsa8OqG9X3w==}
+    dev: true
+
   /oniguruma-to-es@2.3.0:
     resolution: {integrity: sha512-bwALDxriqfKGfUufKGGepCzu9x7nJQuoRoAFp4AnwehhC2crqrDIAP/uN2qdlsAvSMpeRC3+Yzhqc7hLmle5+g==}
     dependencies:
@@ -13959,6 +14527,14 @@ packages:
       regex: 6.0.1
       regex-recursion: 6.0.2
     dev: false
+
+  /oniguruma-to-es@4.3.3:
+    resolution: {integrity: sha512-rPiZhzC3wXwE59YQMRDodUwwT9FZ9nNBwQQfsd1wfdtlKEyCdRV0avrTcSZ5xlIvGRVPd/cx6ZN45ECmS39xvg==}
+    dependencies:
+      oniguruma-parser: 0.12.1
+      regex: 6.0.1
+      regex-recursion: 6.0.2
+    dev: true
 
   /open@8.4.2:
     resolution: {integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==}
@@ -14013,21 +14589,6 @@ packages:
       prelude-ls: 1.2.1
       type-check: 0.4.0
       word-wrap: 1.2.5
-
-  /ora@6.3.1:
-    resolution: {integrity: sha512-ERAyNnZOfqM+Ao3RAvIXkYh5joP220yf59gVe2X/cI6SiCxIdi4c9HZKZD8R6q/RDXEje1THBju6iExiSsgJaQ==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-    dependencies:
-      chalk: 5.4.1
-      cli-cursor: 4.0.0
-      cli-spinners: 2.9.2
-      is-interactive: 2.0.0
-      is-unicode-supported: 1.3.0
-      log-symbols: 5.1.0
-      stdin-discarder: 0.1.0
-      strip-ansi: 7.1.0
-      wcwidth: 1.0.1
-    dev: true
 
   /orderedmap@2.1.1:
     resolution: {integrity: sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==}
@@ -14212,6 +14773,11 @@ packages:
   /parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
+    dev: true
+
+  /patch-console@2.0.0:
+    resolution: {integrity: sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dev: true
 
   /path-exists@4.0.0:
@@ -14455,6 +15021,15 @@ packages:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  /postcss@8.5.6:
+    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
+    engines: {node: ^10 || ^12 || >=14}
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+    dev: true
+
   /preact-render-to-string@5.2.6(preact@10.26.5):
     resolution: {integrity: sha512-JyhErpYOvBV1hEPwIxc/fHWXPfnEGdRKxc8gFdAZ7XV4tlzyzG847XAyEZqoDnynP88akM4eaHcSOzNcLWFguw==}
     peerDependencies:
@@ -14613,10 +15188,6 @@ packages:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
-
-  /property-information@6.5.0:
-    resolution: {integrity: sha512-PgTgs/BlvHxOu8QuEN7wi5A0OmXaBcHpmCSTehcs6Uuu9IkDIEo13Hy7n898RHfrQ49vKCoGeWZSaAK01nwVig==}
-    dev: true
 
   /property-information@7.0.0:
     resolution: {integrity: sha512-7D/qOz/+Y4X/rzSB6jKxKUsQnphO046ei8qxG59mtM3RG3DHgTK81HrxrmoDVINJb8NKT5ZsRbwHvQ6B68Iyhg==}
@@ -14839,14 +15410,15 @@ packages:
       - utf-8-validate
     dev: true
 
-  /puppeteer@22.15.0:
+  /puppeteer@22.15.0(typescript@5.8.3):
     resolution: {integrity: sha512-XjCY1SiSEi1T7iSYuxS82ft85kwDJUS7wj1Z0eGVXKdtr5g4xnVcbjwxhq5xBnpK/E7x1VZZoJDxpjAOasHT4Q==}
     engines: {node: '>=18'}
+    deprecated: < 24.10.2 is no longer supported
     hasBin: true
     requiresBuild: true
     dependencies:
       '@puppeteer/browsers': 2.3.0
-      cosmiconfig: 9.0.0
+      cosmiconfig: 9.0.0(typescript@5.8.3)
       devtools-protocol: 0.0.1312386
       puppeteer-core: 22.15.0
     transitivePeerDependencies:
@@ -14917,13 +15489,13 @@ packages:
       react-dom: 19.1.0(react@19.1.0)
     dev: false
 
-  /react-dom@18.3.1(react@18.3.1):
+  /react-dom@18.3.1(react@19.1.0):
     resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
     peerDependencies:
       react: ^18.3.1
     dependencies:
       loose-envify: 1.4.0
-      react: 18.3.1
+      react: 19.1.0
       scheduler: 0.23.2
     dev: true
 
@@ -14958,10 +15530,36 @@ packages:
       fast-deep-equal: 2.0.1
     dev: false
 
+  /react-reconciler@0.32.0(react@19.1.0):
+    resolution: {integrity: sha512-2NPMOzgTlG0ZWdIf3qG+dcbLSoAc/uLfOwckc3ofy5sSK0pLJqnQLpUFxvGcN2rlXSjnVtGeeFLNimCQEj5gOQ==}
+    engines: {node: '>=0.10.0'}
+    peerDependencies:
+      react: ^19.1.0
+    dependencies:
+      react: 19.1.0
+      scheduler: 0.26.0
+    dev: true
+
   /react-refresh@0.17.0:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
     engines: {node: '>=0.10.0'}
     dev: false
+
+  /react-remove-scroll-bar@2.3.8(@types/react@19.1.14)(react@19.1.0):
+    resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@types/react': 19.1.14
+      react: 19.1.0
+      react-style-singleton: 2.2.3(@types/react@19.1.14)(react@19.1.0)
+      tslib: 2.8.1
+    dev: true
 
   /react-remove-scroll-bar@2.3.8(@types/react@19.1.2)(react@19.1.0):
     resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
@@ -14997,6 +15595,25 @@ packages:
       use-callback-ref: 1.3.3(@types/react@19.1.2)(react@19.1.0)
       use-sidecar: 1.1.3(@types/react@19.1.2)(react@19.1.0)
     dev: false
+
+  /react-remove-scroll@2.6.3(@types/react@19.1.14)(react@19.1.0):
+    resolution: {integrity: sha512-pnAi91oOk8g8ABQKGF5/M9qxmmOPxaAnopyTHYfqYEwJhyFrbbBtHuSgtKEoH0jpcxx5o3hXqH1mNd9/Oi+8iQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@types/react': 19.1.14
+      react: 19.1.0
+      react-remove-scroll-bar: 2.3.8(@types/react@19.1.14)(react@19.1.0)
+      react-style-singleton: 2.2.3(@types/react@19.1.14)(react@19.1.0)
+      tslib: 2.8.1
+      use-callback-ref: 1.3.3(@types/react@19.1.14)(react@19.1.0)
+      use-sidecar: 1.1.3(@types/react@19.1.14)(react@19.1.0)
+    dev: true
 
   /react-remove-scroll@2.6.3(@types/react@19.1.2)(react@19.1.0):
     resolution: {integrity: sha512-pnAi91oOk8g8ABQKGF5/M9qxmmOPxaAnopyTHYfqYEwJhyFrbbBtHuSgtKEoH0jpcxx5o3hXqH1mNd9/Oi+8iQ==}
@@ -15060,6 +15677,22 @@ packages:
       react-transition-group: 4.4.5(react-dom@19.1.0)(react@19.1.0)
     dev: false
 
+  /react-style-singleton@2.2.3(@types/react@19.1.14)(react@19.1.0):
+    resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@types/react': 19.1.14
+      get-nonce: 1.0.1
+      react: 19.1.0
+      tslib: 2.8.1
+    dev: true
+
   /react-style-singleton@2.2.3(@types/react@19.1.2)(react@19.1.0):
     resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
     engines: {node: '>=10'}
@@ -15090,13 +15723,6 @@ packages:
       react-dom: 19.1.0(react@19.1.0)
     dev: false
 
-  /react@18.3.1:
-    resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      loose-envify: 1.4.0
-    dev: true
-
   /react@19.1.0:
     resolution: {integrity: sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==}
     engines: {node: '>=0.10.0'}
@@ -15123,15 +15749,6 @@ packages:
       normalize-package-data: 2.5.0
       parse-json: 5.2.0
       type-fest: 0.6.0
-    dev: true
-
-  /readable-stream@3.6.2:
-    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
-    engines: {node: '>= 6'}
-    dependencies:
-      inherits: 2.0.4
-      string_decoder: 1.3.0
-      util-deprecate: 1.0.2
     dev: true
 
   /readdirp@3.6.0:
@@ -15182,10 +15799,10 @@ packages:
       estree-util-build-jsx: 3.0.1
       vfile: 6.0.3
 
-  /recma-jsx@1.0.0(acorn@8.14.1):
+  /recma-jsx@1.0.0(acorn@8.15.0):
     resolution: {integrity: sha512-5vwkv65qWwYxg+Atz95acp8DMu1JDSqdGkA2Of1j6rCreyFUE/gp15fC8MnGEuG1W68UKjM6x6+YTWIh7hZM/Q==}
     dependencies:
-      acorn-jsx: 5.3.2(acorn@8.14.1)
+      acorn-jsx: 5.3.2(acorn@8.15.0)
       estree-util-to-js: 2.0.0
       recma-parse: 1.0.0
       recma-stringify: 1.0.0
@@ -15235,15 +15852,6 @@ packages:
       which-builtin-type: 1.2.1
     dev: true
 
-  /refractor@4.9.0:
-    resolution: {integrity: sha512-nEG1SPXFoGGx+dcjftjv8cAjEusIh6ED1xhf5DG3C0x/k+rmZ2duKnc3QLpt6qeHv5fPb8uwN3VWN2BT7fr3Og==}
-    dependencies:
-      '@types/hast': 2.3.10
-      '@types/prismjs': 1.26.5
-      hastscript: 7.2.0
-      parse-entities: 4.0.2
-    dev: true
-
   /regenerator-runtime@0.14.1:
     resolution: {integrity: sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==}
     dev: false
@@ -15259,11 +15867,9 @@ packages:
     resolution: {integrity: sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==}
     dependencies:
       regex-utilities: 2.3.0
-    dev: false
 
   /regex-utilities@2.3.0:
     resolution: {integrity: sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==}
-    dev: false
 
   /regex@5.1.1:
     resolution: {integrity: sha512-dN5I359AVGPnwzJm2jN1k0W9LPZ+ePvoOeVMMfqIMFz53sSwXkxaJoxr50ptnsC771lK95BnTrVSZxq0b9yCGw==}
@@ -15275,7 +15881,6 @@ packages:
     resolution: {integrity: sha512-uorlqlzAKjKQZ5P+kTJr3eeJGSVroLKoHmquUj4zHWuR+hEyNqlXsSKlYYF5F4NI6nl7tWCs0apKJ0lmfsXAPA==}
     dependencies:
       regex-utilities: 2.3.0
-    dev: false
 
   /regexp-tree@0.1.27:
     resolution: {integrity: sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==}
@@ -15806,7 +16411,6 @@ packages:
 
   /scheduler@0.26.0:
     resolution: {integrity: sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==}
-    dev: false
 
   /section-matter@1.0.0:
     resolution: {integrity: sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==}
@@ -15934,7 +16538,7 @@ packages:
     requiresBuild: true
     dependencies:
       color: 4.2.3
-      detect-libc: 2.0.4
+      detect-libc: 2.1.1
       semver: 7.7.2
     optionalDependencies:
       '@img/sharp-darwin-arm64': 0.33.5
@@ -15958,37 +16562,37 @@ packages:
       '@img/sharp-win32-x64': 0.33.5
     dev: true
 
-  /sharp@0.34.3:
-    resolution: {integrity: sha512-eX2IQ6nFohW4DbvHIOLRB3MHFpYqaqvXd3Tp5e/T/dSH83fxaNJQRvDMhASmkNTsNTVF2/OOopzRCt7xokgPfg==}
+  /sharp@0.34.4:
+    resolution: {integrity: sha512-FUH39xp3SBPnxWvd5iib1X8XY7J0K0X7d93sie9CJg2PO8/7gmg89Nve6OjItK53/MlAushNNxteBYfM6DEuoA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     requiresBuild: true
     dependencies:
-      color: 4.2.3
-      detect-libc: 2.0.4
+      '@img/colour': 1.0.0
+      detect-libc: 2.1.1
       semver: 7.7.2
     optionalDependencies:
-      '@img/sharp-darwin-arm64': 0.34.3
-      '@img/sharp-darwin-x64': 0.34.3
-      '@img/sharp-libvips-darwin-arm64': 1.2.0
-      '@img/sharp-libvips-darwin-x64': 1.2.0
-      '@img/sharp-libvips-linux-arm': 1.2.0
-      '@img/sharp-libvips-linux-arm64': 1.2.0
-      '@img/sharp-libvips-linux-ppc64': 1.2.0
-      '@img/sharp-libvips-linux-s390x': 1.2.0
-      '@img/sharp-libvips-linux-x64': 1.2.0
-      '@img/sharp-libvips-linuxmusl-arm64': 1.2.0
-      '@img/sharp-libvips-linuxmusl-x64': 1.2.0
-      '@img/sharp-linux-arm': 0.34.3
-      '@img/sharp-linux-arm64': 0.34.3
-      '@img/sharp-linux-ppc64': 0.34.3
-      '@img/sharp-linux-s390x': 0.34.3
-      '@img/sharp-linux-x64': 0.34.3
-      '@img/sharp-linuxmusl-arm64': 0.34.3
-      '@img/sharp-linuxmusl-x64': 0.34.3
-      '@img/sharp-wasm32': 0.34.3
-      '@img/sharp-win32-arm64': 0.34.3
-      '@img/sharp-win32-ia32': 0.34.3
-      '@img/sharp-win32-x64': 0.34.3
+      '@img/sharp-darwin-arm64': 0.34.4
+      '@img/sharp-darwin-x64': 0.34.4
+      '@img/sharp-libvips-darwin-arm64': 1.2.3
+      '@img/sharp-libvips-darwin-x64': 1.2.3
+      '@img/sharp-libvips-linux-arm': 1.2.3
+      '@img/sharp-libvips-linux-arm64': 1.2.3
+      '@img/sharp-libvips-linux-ppc64': 1.2.3
+      '@img/sharp-libvips-linux-s390x': 1.2.3
+      '@img/sharp-libvips-linux-x64': 1.2.3
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.3
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.3
+      '@img/sharp-linux-arm': 0.34.4
+      '@img/sharp-linux-arm64': 0.34.4
+      '@img/sharp-linux-ppc64': 0.34.4
+      '@img/sharp-linux-s390x': 0.34.4
+      '@img/sharp-linux-x64': 0.34.4
+      '@img/sharp-linuxmusl-arm64': 0.34.4
+      '@img/sharp-linuxmusl-x64': 0.34.4
+      '@img/sharp-wasm32': 0.34.4
+      '@img/sharp-win32-arm64': 0.34.4
+      '@img/sharp-win32-ia32': 0.34.4
+      '@img/sharp-win32-x64': 0.34.4
     dev: false
     optional: true
 
@@ -16014,6 +16618,19 @@ packages:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
     dev: false
+
+  /shiki@3.13.0:
+    resolution: {integrity: sha512-aZW4l8Og16CokuCLf8CF8kq+KK2yOygapU5m3+hoGw0Mdosc6fPitjM+ujYarppj5ZIKGyPDPP1vqmQhr+5/0g==}
+    dependencies:
+      '@shikijs/core': 3.13.0
+      '@shikijs/engine-javascript': 3.13.0
+      '@shikijs/engine-oniguruma': 3.13.0
+      '@shikijs/langs': 3.13.0
+      '@shikijs/themes': 3.13.0
+      '@shikijs/types': 3.13.0
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+    dev: true
 
   /shiki@3.3.0:
     resolution: {integrity: sha512-j0Z1tG5vlOFGW8JVj0Cpuatzvshes7VJy5ncDmmMaYcmnGW0Js1N81TOW98ivTFNZfKRn9uwEg/aIm638o368g==}
@@ -16084,6 +16701,7 @@ packages:
     requiresBuild: true
     dependencies:
       is-arrayish: 0.3.2
+    dev: true
 
   /slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
@@ -16094,6 +16712,22 @@ packages:
     resolution: {integrity: sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==}
     engines: {node: '>=14.16'}
     dev: false
+
+  /slice-ansi@5.0.0:
+    resolution: {integrity: sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      ansi-styles: 6.2.1
+      is-fullwidth-code-point: 4.0.0
+    dev: true
+
+  /slice-ansi@7.1.2:
+    resolution: {integrity: sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==}
+    engines: {node: '>=18'}
+    dependencies:
+      ansi-styles: 6.2.1
+      is-fullwidth-code-point: 5.1.0
+    dev: true
 
   /smart-buffer@4.2.0:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
@@ -16274,6 +16908,13 @@ packages:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
     dev: true
 
+  /stack-utils@2.0.6:
+    resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
+    engines: {node: '>=10'}
+    dependencies:
+      escape-string-regexp: 2.0.0
+    dev: true
+
   /standard-as-callback@2.1.0:
     resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
     dev: false
@@ -16287,13 +16928,6 @@ packages:
     resolution: {integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==}
     dev: false
 
-  /stdin-discarder@0.1.0:
-    resolution: {integrity: sha512-xhV7w8S+bUwlPTb4bAOUQhv8/cSS5offJuX8GQGq32ONF0ZtDWKfkdomM3HMRA+LhX6um/FZ0COqlwsjD53LeQ==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-    dependencies:
-      bl: 5.1.0
-    dev: true
-
   /streamsearch@1.1.0:
     resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
     engines: {node: '>=10.0.0'}
@@ -16305,7 +16939,7 @@ packages:
       fast-fifo: 1.3.2
       text-decoder: 1.2.3
     optionalDependencies:
-      bare-events: 2.6.1
+      bare-events: 2.7.0
     dev: true
 
   /string-width@4.2.3:
@@ -16323,6 +16957,15 @@ packages:
       eastasianwidth: 0.2.0
       emoji-regex: 9.2.2
       strip-ansi: 7.1.0
+
+  /string-width@7.2.0:
+    resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
+    engines: {node: '>=18'}
+    dependencies:
+      emoji-regex: 10.5.0
+      get-east-asian-width: 1.4.0
+      strip-ansi: 7.1.0
+    dev: true
 
   /string.prototype.includes@2.0.1:
     resolution: {integrity: sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==}
@@ -16389,12 +17032,6 @@ packages:
       call-bind: 1.0.8
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
-    dev: true
-
-  /string_decoder@1.3.0:
-    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
-    dependencies:
-      safe-buffer: 5.2.1
     dev: true
 
   /stringify-entities@4.0.4:
@@ -16570,7 +17207,7 @@ packages:
       pump: 3.0.2
       tar-stream: 3.1.7
     optionalDependencies:
-      bare-fs: 4.2.3
+      bare-fs: 4.4.4
       bare-path: 3.0.0
     transitivePeerDependencies:
       - bare-buffer
@@ -16814,8 +17451,8 @@ packages:
     dev: false
     optional: true
 
-  /turbo-darwin-64@2.5.6:
-    resolution: {integrity: sha512-3C1xEdo4aFwMJAPvtlPqz1Sw/+cddWIOmsalHFMrsqqydcptwBfu26WW2cDm3u93bUzMbBJ8k3zNKFqxJ9ei2A==}
+  /turbo-darwin-64@2.5.8:
+    resolution: {integrity: sha512-Dh5bCACiHO8rUXZLpKw+m3FiHtAp2CkanSyJre+SInEvEr5kIxjGvCK/8MFX8SFRjQuhjtvpIvYYZJB4AGCxNQ==}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
@@ -16830,8 +17467,8 @@ packages:
     dev: false
     optional: true
 
-  /turbo-darwin-arm64@2.5.6:
-    resolution: {integrity: sha512-LyiG+rD7JhMfYwLqB6k3LZQtYn8CQQUePbpA8mF/hMLPAekXdJo1g0bUPw8RZLwQXUIU/3BU7tXENvhSGz5DPA==}
+  /turbo-darwin-arm64@2.5.8:
+    resolution: {integrity: sha512-f1H/tQC9px7+hmXn6Kx/w8Jd/FneIUnvLlcI/7RGHunxfOkKJKvsoiNzySkoHQ8uq1pJnhJ0xNGTlYM48ZaJOQ==}
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
@@ -16846,8 +17483,8 @@ packages:
     dev: false
     optional: true
 
-  /turbo-linux-64@2.5.6:
-    resolution: {integrity: sha512-GOcUTT0xiT/pSnHL4YD6Yr3HreUhU8pUcGqcI2ksIF9b2/r/kRHwGFcsHgpG3+vtZF/kwsP0MV8FTlTObxsYIA==}
+  /turbo-linux-64@2.5.8:
+    resolution: {integrity: sha512-hMyvc7w7yadBlZBGl/bnR6O+dJTx3XkTeyTTH4zEjERO6ChEs0SrN8jTFj1lueNXKIHh1SnALmy6VctKMGnWfw==}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
@@ -16862,8 +17499,8 @@ packages:
     dev: false
     optional: true
 
-  /turbo-linux-arm64@2.5.6:
-    resolution: {integrity: sha512-10Tm15bruJEA3m0V7iZcnQBpObGBcOgUcO+sY7/2vk1bweW34LMhkWi8svjV9iDF68+KJDThnYDlYE/bc7/zzQ==}
+  /turbo-linux-arm64@2.5.8:
+    resolution: {integrity: sha512-LQELGa7bAqV2f+3rTMRPnj5G/OHAe2U+0N9BwsZvfMvHSUbsQ3bBMWdSQaYNicok7wOZcHjz2TkESn1hYK6xIQ==}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
@@ -16882,8 +17519,8 @@ packages:
     dev: false
     optional: true
 
-  /turbo-windows-64@2.5.6:
-    resolution: {integrity: sha512-FyRsVpgaj76It0ludwZsNN40ytHN+17E4PFJyeliBEbxrGTc5BexlXVpufB7XlAaoaZVxbS6KT8RofLfDRyEPg==}
+  /turbo-windows-64@2.5.8:
+    resolution: {integrity: sha512-3YdcaW34TrN1AWwqgYL9gUqmZsMT4T7g8Y5Azz+uwwEJW+4sgcJkIi9pYFyU4ZBSjBvkfuPZkGgfStir5BBDJQ==}
     cpu: [x64]
     os: [win32]
     requiresBuild: true
@@ -16898,8 +17535,8 @@ packages:
     dev: false
     optional: true
 
-  /turbo-windows-arm64@2.5.6:
-    resolution: {integrity: sha512-j/tWu8cMeQ7HPpKri6jvKtyXg9K1gRyhdK4tKrrchH8GNHscPX/F71zax58yYtLRWTiK04zNzPcUJuoS0+v/+Q==}
+  /turbo-windows-arm64@2.5.8:
+    resolution: {integrity: sha512-eFC5XzLmgXJfnAK3UMTmVECCwuBcORrWdewoiXBnUm934DY6QN8YowC/srhNnROMpaKaqNeRpoB5FxCww3eteQ==}
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
@@ -16918,16 +17555,32 @@ packages:
       turbo-windows-arm64: 2.5.2
     dev: false
 
-  /turbo@2.5.6:
-    resolution: {integrity: sha512-gxToHmi9oTBNB05UjUsrWf0OyN5ZXtD0apOarC1KIx232Vp3WimRNy3810QzeNSgyD5rsaIDXlxlbnOzlouo+w==}
+  /turbo@2.5.8:
+    resolution: {integrity: sha512-5c9Fdsr9qfpT3hA0EyYSFRZj1dVVsb6KIWubA9JBYZ/9ZEAijgUEae0BBR/Xl/wekt4w65/lYLTFaP3JmwSO8w==}
     hasBin: true
     optionalDependencies:
-      turbo-darwin-64: 2.5.6
-      turbo-darwin-arm64: 2.5.6
-      turbo-linux-64: 2.5.6
-      turbo-linux-arm64: 2.5.6
-      turbo-windows-64: 2.5.6
-      turbo-windows-arm64: 2.5.6
+      turbo-darwin-64: 2.5.8
+      turbo-darwin-arm64: 2.5.8
+      turbo-linux-64: 2.5.8
+      turbo-linux-arm64: 2.5.8
+      turbo-windows-64: 2.5.8
+      turbo-windows-arm64: 2.5.8
+    dev: true
+
+  /twoslash-protocol@0.3.4:
+    resolution: {integrity: sha512-HHd7lzZNLUvjPzG/IE6js502gEzLC1x7HaO1up/f72d8G8ScWAs9Yfa97igelQRDl5h9tGcdFsRp+lNVre1EeQ==}
+    dev: true
+
+  /twoslash@0.3.4(typescript@5.8.3):
+    resolution: {integrity: sha512-RtJURJlGRxrkJmTcZMjpr7jdYly1rfgpujJr1sBM9ch7SKVht/SjFk23IOAyvwT1NLCk+SJiMrvW4rIAUM2Wug==}
+    peerDependencies:
+      typescript: ^5.5.0
+    dependencies:
+      '@typescript/vfs': 1.6.1(typescript@5.8.3)
+      twoslash-protocol: 0.3.4
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /type-check@0.4.0:
@@ -17242,6 +17895,21 @@ packages:
     resolution: {integrity: sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg==}
     dev: true
 
+  /use-callback-ref@1.3.3(@types/react@19.1.14)(react@19.1.0):
+    resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@types/react': 19.1.14
+      react: 19.1.0
+      tslib: 2.8.1
+    dev: true
+
   /use-callback-ref@1.3.3(@types/react@19.1.2)(react@19.1.0):
     resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
     engines: {node: '>=10'}
@@ -17265,6 +17933,22 @@ packages:
     dependencies:
       react: 19.1.0
     dev: false
+
+  /use-sidecar@1.1.3(@types/react@19.1.14)(react@19.1.0):
+    resolution: {integrity: sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@types/react': 19.1.14
+      detect-node-es: 1.1.0
+      react: 19.1.0
+      tslib: 2.8.1
+    dev: true
 
   /use-sidecar@1.1.3(@types/react@19.1.2)(react@19.1.0):
     resolution: {integrity: sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==}
@@ -17423,12 +18107,6 @@ packages:
     resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
     dev: false
 
-  /wcwidth@1.0.1:
-    resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
-    dependencies:
-      defaults: 1.0.4
-    dev: true
-
   /web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
 
@@ -17513,6 +18191,13 @@ packages:
     dependencies:
       isexe: 2.0.0
 
+  /widest-line@5.0.0:
+    resolution: {integrity: sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==}
+    engines: {node: '>=18'}
+    dependencies:
+      string-width: 7.2.0
+    dev: true
+
   /word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
@@ -17541,6 +18226,15 @@ packages:
       ansi-styles: 6.2.1
       string-width: 5.1.2
       strip-ansi: 7.1.0
+
+  /wrap-ansi@9.0.2:
+    resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
+    engines: {node: '>=18'}
+    dependencies:
+      ansi-styles: 6.2.1
+      string-width: 7.2.0
+      strip-ansi: 7.1.0
+    dev: true
 
   /wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
@@ -17640,6 +18334,10 @@ packages:
   /yoctocolors-cjs@2.1.2:
     resolution: {integrity: sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==}
     engines: {node: '>=18'}
+    dev: true
+
+  /yoga-layout@3.2.1:
+    resolution: {integrity: sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==}
     dev: true
 
   /zod-to-json-schema@3.24.5(zod@3.24.3):


### PR DESCRIPTION
## Summary
- add DNS record generation to domain service responses and normalize verification metadata
- expose DNS guidance in TRPC and public API responses, updating the OpenAPI schema
- update the dashboard domain detail UI to consume API-provided DNS records and share domain types

## Testing
- pnpm lint --filter web *(fails: existing warnings in packages/ui about unused variables)*

------
https://chatgpt.com/codex/tasks/task_e_68d43c1206c88329b5e02c69fbae2067

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Domain settings now render live DNS records (type, name, value, TTL, priority, verification status) with recommended labels and copy buttons.
  - New public GET /v1/domains/{id} endpoint to fetch a single enriched domain.

- Improvements
  - Verification details exposed (last-checked time, verification errors) and more accurate DKIM/SPF status handling.
  - More robust DMARC lookups and consistent domain data across views.

- SDK & Docs
  - Added domain APIs to Python and JS SDKs and updated OpenAPI/docs to include dnsRecords and verification fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->