### PR TITLE
Add Team Search by Subscription ID

### DIFF
--- a/apps/web/src/app/(dashboard)/admin/teams/page.tsx
+++ b/apps/web/src/app/(dashboard)/admin/teams/page.tsx
@@ -34,9 +34,9 @@ import { isCloud } from "~/utils/common";
 
 const searchSchema = z.object({
   query: z
-    .string({ required_error: "Enter a team ID, name, domain, or member email" })
+    .string({ required_error: "Enter a team ID, name, domain, member email, or subscription ID" })
     .trim()
-    .min(1, "Enter a team ID, name, domain, or member email"),
+    .min(1, "Enter a team ID, name, domain, member email, or subscription ID"),
 });
 
 type SearchInput = z.infer<typeof searchSchema>;
@@ -150,7 +150,7 @@ export default function AdminTeamsPage() {
                   <FormLabel>Team lookup</FormLabel>
                   <FormControl>
                     <Input
-                      placeholder="Team ID, team name, domain, or member email"
+                      placeholder="Team ID, team name, domain, member email, or subscription ID"
                       autoComplete="off"
                       {...field}
                       value={field.value}

--- a/apps/web/src/server/api/routers/admin.ts
+++ b/apps/web/src/server/api/routers/admin.ts
@@ -373,6 +373,13 @@ export const adminRouter = createTRPCRouter({
                   },
                 },
               },
+              {
+                subscription: {
+                  some: {
+                    id: { equals: query, mode: "insensitive" },
+                  },
+                },
+              },
             ],
           },
           select: teamAdminSelection,


### PR DESCRIPTION
Enable admins to search for teams using Stripe subscription IDs in addition to existing search methods (team ID, name, domain, member email).

Changes:
- Add subscription ID search clause to admin.findTeam mutation
- Update placeholder text to include subscription ID as searchable field

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Admins can now find teams by subscription ID in the Admin > Teams page and the admin.findTeam API. Aligns with Linear issue 011CUUhfKhAipkJWKX3vo7Tw to speed up billing/support lookups.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Teams can now be searched by subscription ID in addition to existing search criteria such as name, billing email, user email, and domain. The search functionality and user interface have been enhanced with updated validation to support this new search capability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->