### PR TITLE
Fix free limits and email notifications for inactive users

### DIFF
--- a/apps/web/src/server/service/limit-service.ts
+++ b/apps/web/src/server/service/limit-service.ts
@@ -136,10 +136,11 @@ export class LimitService {
     );
 
     const dailyUsage = usage.day.reduce((acc, curr) => acc + curr.sent, 0);
+    const activePlan = getActivePlan(team);
     const dailyLimit =
-      team.plan !== "FREE"
+      activePlan !== "FREE"
         ? team.dailyEmailLimit
-        : PLAN_LIMITS[team.plan].emailsPerDay;
+        : PLAN_LIMITS.FREE.emailsPerDay;
 
     logger.info(
       { dailyUsage, dailyLimit, team },

--- a/apps/web/src/server/service/team-service.ts
+++ b/apps/web/src/server/service/team-service.ts
@@ -400,7 +400,8 @@ export class TeamService {
     }
 
     const team = await TeamService.getTeamCached(teamId);
-    const isPaidPlan = team.plan !== "FREE";
+    // Only consider it a paid plan if the subscription is active
+    const isPaidPlan = team.isActive && team.plan !== "FREE";
 
     const html = await getLimitReachedEmail(teamId, limit, reason);
 
@@ -501,7 +502,8 @@ export class TeamService {
     }
 
     const team = await TeamService.getTeamCached(teamId);
-    const isPaidPlan = team.plan !== "FREE";
+    // Only consider it a paid plan if the subscription is active
+    const isPaidPlan = team.isActive && team.plan !== "FREE";
 
     const period =
       reason === LimitReason.EMAIL_FREE_PLAN_MONTHLY_LIMIT_REACHED


### PR DESCRIPTION
When a user's subscription is inactive, they should be treated as a FREE plan user with all free tier limits applied and appropriate email notifications.

Changes:
- limit-service.ts: Use getActivePlan() for daily limit checks so inactive users get FREE plan daily limits (100/day) instead of unlimited
- team-service.ts: Fix isPaidPlan flag in email notifications to check team.isActive, ensuring inactive users receive free plan messaging

This ensures:
1. Inactive users have daily limits enforced (100 emails/day)
2. Inactive users receive correct email messaging (upgrade plan vs verify team)
3. All free tier limits apply when subscription is inactive

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treat inactive subscriptions as FREE plan users across limits and emails. Enforces 100 emails/day and sends the correct free-plan messaging.

- **Bug Fixes**
  - Use getActivePlan for daily limit checks so inactive users get the FREE limit (100/day).
  - Email notifications now consider team.isActive when setting isPaidPlan, sending free-plan upgrade messages to inactive teams.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved email sending limits to properly account for active subscription status. Teams with inactive subscriptions now correctly receive free-tier email limits as intended.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->