### PR TITLE
feat: add streaming(loading) for smtp settings page navigation

### DIFF
--- a/apps/web/src/app/(dashboard)/dev-settings/smtp/loading.tsx
+++ b/apps/web/src/app/(dashboard)/dev-settings/smtp/loading.tsx
@@ -1,5 +1,4 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@usesend/ui/src/card";
-  
   export default function Loading() {
     return (
       <Card className="mt-9 max-w-xl">


### PR DESCRIPTION
### **Problem**
The SMTP settings page uses `force-dynamic` to display real-time environment variables, causing a ~0.5s delay on navigation with no visual feedback.

### **Solution**
Added a `loading.tsx` file that displays an instant loading skeleton matching the page layout. Users now see immediate feedback when navigating to the SMTP page, with pulsing placeholders while the server renders the actual environment values.
### **Changes**

Created `apps/web/src/app/(dashboard)/dev-settings/smtp/loading.tsx` with skeleton UI matching the SMTP page structure

### **Before**

https://github.com/user-attachments/assets/8a563c98-1ca7-49be-a5c3-ce8f5e92d25e

### **After**

https://github.com/user-attachments/assets/799e540d-ba15-4641-bef0-41d1cde1a8dc



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a loading skeleton for the SMTP settings page in the dashboard so users see a structured placeholder while settings load.
  * Displays animated placeholder fields for Host, Port (with helper text for common TLS ports), User, and Password to reduce layout shifts.
  * Enhances perceived performance and provides clearer guidance during loading with consistent visuals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->