### PR TITLE
feat: add custom email headers

### DIFF
--- a/apps/docs/api-reference/openapi.json
+++ b/apps/docs/api-reference/openapi.json
@@ -1140,6 +1140,14 @@
                     "nullable": true,
                     "minLength": 1
                   },
+                  "headers": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "description": "Custom headers to included with the emails"
+                  },
                   "attachments": {
                     "type": "array",
                     "items": {
@@ -1287,6 +1295,14 @@
                       "type": "string",
                       "nullable": true,
                       "minLength": 1
+                    },
+                    "headers": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "description": "Custom headers to included with the emails"
                     },
                     "attachments": {
                       "type": "array",

--- a/apps/docs/get-started/nodejs.mdx
+++ b/apps/docs/get-started/nodejs.mdx
@@ -57,8 +57,13 @@ icon: node-js
       subject: "useSend email",
       html: "<p>useSend is the best open source product to send emails</p>",
       text: "useSend is the best open source product to send emails",
+      headers: {
+        "X-Campaign": "welcome",
+      },
     });
     ```
+
+    > Custom headers are forwarded as-is. useSend only manages the `X-Usesend-Email-ID` and `References` headers.
   </Step>
 </Steps>
 

--- a/apps/docs/get-started/python.mdx
+++ b/apps/docs/get-started/python.mdx
@@ -41,11 +41,14 @@ payload: types.EmailCreate = {
     "from": "no-reply@yourdomain.com",
     "subject": "Welcome",
     "html": "<strong>Hello!</strong>",
+    "headers": {"X-Campaign": "welcome"},
 }
 
 data, err = client.emails.send(payload)
 print(data or err)
 ```
+
+useSend forwards your custom headers to SES. Only the `X-Usesend-Email-ID` and `References` headers are managed automatically.
 
 Attachments and scheduling:
 

--- a/apps/web/prisma/migrations/20250207121500_add_email_headers/migration.sql
+++ b/apps/web/prisma/migrations/20250207121500_add_email_headers/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Email" ADD COLUMN "headers" JSONB;

--- a/apps/web/prisma/migrations/20250207121500_add_email_headers/migration.sql
+++ b/apps/web/prisma/migrations/20250207121500_add_email_headers/migration.sql
@@ -1,2 +1,0 @@
--- AlterTable
-ALTER TABLE "Email" ADD COLUMN "headers" JSONB;

