### PR TITLE
feat: allow deleting ses settings

### DIFF
--- a/apps/web/src/app/(dashboard)/admin/delete-ses-configuration.tsx
+++ b/apps/web/src/app/(dashboard)/admin/delete-ses-configuration.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { useState } from "react";
+import { SesSetting } from "@prisma/client";
+import { Trash } from "lucide-react";
+
+import { Button } from "@usesend/ui/src/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@usesend/ui/src/dialog";
+import { toast } from "@usesend/ui/src/toaster";
+
+import { api } from "~/trpc/react";
+
+export default function DeleteSesConfiguration({
+  setting,
+}: {
+  setting: SesSetting;
+}) {
+  const [open, setOpen] = useState(false);
+
+  const deleteSesSettings = api.admin.deleteSesSettings.useMutation();
+  const utils = api.useUtils();
+
+  const handleDelete = () => {
+    deleteSesSettings.mutate(
+      { settingsId: setting.id },
+      {
+        onSuccess: () => {
+          utils.admin.invalidate();
+          toast.success("SES configuration deleted", {
+            description: `${setting.region} has been removed`,
+          });
+          setOpen(false);
+        },
+        onError: (error) => {
+          toast.error("Failed to delete SES configuration", {
+            description: error.message,
+          });
+        },
+      }
+    );
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => setOpen(next)}>
+      <DialogTrigger asChild>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="text-destructive hover:text-destructive"
+        >
+          <Trash className="h-4 w-4" />
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Delete SES configuration</DialogTitle>
+          <DialogDescription>
+            This will delete the callback URL, SNS topic, and queues for the{" "}
+            <span className="font-semibold">{setting.region}</span> region.
+            This action cannot be undone.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={() => setOpen(false)}
+            disabled={deleteSesSettings.isPending}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            variant="destructive"
+            onClick={handleDelete}
+            isLoading={deleteSesSettings.isPending}
+            showSpinner
+          >
+            Delete
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/app/(dashboard)/admin/ses-configurations.tsx
+++ b/apps/web/src/app/(dashboard)/admin/ses-configurations.tsx
@@ -13,6 +13,7 @@ import { api } from "~/trpc/react";
 import Spinner from "@usesend/ui/src/spinner";
 import EditSesConfiguration from "./edit-ses-configuration";
 import { TextWithCopyButton } from "@usesend/ui/src/text-with-copy";
+import DeleteSesConfiguration from "./delete-ses-configuration";
 
 export default function SesConfigurations() {
   const sesSettingsQuery = api.admin.getSesSettings.useQuery();
@@ -71,7 +72,10 @@ export default function SesConfigurations() {
                   <TableCell>{sesSetting.sesEmailRateLimit}</TableCell>
                   <TableCell>{sesSetting.transactionalQuota}%</TableCell>
                   <TableCell>
-                    <EditSesConfiguration setting={sesSetting} />
+                    <div className="flex items-center gap-1">
+                      <EditSesConfiguration setting={sesSetting} />
+                      <DeleteSesConfiguration setting={sesSetting} />
+                    </div>
                   </TableCell>
                 </TableRow>
               ))

--- a/apps/web/src/server/api/routers/admin.ts
+++ b/apps/web/src/server/api/routers/admin.ts
@@ -122,6 +122,17 @@ export const adminRouter = createTRPCRouter({
       });
     }),
 
+  deleteSesSettings: adminProcedure
+    .input(
+      z.object({
+        settingsId: z.string(),
+      })
+    )
+    .mutation(async ({ input }) => {
+      await SesSettingsService.deleteSesSetting(input.settingsId);
+      return true;
+    }),
+
   getSetting: adminProcedure
     .input(
       z.object({

--- a/apps/web/src/server/aws/ses.ts
+++ b/apps/web/src/server/aws/ses.ts
@@ -7,6 +7,7 @@ import {
   SendEmailCommand,
   CreateConfigurationSetEventDestinationCommand,
   CreateConfigurationSetCommand,
+  DeleteConfigurationSetCommand,
   EventType,
   GetAccountCommand,
   CreateTenantResourceAssociationCommand,
@@ -309,4 +310,27 @@ export async function addWebhookConfiguration(
 
   const response = await sesClient.send(command);
   return response.$metadata.httpStatusCode === 200;
+}
+
+export async function deleteConfigurationSet(
+  configName: string,
+  region: string
+) {
+  const sesClient = getSesClient(region);
+  const command = new DeleteConfigurationSetCommand({
+    ConfigurationSetName: configName,
+  });
+
+  try {
+    await sesClient.send(command);
+  } catch (error: any) {
+    if (error?.name === "NotFoundException") {
+      logger.warn(
+        { configName, region },
+        "Configuration set not found while deleting"
+      );
+      return;
+    }
+    throw error;
+  }
 }

--- a/apps/web/src/server/service/email-queue-service.ts
+++ b/apps/web/src/server/service/email-queue-service.ts
@@ -108,6 +108,27 @@ export class EmailQueueService {
     }
   }
 
+  public static async removeRegion(region: string) {
+    logger.info({ region }, `[EmailQueueService]: Removing queues for region`);
+
+    const transactionalQueue = this.transactionalQueue.get(region);
+    const transactionalWorker = this.transactionalWorker.get(region);
+    const marketingQueue = this.marketingQueue.get(region);
+    const marketingWorker = this.marketingWorker.get(region);
+
+    await Promise.all([
+      transactionalWorker?.close(),
+      transactionalQueue?.close(),
+      marketingWorker?.close(),
+      marketingQueue?.close(),
+    ]);
+
+    this.transactionalQueue.delete(region);
+    this.transactionalWorker.delete(region);
+    this.marketingQueue.delete(region);
+    this.marketingWorker.delete(region);
+  }
+
   public static async queueEmail(
     emailId: string,
     teamId: number,


### PR DESCRIPTION
## Summary
- add a delete action to the SES configuration table so admins can remove settings from the UI
- expose a deleteSesSettings mutation that tears down SNS topics/configuration sets, clears queues, and drops the DB record
- allow EmailQueueService to drop per-region queues/workers so deleted regions no longer dispatch mail

## Testing
- pnpm lint *(fails: existing warnings in packages/ui lint task)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a286605c883298f53afe3d1154249)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a delete action for SES configurations in the admin dashboard. Deleting a configuration cleans up SES/SNS resources, stops regional queues, and removes the database record.

- **New Features**
  - Added delete button with confirmation dialog in the SES configurations table.
  - New admin.deleteSesSettings mutation to delete a setting by ID.
  - SES: added deleteConfigurationSet helper (handles NotFoundException).
  - SesSettingsService.deleteSesSetting: deletes SES config sets and SNS topic, removes region queues, deletes DB row, and invalidates cache.
  - EmailQueueService.removeRegion: closes and removes per-region queues/workers.

<sup>Written for commit a5b2f0ff11f24ef9d9b71d28048c9f9e59544570. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now delete SES email configurations with a confirmation dialog for safety.
  * Automatic cleanup of email queues, configuration sets, and related resources upon deletion.
  * Delete option available alongside edit functionality in the configurations list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->