### PR TITLE
docs: add .env symlink setup instructions for apps/web

### DIFF
--- a/CONTRIBUTION.md
+++ b/CONTRIBUTION.md
@@ -55,6 +55,14 @@ openssl rand -base64 32
 
 - Add this to `.env` as `NEXTAUTH_SECRET`.
 
+- Create symlink for Next.js:
+
+```bash
+ln -s ../../.env apps/web/.env
+```
+
+> Next.js requires the `.env` file in its directory. This symlink ensures both root and `apps/web` can access the same environment variables.
+
 ### 4. GitHub OAuth (Optional for Dev)
 
 Set up a GitHub OAuth App:

--- a/apps/docs/get-started/local.mdx
+++ b/apps/docs/get-started/local.mdx
@@ -101,6 +101,14 @@ openssl rand -base64 32
 ```
 
   </Step>
+  <Step title="Create symlink for Next.js">
+  Create a symlink so that Next.js can access the root `.env` file:
+
+```bash
+ln -s ../../.env apps/web/.env
+```
+
+  </Step>
   <Step title="Setup GitHub Oauth (optional)">
   <Note>
     You don't need this setup if you have `FROM_EMAIL` set in your environment


### PR DESCRIPTION
## Summary by cubic
Added setup instructions to symlink apps/web/.env to the root .env so Next.js reads environment variables during local development. This prevents pnpm d from failing with "Invalid environment variables".

- **Migration**
  - Create the symlink: ln -s ../../.env apps/web/.env
  - Re-run pnpm d

<sup>Written for commit a329ebf351bb8f04b394e30d11867cd94f662190. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated local development setup guide with environment variable configuration instructions for Next.js, including symlink setup details.
  * Updated contribution guidelines with environment variable setup steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->