### PR TITLE
Add Team ID to Existing System

### DIFF
--- a/apps/web/src/app/(dashboard)/admin/email-analytics/page.tsx
+++ b/apps/web/src/app/(dashboard)/admin/email-analytics/page.tsx
@@ -118,6 +118,7 @@ export default function AdminEmailAnalyticsPage() {
             <TableHeader>
               <TableRow>
                 <TableHead>Team</TableHead>
+                <TableHead>Team ID</TableHead>
                 <TableHead>Plan</TableHead>
                 <TableHead className="text-right">Sent</TableHead>
                 <TableHead className="text-right">Delivered</TableHead>
@@ -131,13 +132,13 @@ export default function AdminEmailAnalyticsPage() {
             <TableBody>
               {analyticsQuery.isLoading ? (
                 <TableRow>
-                  <TableCell colSpan={9} className="py-12 text-center">
+                  <TableCell colSpan={10} className="py-12 text-center">
                     <Spinner className="h-6 w-6" />
                   </TableCell>
                 </TableRow>
               ) : rows.length === 0 ? (
                 <TableRow>
-                  <TableCell colSpan={9} className="py-12 text-center">
+                  <TableCell colSpan={10} className="py-12 text-center">
                     No email activity found for this period.
                   </TableCell>
                 </TableRow>
@@ -145,6 +146,7 @@ export default function AdminEmailAnalyticsPage() {
                 rows.map((row) => (
                   <TableRow key={row.teamId}>
                     <TableCell>{row.name}</TableCell>
+                    <TableCell>{row.teamId}</TableCell>
                     <TableCell>{row.plan}</TableCell>
                     <TableCell className="text-right">{row.sent}</TableCell>
                     <TableCell className="text-right">


### PR DESCRIPTION
Added Team ID column to the email analytics table to display the team identifier alongside team name, making it easier to identify teams in the analytics view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a Team ID column to the Admin Email Analytics table to show each team’s unique identifier alongside the team name for easier identification. Updated loading and empty states to span the new column so the spinner/message covers all 10 columns.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Team ID" column to the email analytics dashboard table, enabling users to easily identify which team each analytics entry belongs to.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->