### PR TITLE
docs: add PHP getting started guide

### DIFF
--- a/apps/docs/docs.json
+++ b/apps/docs/docs.json
@@ -28,6 +28,7 @@
               "introduction",
               "get-started/nodejs",
               "get-started/python",
+              "get-started/php",
               "get-started/local",
               "get-started/smtp"
             ]

--- a/apps/docs/get-started/php.mdx
+++ b/apps/docs/get-started/php.mdx
@@ -1,0 +1,105 @@
+---
+title: PHP (API)
+description: "Use the REST API to send emails and manage contacts from PHP."
+icon: php
+---
+
+useSend doesn't ship an official PHP SDK yet, but you can call the REST API with any HTTP client. The examples below use [Guzzle](https://github.com/guzzle/guzzle).
+
+## Prerequisites
+
+- [useSend API key](https://app.usesend.com/dev-settings/api-keys)
+- [Verified domain](https://app.usesend.com/domains)
+- PHP 8.1+ with Composer
+
+## Install an HTTP client
+
+```bash
+composer require guzzlehttp/guzzle
+```
+
+## Configure a reusable client
+
+```php
+<?php
+require __DIR__ . '/vendor/autoload.php';
+
+use GuzzleHttp\\Client;
+
+$apiKey = getenv('USESEND_API_KEY');
+
+$client = new Client([
+    'base_uri' => 'https://app.usesend.com/api/',
+    'headers' => [
+        'Authorization' => "Bearer {$apiKey}",
+        'Content-Type' => 'application/json',
+    ],
+]);
+
+// Self-hosted example:
+// $client = new Client(['base_uri' => 'https://your-self-hosted.example/api/', ...]);
+```
+
+## Send an email
+
+```php
+<?php
+$response = $client->post('v1/emails', [
+    'json' => [
+        'to' => 'hello@example.com',
+        'from' => 'no-reply@yourdomain.com',
+        'subject' => 'Welcome to useSend',
+        'html' => '<p>useSend is the best open source product to send emails</p>',
+        'text' => 'useSend is the best open source product to send emails',
+        'headers' => [
+            'X-Campaign' => 'welcome',
+        ],
+    ],
+]);
+
+$body = json_decode($response->getBody()->getContents(), true);
+```
+
+> Custom headers are forwarded as-is. useSend only manages the `X-Usesend-Email-ID` and `References` headers.
+
+## Create or update contacts
+
+All contact operations require a contact book ID from the [Contacts dashboard](https://app.usesend.com/contacts/).
+
+```php
+<?php
+$bookId = 'contact_book_id';
+
+// Create a contact
+$createResponse = $client->post("v1/contactBooks/{$bookId}/contacts", [
+    'json' => [
+        'email' => 'user@example.com',
+        'firstName' => 'Ada',
+        'properties' => ['plan' => 'pro'],
+    ],
+]);
+
+// Update a contact
+$contactId = 'contact_123';
+$updateResponse = $client->patch("v1/contactBooks/{$bookId}/contacts/{$contactId}", [
+    'json' => [
+        'subscribed' => false,
+    ],
+]);
+```
+
+## Basic error handling
+
+```php
+<?php
+try {
+    $response = $client->get('v1/emails/email_123');
+    $email = json_decode($response->getBody()->getContents(), true);
+} catch (\\GuzzleHttp\\Exception\\ClientException $e) {
+    // 4xx responses
+    error_log($e->getResponse()->getBody()->getContents());
+} catch (\\GuzzleHttp\\Exception\\ServerException $e) {
+    // 5xx responses
+    error_log('Server error: ' . $e->getMessage());
+}
+```


### PR DESCRIPTION
## Summary
- add a PHP getting-started guide that uses the REST API for sending emails and managing contacts
- document setup with Guzzle, email sending, contact operations, and basic error handling
- surface the PHP guide in the Getting Started navigation

## Issues
- None

## Screenshots
- Not applicable

## Migrations
- None

## Verification
- Not run (docs-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a170f5a3083298f3c60178212fb64)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a PHP getting started guide that uses the REST API via Guzzle to send emails and manage contacts, and surfaces it in the Getting Started navigation.

- **New Features**
  - Setup with Composer/Guzzle and a reusable client.
  - Examples for sending emails and creating/updating contacts.
  - Basic error handling patterns.
  - Added “PHP (API)” to the Getting Started nav.

<sup>Written for commit 45c89cbc3464ec7e68cc3ae8a6d066df48675108. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added PHP Getting Started guide covering REST API integration with code examples for email sending and contact management
  * Updated documentation navigation to include the new PHP guide

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->