### PR TITLE
fix: contact update mutation

### DIFF
--- a/apps/web/src/server/api/routers/contacts.ts
+++ b/apps/web/src/server/api/routers/contacts.ts
@@ -51,7 +51,8 @@ export const contactsRouter = createTRPCRouter({
       })
     )
     .mutation(async ({ ctx: { contactBook }, input }) => {
-      return contactBookService.updateContactBook(contactBook.id, input);
+      const { contactBookId, ...data } = input;
+      return contactBookService.updateContactBook(contactBook.id, data);
     }),
 
   deleteContactBook: contactBookProcedure


### PR DESCRIPTION
**Issue**: The contactBookId was being passed to Prisma's update method as part of the data object, but it's not an updatable field, causing an "Unknown argument" error.

**Fix**: Destructured contactBookId out of the input , so only valid update fields reach Prisma





**Before**

https://github.com/user-attachments/assets/f345b1d4-1a6b-4089-8574-22d95ab50b48

**After**

https://github.com/user-attachments/assets/b26b4786-f740-4001-a117-13ca6fe305f8


