### PR TITLE
Refact Image Component for TrustedBy Section

### DIFF
--- a/apps/marketing/src/app/page.tsx
+++ b/apps/marketing/src/app/page.tsx
@@ -8,6 +8,7 @@ import { FeatureCard } from "~/components/FeatureCard";
 import { FeatureCardPlain } from "~/components/FeatureCardPlain";
 import { PricingCalculator } from "~/components/PricingCalculator";
 import CodeExample from "~/components/CodeExample";
+import { Avatar, AvatarFallback, AvatarImage } from "@usesend/ui/src/avatar";
 
 const REPO = "usesend/usesend";
 const REPO_URL = `https://github.com/${REPO}`;
@@ -185,13 +186,10 @@ function TrustedBy() {
                 {t.quote}
               </blockquote>
               <div className="mt-5 flex items-center gap-3">
-                <Image
-                  src={t.image}
-                  alt={`${t.author} avatar`}
-                  width={32}
-                  height={32}
-                  className=" rounded-md border-2 border-primary/50"
-                />
+                <Avatar className="rounded-lg border-2 border-primary/50 h-8 w-8">
+                  <AvatarImage src={t.image} alt={`${t.author} avatar`} />
+                  <AvatarFallback className="rounded-lg text-xs">{t.author.charAt(0).toUpperCase()}</AvatarFallback>
+                </Avatar> 
                 <figcaption className="text-sm">
                   <span className="font-medium">{t.author}</span>
                   <a
@@ -219,13 +217,10 @@ function TrustedBy() {
                 {t.quote}
               </blockquote>
               <div className="mt-5 flex items-center gap-3">
-                <Image
-                  src={t.image}
-                  alt={`${t.author} avatar`}
-                  width={32}
-                  height={32}
-                  className=" rounded-md border-2 border-primary/50"
-                />
+                <Avatar className="rounded-lg border-2 border-primary/50 h-8 w-8">
+                  <AvatarImage src={t.image} alt={`${t.author} avatar`} />
+                  <AvatarFallback className="rounded-lg text-xs">{t.author.charAt(0).toUpperCase()}</AvatarFallback>
+                </Avatar>
                 <figcaption className="text-sm">
                   <span className="font-medium">{t.author}</span>
                   <a


### PR DESCRIPTION
### Current 

<img width="1239" height="426" alt="image" src="https://github.com/user-attachments/assets/70a2e8c3-d0ad-440c-a7aa-de1106e8d564" />

### Refactored
<img width="1152" height="348" alt="image" src="https://github.com/user-attachments/assets/b2738b5c-19f2-44e2-8ed1-8dae24c772e7" />

### Changes
@KMKoushik, I have used the avatar component from the UI package.  Issue #296 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored the TrustedBy section to use the UI Avatar component for author photos. Adds fallback initials and consistent sizing/borders for a more reliable, polished display.

- **Refactors**
  - Replaced Image with Avatar, AvatarImage, and AvatarFallback in apps/marketing/src/app/page.tsx.
  - Fallback shows the author’s first initial when the image fails.
  - Standardized size (h-8 w-8) and rounded-lg border-primary/50, keeping alt text intact.

<sup>Written for commit a01212f708c692cb7def0ad393a629587905d89f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced avatar display in testimonials section with improved fallback behavior. Avatars now gracefully display initials when images are unavailable, providing better visual consistency and user experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->