### PR TITLE
Use local Prisma version instead of pnpx

### DIFF
--- a/docker/start.sh
+++ b/docker/start.sh
@@ -4,9 +4,8 @@ set -x
 
 echo "Deploying prisma migrations"
 
-pnpx prisma migrate deploy --schema ./apps/web/prisma/schema.prisma
+./node_modules/.bin/prisma migrate deploy --schema ./apps/web/prisma/schema.prisma
 
 echo "Starting web server"
 
 node apps/web/server.js
-


### PR DESCRIPTION
Should fix the issues with Prisma 7. It will now use the packaged Prisma instead of downloading a new one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved deployment process for database migrations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run Prisma migrations in Docker using the project's local CLI instead of pnpx. This fixes Prisma 7 issues and avoids downloading a mismatched Prisma version during deploy.

<sup>Written for commit 3a23754ed78b7d600f562ce98b278fa9d73353f1. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

