### PR TITLE
fix: update docker node version

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20.11.1-alpine AS base
+FROM node:20.19-alpine AS base
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 ENV SKIP_ENV_VALIDATION="true"

--- a/docker/README.md
+++ b/docker/README.md
@@ -8,6 +8,7 @@ Before you begin, ensure that you have the following installed:
 
 - Docker
 - Docker Compose (if using the Docker Compose setup)
+- Node.js 20.19 or newer (Prisma requires at least v20.19 in the build image)
 
 ## Option 1: Production Docker Compose Setup
 


### PR DESCRIPTION
## Summary
- bump Docker base image to Node 20.19 to satisfy Prisma's minimum version
- document the Node 20.19+ requirement in Docker setup prerequisites

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ea6d6d0f48329807ac2ea6c40d95d)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update Docker base image to Node 20.19-alpine to meet Prisma’s minimum version and prevent build failures. Documented the Node 20.19+ requirement in the Docker setup README.

<sup>Written for commit cef05398592e3a489914c7a48c447f9b4ffd2f25. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker base image to Node.js 20.19 or newer. Developers building Docker images must ensure Node.js 20.19+ is available in their build environment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->