### PR TITLE
feat: add email send idempotency caching

### DIFF
--- a/apps/docs/docs.json
+++ b/apps/docs/docs.json
@@ -38,7 +38,10 @@
           },
           {
             "group": "Guides",
-            "pages": ["guides/use-with-react-email"]
+            "pages": [
+              "guides/use-with-react-email",
+              "guides/email-idempotency"
+            ]
           },
           {
             "group": "Community SDKs",

--- a/apps/docs/guides/email-idempotency.mdx
+++ b/apps/docs/guides/email-idempotency.mdx
@@ -1,0 +1,49 @@
+---
+title: Email idempotency
+description: Deduplicate email send requests by reusing the same queued job.
+---
+
+## Overview
+
+When you provide an `idempotencyKey` with the email send endpoint, useSend will
+short-circuit duplicate requests and return the first queued email. The key is
+scoped to the team and automatically expires after three days so you do not need
+any manual cleanup.
+
+## JavaScript SDK example
+
+```ts
+import { UseSend } from "usesend-js";
+
+const usesend = new UseSend(process.env.USESEND_API_KEY!);
+
+await usesend.emails.send({
+  to: "recipient@example.com",
+  from: "hello@example.com",
+  subject: "Receipt",
+  html: "<p>Thanks for your order!</p>",
+  idempotencyKey: "order-123",
+});
+```
+
+## Python SDK example
+
+```py
+from usesend import UseSend
+
+client = UseSend("us_your_api_key")
+
+client.emails.send({
+    "to": "recipient@example.com",
+    "from": "hello@example.com",
+    "subject": "Receipt",
+    "html": "<p>Thanks for your order!</p>",
+    "idempotencyKey": "order-123",
+})
+```
+
+:::note
+Repeated calls with the same key will reuse the cached response until the
+three-day expiration window passes. If a send fails, a new request can reuse the
+same key after the failure record is cleared automatically.
+:::

--- a/apps/web/src/server/public-api/api/emails/send-email.ts
+++ b/apps/web/src/server/public-api/api/emails/send-email.ts
@@ -32,19 +32,21 @@ function send(app: PublicAPIApp) {
   app.openapi(route, async (c) => {
     const team = c.var.team;
 
+    const body = c.req.valid("json");
+
     let html = undefined;
 
-    const _html = c.req.valid("json")?.html?.toString();
+    const _html = body?.html?.toString();
 
     if (_html && _html !== "true" && _html !== "false") {
       html = _html;
     }
 
     const email = await sendEmail({
-      ...c.req.valid("json"),
+      ...body,
       teamId: team.id,
       apiKeyId: team.apiKeyId,
-      text: c.req.valid("json").text ?? undefined,
+      text: body.text ?? undefined,
       html: html,
     });
 

--- a/apps/web/src/server/public-api/schemas/email-schema.ts
+++ b/apps/web/src/server/public-api/schemas/email-schema.ts
@@ -7,6 +7,16 @@ export const emailSchema = z
   .object({
     to: z.string().or(z.array(z.string())),
     from: z.string(),
+    idempotencyKey: z
+      .string()
+      .trim()
+      .min(1)
+      .max(255)
+      .optional()
+      .openapi({
+        description:
+          "Optional key to deduplicate send requests. Duplicate keys reuse results.",
+      }),
     subject: z.string().min(1).optional().openapi({
       description: "Optional when templateId is provided",
     }),

--- a/apps/web/src/types/index.ts
+++ b/apps/web/src/types/index.ts
@@ -1,6 +1,7 @@
 export type EmailContent = {
   to: string | string[];
   from: string;
+  idempotencyKey?: string;
   subject?: string;
   templateId?: string;
   variables?: Record<string, string>;

--- a/packages/python-sdk/usesend/emails.py
+++ b/packages/python-sdk/usesend/emails.py
@@ -42,6 +42,13 @@ class Emails:
         if isinstance(body.get("scheduledAt"), datetime):
             body["scheduledAt"] = body["scheduledAt"].isoformat()
 
+        if body.get("idempotencyKey") is not None:
+            key = str(body["idempotencyKey"]).strip()
+            if key:
+                body["idempotencyKey"] = key
+            else:
+                body.pop("idempotencyKey", None)
+
         data, err = self.usesend.post("/emails", body)
         return (data, err)  # type: ignore[return-value]
 

--- a/packages/python-sdk/usesend/types.py
+++ b/packages/python-sdk/usesend/types.py
@@ -210,6 +210,7 @@ EmailCreate = TypedDict(
     {
         "to": Required[Union[str, List[str]]],
         "from": Required[str],
+        "idempotencyKey": NotRequired[str],
         "subject": NotRequired[str],
         "templateId": NotRequired[str],
         "variables": NotRequired[Dict[str, str]],

--- a/packages/sdk/src/email.ts
+++ b/packages/sdk/src/email.ts
@@ -82,6 +82,16 @@ export class Emails {
       delete payload.react;
     }
 
+    if (payload.idempotencyKey !== undefined) {
+      const normalizedKey = String(payload.idempotencyKey).trim();
+
+      if (normalizedKey.length > 0) {
+        payload.idempotencyKey = normalizedKey;
+      } else {
+        delete payload.idempotencyKey;
+      }
+    }
+
     const data = await this.usesend.post<CreateEmailResponseSuccess>(
       "/emails",
       payload

--- a/packages/sdk/types/schema.d.ts
+++ b/packages/sdk/types/schema.d.ts
@@ -570,6 +570,8 @@ export interface paths {
                     "application/json": {
                         to: string | string[];
                         from: string;
+                        /** @description Optional key to deduplicate send requests. Duplicate keys reuse results. */
+                        idempotencyKey?: string;
                         /** @description Optional when templateId is provided */
                         subject?: string;
                         /** @description ID of a template from the dashboard */


### PR DESCRIPTION
## Summary
- add support for optional idempotency keys on the email send API, including Redis-backed reservation, cached responses, and 3-day expiry logging
- extend Redis helpers plus TypeScript and Python SDKs to normalize the idempotency key before sending requests
- document the new behaviour with a dedicated guide and navigation entry

## Testing
- pnpm lint --filter web *(fails: existing warnings in @usesend/ui lint task)*

------
https://chatgpt.com/codex/tasks/task_e_68faf7f22c5c8329a7f92d920f50693a

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds optional idempotencyKey to the email send API to deduplicate duplicate requests, using Redis reservations and cached results with a 3-day TTL. SDKs normalize the key, and a new guide documents usage.

- New Features
  - Email send accepts idempotencyKey; duplicate keys return the first email result (scoped per team).
  - Redis-backed reservation with a 3-day TTL; states tracked during PENDING/CREATED/QUEUED/FAILED.
  - In-progress duplicate requests respond with a “request already in progress” error.
  - Failed sends are retriable; previous FAILED keys are cleared on the next attempt.
  - JS and Python SDKs trim and drop empty idempotencyKey values; OpenAPI/schema updated.
  - Added “Email idempotency” guide and docs navigation entry.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added email idempotency support: use an `idempotencyKey` parameter when sending emails to deduplicate requests and reuse cached responses for up to 3 days.

* **Documentation**
  * New guide on email idempotency usage and best practices added to the documentation library.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->