--- a/apps/web/prisma/migrations/20250927193506_add_email_headers/migration.sql
+++ b/apps/web/prisma/migrations/20250927193506_add_email_headers/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Email" ADD COLUMN     "headers" TEXT;

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -259,6 +259,7 @@ model Email {
   campaignId   String?
   contactId    String?
   inReplyToId  String?
+  headers      Json?
   team         Team         @relation(fields: [teamId], references: [id], onDelete: Cascade)
   emailEvents  EmailEvent[]
 

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -259,7 +259,7 @@ model Email {
   campaignId   String?
   contactId    String?
   inReplyToId  String?
-  headers      Json?
+  headers      String?
   team         Team         @relation(fields: [teamId], references: [id], onDelete: Cascade)
   emailEvents  EmailEvent[]
 

--- a/apps/web/src/server/public-api/schemas/email-schema.ts
+++ b/apps/web/src/server/public-api/schemas/email-schema.ts
@@ -19,13 +19,9 @@ export const emailSchema = z
     bcc: z.string().or(z.array(z.string())).optional(),
     text: z.string().min(1).optional().nullable(),
     html: z.coerce.string().min(1).optional().nullable(),
-    headers: z
-      .record(z.string().min(1))
-      .optional()
-      .openapi({
-        description:
-          "Custom headers to include with the message. All headers are forwarded except `X-Usesend-Email-ID` and `References`, which useSend manages.",
-      }),
+    headers: z.record(z.string().min(1)).optional().openapi({
+      description: "Custom headers to included with the emails",
+    }),
     attachments: z
       .array(
         z.object({

--- a/apps/web/src/server/public-api/schemas/email-schema.ts
+++ b/apps/web/src/server/public-api/schemas/email-schema.ts
@@ -19,6 +19,13 @@ export const emailSchema = z
     bcc: z.string().or(z.array(z.string())).optional(),
     text: z.string().min(1).optional().nullable(),
     html: z.coerce.string().min(1).optional().nullable(),
+    headers: z
+      .record(z.string().min(1))
+      .optional()
+      .openapi({
+        description:
+          "Custom headers to include with the message. All headers are forwarded except `X-Usesend-Email-ID` and `References`, which useSend manages.",
+      }),
     attachments: z
       .array(
         z.object({

--- a/apps/web/src/server/service/email-queue-service.ts
+++ b/apps/web/src/server/service/email-queue-service.ts
@@ -397,15 +397,7 @@ async function executeEmail(job: QueueEmailJob) {
       return;
     }
 
-    const storedHeaders = (() => {
-      const headers = (email as any)?.headers;
-      if (!headers || typeof headers !== "object" || Array.isArray(headers)) {
-        return undefined;
-      }
-      return headers as Record<string, string | null | undefined>;
-    })();
-
-    const customHeaders = sanitizeCustomHeaders(storedHeaders);
+    const customHeaders = email.headers ? JSON.parse(email.headers) : undefined;
 
     const messageId = await sendRawEmail({
       to: email.to,
@@ -432,10 +424,10 @@ async function executeEmail(job: QueueEmailJob) {
       `[EmailQueueService]: Email sent`
     );
 
-    // Delete attachments after sending the email
+    // Delete attachments and headers after sending the email
     await db.email.update({
       where: { id: email.id },
-      data: { sesEmailId: messageId, text, attachments: null },
+      data: { sesEmailId: messageId, text, attachments: null, headers: null },
     });
   } catch (error: any) {
     await db.emailEvent.create({

--- a/apps/web/src/server/service/email-service.ts
+++ b/apps/web/src/server/service/email-service.ts
@@ -542,36 +542,31 @@ export async function sendBulkEmails(
         : [originalContent.bcc]
       : [];
 
-    const sanitizedHeaders = sanitizeCustomHeaders(originalContent.headers);
-
-    const emailCreateData: Record<string, unknown> = {
-      to: originalToEmails,
-      from,
-      subject: subject as string,
-      replyTo: replyTo
-        ? Array.isArray(replyTo)
-          ? replyTo
-          : [replyTo]
-        : undefined,
-      cc: originalCcEmails.length > 0 ? originalCcEmails : undefined,
-      bcc: originalBccEmails.length > 0 ? originalBccEmails : undefined,
-      text,
-      html,
-      teamId,
-      domainId: domain.id,
-      attachments: attachments ? JSON.stringify(attachments) : undefined,
-      scheduledAt: scheduledAt ? new Date(scheduledAt) : undefined,
-      latestStatus: "SUPPRESSED",
-      apiId: apiKeyId,
-      inReplyToId,
-    };
-
-    if (sanitizedHeaders) {
-      emailCreateData.headers = sanitizedHeaders;
-    }
-
     const email = await db.email.create({
-      data: emailCreateData as any,
+      data: {
+        to: originalToEmails,
+        from,
+        subject: subject as string,
+        replyTo: replyTo
+          ? Array.isArray(replyTo)
+            ? replyTo
+            : [replyTo]
+          : undefined,
+        cc: originalCcEmails.length > 0 ? originalCcEmails : undefined,
+        bcc: originalBccEmails.length > 0 ? originalBccEmails : undefined,
+        text,
+        html,
+        teamId,
+        domainId: domain.id,
+        attachments: attachments ? JSON.stringify(attachments) : undefined,
+        scheduledAt: scheduledAt ? new Date(scheduledAt) : undefined,
+        latestStatus: "SUPPRESSED",
+        apiId: apiKeyId,
+        inReplyToId,
+        headers: originalContent.headers
+          ? JSON.stringify(originalContent.headers)
+          : undefined,
+      },
     });
 
     await db.emailEvent.create({
@@ -653,7 +648,6 @@ export async function sendBulkEmails(
 
       let subject = subjectFromApiCall;
       let html = htmlFromApiCall;
-      const sanitizedHeaders = sanitizeCustomHeaders(headers);
 
       // Process template if specified
       if (templateId) {
@@ -708,34 +702,28 @@ export async function sendBulkEmails(
         : undefined;
 
       try {
-        // Create email record
-        const emailCreateData: Record<string, unknown> = {
-          to: Array.isArray(to) ? to : [to],
-          from,
-          subject: subject as string,
-          replyTo: replyTo
-            ? Array.isArray(replyTo)
-              ? replyTo
-              : [replyTo]
-            : undefined,
-          cc: cc && cc.length > 0 ? cc : undefined,
-          bcc: bcc && bcc.length > 0 ? bcc : undefined,
-          text,
-          html,
-          teamId,
-          domainId: domain.id,
-          attachments: attachments ? JSON.stringify(attachments) : undefined,
-          scheduledAt: scheduledAtDate,
-          latestStatus: scheduledAtDate ? "SCHEDULED" : "QUEUED",
-          apiId: apiKeyId,
-        };
-
-        if (sanitizedHeaders) {
-          emailCreateData.headers = sanitizedHeaders;
-        }
-
         const email = await db.email.create({
-          data: emailCreateData as any,
+          data: {
+            to: Array.isArray(to) ? to : [to],
+            from,
+            subject: subject as string,
+            replyTo: replyTo
+              ? Array.isArray(replyTo)
+                ? replyTo
+                : [replyTo]
+              : undefined,
+            cc: cc && cc.length > 0 ? cc : undefined,
+            bcc: bcc && bcc.length > 0 ? bcc : undefined,
+            text,
+            html,
+            teamId,
+            domainId: domain.id,
+            attachments: attachments ? JSON.stringify(attachments) : undefined,
+            scheduledAt: scheduledAtDate,
+            latestStatus: scheduledAtDate ? "SCHEDULED" : "QUEUED",
+            apiId: apiKeyId,
+            headers: headers ? JSON.stringify(headers) : undefined,
+          },
         });
 
         createdEmails.push({ email, originalIndex });

--- a/apps/web/src/server/utils/email-headers.ts
+++ b/apps/web/src/server/utils/email-headers.ts
@@ -1,0 +1,56 @@
+const RESERVED_EMAIL_HEADERS = new Set(
+  ["x-usesend-email-id", "references"].map((header) =>
+    header.toLowerCase()
+  )
+);
+
+const HEADER_INJECTION_PATTERN = /[\r\n]/;
+
+/**
+ * Removes reserved headers and values that could result in header injection.
+ * Returns `undefined` when the resulting object is empty so downstream callers
+ * can skip persisting redundant data.
+ */
+export function sanitizeHeader(
+  rawName: unknown,
+  rawValue: unknown
+): { name: string; value: string } | undefined {
+  if (typeof rawName !== "string" || typeof rawValue !== "string") {
+    return undefined;
+  }
+
+  const name = rawName.trim();
+  if (!name || RESERVED_EMAIL_HEADERS.has(name.toLowerCase())) {
+    return undefined;
+  }
+
+  if (
+    HEADER_INJECTION_PATTERN.test(name) ||
+    HEADER_INJECTION_PATTERN.test(rawValue)
+  ) {
+    return undefined;
+  }
+
+  return { name, value: rawValue };
+}
+
+export function sanitizeCustomHeaders(
+  headers?: Record<string, string | null | undefined>
+): Record<string, string> | undefined {
+  if (!headers) {
+    return undefined;
+  }
+
+  const sanitizedEntries = Object.entries(headers)
+    .map(([name, value]) => sanitizeHeader(name, value))
+    .filter((entry): entry is { name: string; value: string } => Boolean(entry));
+
+  if (sanitizedEntries.length === 0) {
+    return undefined;
+  }
+
+  return sanitizedEntries.reduce((acc, { name, value }) => {
+    acc[name] = value;
+    return acc;
+  }, {} as Record<string, string>);
+}

--- a/apps/web/src/types/index.ts
+++ b/apps/web/src/types/index.ts
@@ -10,6 +10,7 @@ export type EmailContent = {
   cc?: string | string[];
   bcc?: string | string[];
   attachments?: Array<EmailAttachment>;
+  headers?: Record<string, string>;
   unsubUrl?: string;
   scheduledAt?: string;
   inReplyToId?: string | null;

--- a/packages/python-sdk/pyproject.toml
+++ b/packages/python-sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "usesend"
-version = "0.2.4"
+version = "0.2.5"
 description = "Python SDK for the UseSend API"
 authors = ["UseSend"]
 license = "MIT"

--- a/packages/python-sdk/usesend/types.py
+++ b/packages/python-sdk/usesend/types.py
@@ -215,6 +215,7 @@ EmailCreate = TypedDict(
         'attachments': NotRequired[List[Attachment]],
         'scheduledAt': NotRequired[Union[datetime, str]],
         'inReplyToId': NotRequired[str],
+        'headers': NotRequired[Dict[str, str]],
     }
 )
 
@@ -239,6 +240,7 @@ EmailBatchItem = TypedDict(
         'attachments': NotRequired[List[Attachment]],
         'scheduledAt': NotRequired[Union[datetime, str]],
         'inReplyToId': NotRequired[str],
+        'headers': NotRequired[Dict[str, str]],
     }
 )
 

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "usesend-js",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/sdk/types/schema.d.ts
+++ b/packages/sdk/types/schema.d.ts
@@ -535,6 +535,10 @@ export interface paths {
                         bcc?: string | string[];
                         text?: string | null;
                         html?: string | null;
+                        /** @description Custom headers to included with the emails */
+                        headers?: {
+                            [key: string]: string;
+                        };
                         attachments?: {
                             filename: string;
                             content: string;
@@ -542,9 +546,6 @@ export interface paths {
                         /** Format: date-time */
                         scheduledAt?: string;
                         inReplyToId?: string | null;
-                        headers?: {
-                            [key: string]: string;
-                        };
                     };
                 };
             };
@@ -601,6 +602,10 @@ export interface paths {
                         bcc?: string | string[];
                         text?: string | null;
                         html?: string | null;
+                        /** @description Custom headers to included with the emails */
+                        headers?: {
+                            [key: string]: string;
+                        };
                         attachments?: {
                             filename: string;
                             content: string;
@@ -608,9 +613,6 @@ export interface paths {
                         /** Format: date-time */
                         scheduledAt?: string;
                         inReplyToId?: string | null;
-                        headers?: {
-                            [key: string]: string;
-                        };
                     }[];
                 };
             };

--- a/packages/sdk/types/schema.d.ts
+++ b/packages/sdk/types/schema.d.ts
@@ -542,6 +542,9 @@ export interface paths {
                         /** Format: date-time */
                         scheduledAt?: string;
                         inReplyToId?: string | null;
+                        headers?: {
+                            [key: string]: string;
+                        };
                     };
                 };
             };
@@ -605,6 +608,9 @@ export interface paths {
                         /** Format: date-time */
                         scheduledAt?: string;
                         inReplyToId?: string | null;
+                        headers?: {
+                            [key: string]: string;
+                        };
                     }[];
                 };
             };


### PR DESCRIPTION
## Summary
- add a headers column to the email table and include a migration so custom API headers persist with each message
- store sanitized header maps on email records, drop header payloads from queue jobs, and hydrate SES requests from the persisted data
- extract a reusable sanitizeHeader helper and reuse it inside the existing custom header sanitizer

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d056e6c4848329b99dbf5b5562800a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Add support for custom email headers in single and batch sends; headers accepted as string maps and forwarded (system headers auto-managed).

- Documentation
  - Node.js and Python guides updated with headers examples and notes; OpenAPI updated to document the optional headers field.

- SDKs
  - JavaScript SDK bumped to v1.5.4; Python SDK bumped to v0.2.5 with headers added to types.

- Chores
  - Database migration adds a nullable headers column to emails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->