### PR TITLE
add contact to users on waitlist removal

### DIFF
--- a/apps/web/src/env.js
+++ b/apps/web/src/env.js
@@ -13,7 +13,7 @@ export const env = createEnv({
       .url()
       .refine(
         (str) => !str.includes("YOUR_MYSQL_URL_HERE"),
-        "You forgot to change the default URL"
+        "You forgot to change the default URL",
       ),
     NODE_ENV: z
       .enum(["development", "test", "production"])
@@ -27,7 +27,7 @@ export const env = createEnv({
       // Since NextAuth.js automatically uses the VERCEL_URL if present.
       (str) => process.env.VERCEL_URL ?? str,
       // VERCEL_URL doesn't include `https` so it cant be validated as a URL
-      process.env.VERCEL ? z.string() : z.string().url()
+      process.env.VERCEL ? z.string() : z.string().url(),
     ),
     GITHUB_ID: z.string().optional(),
     GITHUB_SECRET: z.string().optional(),
@@ -65,6 +65,7 @@ export const env = createEnv({
     STRIPE_WEBHOOK_SECRET: z.string().optional(),
     SMTP_HOST: z.string().default("smtp.usesend.com"),
     SMTP_USER: z.string().default("usesend"),
+    CONTACT_BOOK_ID: z.string().optional(),
   },
 
   /**
@@ -120,6 +121,7 @@ export const env = createEnv({
     STRIPE_WEBHOOK_SECRET: process.env.STRIPE_WEBHOOK_SECRET,
     SMTP_HOST: process.env.SMTP_HOST,
     SMTP_USER: process.env.SMTP_USER,
+    CONTACT_BOOK_ID: process.env.CONTACT_BOOK_ID,
   },
   /**
    * Run `build` or `dev` with `SKIP_ENV_VALIDATION` to skip env validation. This is especially


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Automatically add users to the Usesend contact book when they are removed from the waitlist in cloud deployments. Adds CONTACT_BOOK_ID env support and logs success/failure.

- **New Features**
  - On waitlist removal, create a contact via usesend-js when isCloud(), CONTACT_BOOK_ID exists, and the user has an email.
  - Logs both success and errors with user and contact details.

- **Migration**
  - Set CONTACT_BOOK_ID in the cloud environment (USESEND_API_KEY must be set).

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Users removed from the waitlist are now automatically added to a configured contact book (cloud deployments only).

## Chores
* Added environment variable support for contact book configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->