### PR TITLE
chore: rename public API error class

### DIFF
--- a/apps/web/src/server/public-api/api-error.ts
+++ b/apps/web/src/server/public-api/api-error.ts
@@ -59,7 +59,7 @@ function statusToCode(status: StatusCode): z.infer<typeof ErrorCode> {
   }
 }
 
-export class UnsendApiError extends HTTPException {
+export class UseSendApiError extends HTTPException {
   public readonly code: z.infer<typeof ErrorCode>;
 
   constructor({
@@ -78,7 +78,7 @@ export function handleError(err: Error, c: Context): Response {
   /**
    * We can handle this very well, as it is something we threw ourselves
    */
-  if (err instanceof UnsendApiError) {
+  if (err instanceof UseSendApiError) {
     if (err.status >= 500) {
       logger.error(
         { name: err.name, code: err.code, status: err.status, err },

--- a/apps/web/src/server/public-api/api-utils.ts
+++ b/apps/web/src/server/public-api/api-utils.ts
@@ -1,12 +1,12 @@
 import { Context } from "hono";
 import { db } from "../db";
-import { UnsendApiError } from "./api-error";
+import { UseSendApiError } from "./api-error";
 
 export const getContactBook = async (c: Context, teamId: number) => {
   const contactBookId = c.req.param("contactBookId");
 
   if (!contactBookId) {
-    throw new UnsendApiError({
+    throw new UseSendApiError({
       code: "BAD_REQUEST",
       message: "contactBookId is mandatory",
     });
@@ -17,7 +17,7 @@ export const getContactBook = async (c: Context, teamId: number) => {
   });
 
   if (!contactBook) {
-    throw new UnsendApiError({
+    throw new UseSendApiError({
       code: "NOT_FOUND",
       message: "Contact book not found for this team",
     });
@@ -30,7 +30,7 @@ export const checkIsValidEmailId = async (emailId: string, teamId: number) => {
   const email = await db.email.findUnique({ where: { id: emailId, teamId } });
 
   if (!email) {
-    throw new UnsendApiError({ code: "NOT_FOUND", message: "Email not found" });
+    throw new UseSendApiError({ code: "NOT_FOUND", message: "Email not found" });
   }
 };
 
@@ -51,7 +51,7 @@ export const checkIsValidEmailIdWithDomainRestriction = async (
   const email = await db.email.findUnique({ where: whereClause });
 
   if (!email) {
-    throw new UnsendApiError({ code: "NOT_FOUND", message: "Email not found" });
+    throw new UseSendApiError({ code: "NOT_FOUND", message: "Email not found" });
   }
 
   return email;

--- a/apps/web/src/server/public-api/api/contacts/get-contact.ts
+++ b/apps/web/src/server/public-api/api/contacts/get-contact.ts
@@ -2,7 +2,7 @@ import { createRoute, z } from "@hono/zod-openapi";
 import { PublicAPIApp } from "~/server/public-api/hono";
 import { getTeamFromToken } from "~/server/public-api/auth";
 import { db } from "~/server/db";
-import { UnsendApiError } from "../../api-error";
+import { UseSendApiError } from "../../api-error";
 import { getContactBook } from "../../api-utils";
 
 const route = createRoute({
@@ -63,7 +63,7 @@ function getContact(app: PublicAPIApp) {
     });
 
     if (!contact) {
-      throw new UnsendApiError({
+      throw new UseSendApiError({
         code: "NOT_FOUND",
         message: "Contact not found",
       });

--- a/apps/web/src/server/public-api/api/contacts/get-contacts.ts
+++ b/apps/web/src/server/public-api/api/contacts/get-contacts.ts
@@ -2,7 +2,7 @@ import { createRoute, z } from "@hono/zod-openapi";
 import { PublicAPIApp } from "~/server/public-api/hono";
 import { getTeamFromToken } from "~/server/public-api/auth";
 import { db } from "~/server/db";
-import { UnsendApiError } from "../../api-error";
+import { UseSendApiError } from "../../api-error";
 import { getContactBook } from "../../api-utils";
 
 const route = createRoute({

--- a/apps/web/src/server/public-api/api/domains/delete-domain.ts
+++ b/apps/web/src/server/public-api/api/domains/delete-domain.ts
@@ -1,7 +1,7 @@
 import { createRoute, z } from "@hono/zod-openapi";
 import { PublicAPIApp } from "../../hono";
 import { db } from "~/server/db";
-import { UnsendApiError } from "../../api-error";
+import { UseSendApiError } from "../../api-error";
 import { deleteDomain as deleteDomainService } from "~/server/service/domain-service";
 
 const route = createRoute({
@@ -61,7 +61,7 @@ function deleteDomain(app: PublicAPIApp) {
 
     // Enforce API key domain restriction
     if (team.apiKey.domainId && team.apiKey.domainId !== domainId) {
-      throw new UnsendApiError({
+      throw new UseSendApiError({
         code: "FORBIDDEN",
         message: "API key doesn't have access to this domain",
       });
@@ -75,7 +75,7 @@ function deleteDomain(app: PublicAPIApp) {
     });
 
     if (!domain) {
-      throw new UnsendApiError({
+      throw new UseSendApiError({
         code: "NOT_FOUND",
         message: "Domain not found",
       });

--- a/apps/web/src/server/public-api/api/domains/get-domain.ts
+++ b/apps/web/src/server/public-api/api/domains/get-domain.ts
@@ -1,7 +1,7 @@
 import { createRoute, z } from "@hono/zod-openapi";
 import { DomainSchema } from "~/lib/zod/domain-schema";
 import { PublicAPIApp } from "~/server/public-api/hono";
-import { UnsendApiError } from "../../api-error";
+import { UseSendApiError } from "../../api-error";
 import { db } from "~/server/db";
 import { getDomain as getDomainService } from "~/server/service/domain-service";
 
@@ -35,7 +35,7 @@ function getDomain(app: PublicAPIApp) {
 
     // Enforce API key domain restriction (if any)
     if (team.apiKey.domainId && team.apiKey.domainId !== id) {
-      throw new UnsendApiError({
+      throw new UseSendApiError({
         code: "NOT_FOUND",
         message: "Domain not found",
       });
@@ -46,7 +46,7 @@ function getDomain(app: PublicAPIApp) {
     try {
       enriched = await getDomainService(id, team.id);
     } catch (e) {
-      throw new UnsendApiError({
+      throw new UseSendApiError({
         code: "INTERNAL_SERVER_ERROR",
         message: e instanceof Error ? e.message : "Internal server error",
       });

--- a/apps/web/src/server/public-api/api/emails/get-email.ts
+++ b/apps/web/src/server/public-api/api/emails/get-email.ts
@@ -3,7 +3,7 @@ import { PublicAPIApp } from "~/server/public-api/hono";
 import { getTeamFromToken } from "~/server/public-api/auth";
 import { db } from "~/server/db";
 import { EmailStatus } from "@prisma/client";
-import { UnsendApiError } from "../../api-error";
+import { UseSendApiError } from "../../api-error";
 
 const route = createRoute({
   method: "get",
@@ -88,7 +88,7 @@ function send(app: PublicAPIApp) {
     });
 
     if (!email) {
-      throw new UnsendApiError({
+      throw new UseSendApiError({
         code: "NOT_FOUND",
         message: "Email not found",
       });

--- a/apps/web/src/server/public-api/auth.ts
+++ b/apps/web/src/server/public-api/auth.ts
@@ -1,6 +1,6 @@
 import { Context } from "hono";
 import { db } from "../db";
-import { UnsendApiError } from "./api-error";
+import { UseSendApiError } from "./api-error";
 import { getTeamAndApiKey } from "../service/api-service";
 import { isSelfHosted } from "~/utils/common";
 import { logger } from "../logger/log";
@@ -12,7 +12,7 @@ export const getTeamFromToken = async (c: Context) => {
   const authHeader = c.req.header("Authorization");
 
   if (!authHeader) {
-    throw new UnsendApiError({
+    throw new UseSendApiError({
       code: "UNAUTHORIZED",
       message: "No Authorization header provided",
     });
@@ -21,7 +21,7 @@ export const getTeamFromToken = async (c: Context) => {
   const token = authHeader.split(" ")[1];
 
   if (!token) {
-    throw new UnsendApiError({
+    throw new UseSendApiError({
       code: "UNAUTHORIZED",
       message: "No Authorization header provided",
     });
@@ -30,7 +30,7 @@ export const getTeamFromToken = async (c: Context) => {
   const teamAndApiKey = await getTeamAndApiKey(token);
 
   if (!teamAndApiKey) {
-    throw new UnsendApiError({
+    throw new UseSendApiError({
       code: "FORBIDDEN",
       message: "Invalid API token",
     });
@@ -39,7 +39,7 @@ export const getTeamFromToken = async (c: Context) => {
   const { team, apiKey } = teamAndApiKey;
 
   if (!team) {
-    throw new UnsendApiError({
+    throw new UseSendApiError({
       code: "FORBIDDEN",
       message: "Invalid API token",
     });

--- a/apps/web/src/server/public-api/hono.ts
+++ b/apps/web/src/server/public-api/hono.ts
@@ -6,7 +6,7 @@ import { env } from "~/env";
 import { getRedis } from "~/server/redis";
 import { getTeamFromToken } from "~/server/public-api/auth";
 import { isSelfHosted } from "~/utils/common";
-import { UnsendApiError } from "./api-error";
+import { UseSendApiError } from "./api-error";
 import { Team, ApiKey } from "@prisma/client";
 import { logger } from "../logger/log";
 
@@ -36,11 +36,11 @@ export function getApp() {
       const team = await getTeamFromToken(c as any);
       c.set("team", team);
     } catch (error) {
-      if (error instanceof UnsendApiError) {
+      if (error instanceof UseSendApiError) {
         throw error;
       }
       logger.error({ err: error }, "Error in getTeamFromToken middleware");
-      throw new UnsendApiError({
+      throw new UseSendApiError({
         code: "INTERNAL_SERVER_ERROR",
         message: "Authentication failed",
       });
@@ -104,7 +104,7 @@ export function getApp() {
         "Retry-After",
         String(ttl > 0 ? ttl : RATE_LIMIT_WINDOW_SECONDS)
       );
-      throw new UnsendApiError({
+      throw new UseSendApiError({
         code: "RATE_LIMITED",
         message: `Rate limit exceeded. Try again in ${ttl > 0 ? ttl : RATE_LIMIT_WINDOW_SECONDS} seconds.`,
       });

--- a/apps/web/src/server/public-api/schemas/campaign-schema.ts
+++ b/apps/web/src/server/public-api/schemas/campaign-schema.ts
@@ -1,6 +1,6 @@
 import { z } from "@hono/zod-openapi";
 import * as chrono from "chrono-node";
-import { UnsendApiError } from "../api-error";
+import { UseSendApiError } from "../api-error";
 
 const stringOrStringArray = z.union([
   z.string().min(1),
@@ -22,7 +22,7 @@ export const parseScheduledAt = (scheduledAt?: string): Date | undefined => {
     return chronoDate;
   }
 
-  throw new UnsendApiError({
+  throw new UseSendApiError({
     code: "BAD_REQUEST",
     message: `Invalid date format: ${scheduledAt}. Use ISO 8601 format or natural language like 'tomorrow 9am'.`,
   });

--- a/apps/web/src/server/service/campaign-service.ts
+++ b/apps/web/src/server/service/campaign-service.ts
@@ -18,7 +18,7 @@ import {
 import { logger } from "../logger/log";
 import { createWorkerHandler, TeamJob } from "../queue/bullmq-context";
 import { SuppressionService } from "./suppression-service";
-import { UnsendApiError } from "../public-api/api-error";
+import { UseSendApiError } from "../public-api/api-error";
 import {
   validateApiKeyDomainAccess,
   validateDomainFromEmail,
@@ -190,7 +190,7 @@ export async function createCampaignFromApi({
   batchSize?: number;
 }) {
   if (!content && !html) {
-    throw new UnsendApiError({
+    throw new UseSendApiError({
       code: "BAD_REQUEST",
       message: "Either content or html must be provided",
     });
@@ -201,7 +201,7 @@ export async function createCampaignFromApi({
       JSON.parse(content);
     } catch (error) {
       logger.error({ err: error }, "Invalid campaign content JSON from API");
-      throw new UnsendApiError({
+      throw new UseSendApiError({
         code: "BAD_REQUEST",
         message: "Invalid content JSON",
       });
@@ -214,7 +214,7 @@ export async function createCampaignFromApi({
   });
 
   if (!contactBook) {
-    throw new UnsendApiError({
+    throw new UseSendApiError({
       code: "BAD_REQUEST",
       message: "Contact book not found",
     });
@@ -229,7 +229,7 @@ export async function createCampaignFromApi({
     });
 
     if (!apiKey || apiKey.teamId !== teamId) {
-      throw new UnsendApiError({
+      throw new UseSendApiError({
         code: "FORBIDDEN",
         message: "Invalid API key",
       });
@@ -249,7 +249,7 @@ export async function createCampaignFromApi({
   );
 
   if (!unsubPlaceholderFound) {
-    throw new UnsendApiError({
+    throw new UseSendApiError({
       code: "BAD_REQUEST",
       message: "Campaign must include an unsubscribe link before sending",
     });
@@ -319,7 +319,7 @@ export async function getCampaignForTeam({
   });
 
   if (!campaign) {
-    throw new UnsendApiError({
+    throw new UseSendApiError({
       code: "NOT_FOUND",
       message: "Campaign not found",
     });
@@ -396,7 +396,7 @@ export async function scheduleCampaign({
     where: { id: campaignId, teamId },
   });
   if (!campaign) {
-    throw new UnsendApiError({
+    throw new UseSendApiError({
       code: "NOT_FOUND",
       message: "Campaign not found",
     });
@@ -408,21 +408,21 @@ export async function scheduleCampaign({
     campaign = prepared.campaign;
     html = prepared.html;
   } catch (err) {
-    throw new UnsendApiError({
+    throw new UseSendApiError({
       code: "BAD_REQUEST",
       message: err instanceof Error ? err.message : "Invalid campaign content",
     });
   }
 
   if (!campaign.contactBookId) {
-    throw new UnsendApiError({
+    throw new UseSendApiError({
       code: "BAD_REQUEST",
       message: "No contact book found for campaign",
     });
   }
 
   if (!html) {
-    throw new UnsendApiError({
+    throw new UseSendApiError({
       code: "BAD_REQUEST",
       message: "No HTML content for campaign",
     });
@@ -433,7 +433,7 @@ export async function scheduleCampaign({
     html
   );
   if (!unsubPlaceholderFound) {
-    throw new UnsendApiError({
+    throw new UseSendApiError({
       code: "BAD_REQUEST",
       message: "Campaign must include an unsubscribe link before scheduling",
     });
@@ -445,7 +445,7 @@ export async function scheduleCampaign({
   });
 
   if (total === 0) {
-    throw new UnsendApiError({
+    throw new UseSendApiError({
       code: "BAD_REQUEST",
       message: "No subscribed contacts to send",
     });
@@ -486,7 +486,7 @@ export async function pauseCampaign({
   });
 
   if (!campaign) {
-    throw new UnsendApiError({
+    throw new UseSendApiError({
       code: "NOT_FOUND",
       message: "Campaign not found",
     });
@@ -512,7 +512,7 @@ export async function resumeCampaign({
   });
 
   if (!campaign) {
-    throw new UnsendApiError({
+    throw new UseSendApiError({
       code: "NOT_FOUND",
       message: "Campaign not found",
     });

--- a/apps/web/src/server/service/contact-book-service.ts
+++ b/apps/web/src/server/service/contact-book-service.ts
@@ -1,7 +1,7 @@
 import { CampaignStatus, type ContactBook } from "@prisma/client";
 import { db } from "../db";
 import { LimitService } from "./limit-service";
-import { UnsendApiError } from "../public-api/api-error";
+import { UseSendApiError } from "../public-api/api-error";
 
 export async function getContactBooks(teamId: number, search?: string) {
   return db.contactBook.findMany({
@@ -22,7 +22,7 @@ export async function createContactBook(teamId: number, name: string) {
     await LimitService.checkContactBookLimit(teamId);
 
   if (isLimitReached) {
-    throw new UnsendApiError({
+    throw new UseSendApiError({
       code: "FORBIDDEN",
       message: reason ?? "Contact book limit reached",
     });

--- a/apps/web/src/server/service/domain-service.ts
+++ b/apps/web/src/server/service/domain-service.ts
@@ -4,7 +4,7 @@ import * as tldts from "tldts";
 import * as ses from "~/server/aws/ses";
 import { db } from "~/server/db";
 import { SesSettingsService } from "./ses-settings-service";
-import { UnsendApiError } from "../public-api/api-error";
+import { UseSendApiError } from "../public-api/api-error";
 import { logger } from "../logger/log";
 import { ApiKey, DomainStatus, type Domain } from "@prisma/client";
 import { LimitService } from "./limit-service";
@@ -100,7 +100,7 @@ export async function validateDomainFromEmail(email: string, teamId: number) {
   }
 
   if (!fromDomain) {
-    throw new UnsendApiError({
+    throw new UseSendApiError({
       code: "BAD_REQUEST",
       message: "From email is invalid",
     });
@@ -111,14 +111,14 @@ export async function validateDomainFromEmail(email: string, teamId: number) {
   });
 
   if (!domain) {
-    throw new UnsendApiError({
+    throw new UseSendApiError({
       code: "BAD_REQUEST",
       message: `Domain: ${fromDomain} of from email is wrong. Use the domain verified by useSend`,
     });
   }
 
   if (domain.status !== "SUCCESS") {
-    throw new UnsendApiError({
+    throw new UseSendApiError({
       code: "BAD_REQUEST",
       message: `Domain: ${fromDomain} is not verified`,
     });
@@ -142,7 +142,7 @@ export async function validateApiKeyDomainAccess(
 
   // If API key is restricted to a specific domain, check if it matches
   if (apiKey.domainId !== domain.id) {
-    throw new UnsendApiError({
+    throw new UseSendApiError({
       code: "FORBIDDEN",
       message: `API key does not have access to domain: ${domain.name}`,
     });
@@ -175,7 +175,7 @@ export async function createDomain(
     await LimitService.checkDomainLimit(teamId);
 
   if (isLimitReached) {
-    throw new UnsendApiError({
+    throw new UseSendApiError({
       code: "FORBIDDEN",
       message: reason ?? "Domain limit reached",
     });
@@ -216,7 +216,7 @@ export async function getDomain(id: number, teamId: number) {
   });
 
   if (!domain) {
-    throw new UnsendApiError({
+    throw new UseSendApiError({
       code: "NOT_FOUND",
       message: "Domain not found",
     });

--- a/apps/web/src/server/service/email-service.ts
+++ b/apps/web/src/server/service/email-service.ts
@@ -1,6 +1,6 @@
 import { EmailContent } from "~/types";
 import { db } from "../db";
-import { UnsendApiError } from "~/server/public-api/api-error";
+import { UseSendApiError } from "~/server/public-api/api-error";
 import { EmailQueueService } from "./email-queue-service";
 import {
   validateDomainFromEmail,
@@ -18,7 +18,7 @@ async function checkIfValidEmail(emailId: string) {
   });
 
   if (!email || !email.domainId) {
-    throw new UnsendApiError({
+    throw new UseSendApiError({
       code: "BAD_REQUEST",
       message: "Email not found",
     });
@@ -29,7 +29,7 @@ async function checkIfValidEmail(emailId: string) {
   });
 
   if (!domain) {
-    throw new UnsendApiError({
+    throw new UseSendApiError({
       code: "BAD_REQUEST",
       message: "Email not found",
     });
@@ -86,7 +86,7 @@ export async function sendEmail(
     });
 
     if (!apiKey) {
-      throw new UnsendApiError({
+      throw new UseSendApiError({
         code: "BAD_REQUEST",
         message: "Invalid API key",
       });
@@ -227,7 +227,7 @@ export async function sendEmail(
     });
 
     if (!email) {
-      throw new UnsendApiError({
+      throw new UseSendApiError({
         code: "BAD_REQUEST",
         message: '"inReplyTo" is invalid',
       });
@@ -235,7 +235,7 @@ export async function sendEmail(
   }
 
   if (!text && !html) {
-    throw new UnsendApiError({
+    throw new UseSendApiError({
       code: "BAD_REQUEST",
       message: "Either text or html is required",
     });
@@ -312,7 +312,7 @@ export async function updateEmail(
   const { email, domain } = await checkIfValidEmail(emailId);
 
   if (email.latestStatus !== "SCHEDULED") {
-    throw new UnsendApiError({
+    throw new UseSendApiError({
       code: "BAD_REQUEST",
       message: "Email already processed",
     });
@@ -337,7 +337,7 @@ export async function cancelEmail(emailId: string) {
   const { email, domain } = await checkIfValidEmail(emailId);
 
   if (email.latestStatus !== "SCHEDULED") {
-    throw new UnsendApiError({
+    throw new UseSendApiError({
       code: "BAD_REQUEST",
       message: "Email already processed",
     });
@@ -374,14 +374,14 @@ export async function sendBulkEmails(
   >
 ) {
   if (emailContents.length === 0) {
-    throw new UnsendApiError({
+    throw new UseSendApiError({
       code: "BAD_REQUEST",
       message: "No emails provided for bulk send",
     });
   }
 
   if (emailContents.length > 100) {
-    throw new UnsendApiError({
+    throw new UseSendApiError({
       code: "BAD_REQUEST",
       message: "Cannot send more than 100 emails in a single bulk request",
     });
@@ -690,7 +690,7 @@ export async function sendBulkEmails(
       }
 
       if (!text && !html) {
-        throw new UnsendApiError({
+        throw new UseSendApiError({
           code: "BAD_REQUEST",
           message: `Either text or html is required for email to ${to}`,
         });
@@ -748,7 +748,7 @@ export async function sendBulkEmails(
   }
 
   if (queueJobs.length === 0) {
-    throw new UnsendApiError({
+    throw new UseSendApiError({
       code: "INTERNAL_SERVER_ERROR",
       message: "Failed to create any email records",
     });

--- a/apps/web/src/server/service/idempotency-service.ts
+++ b/apps/web/src/server/service/idempotency-service.ts
@@ -1,6 +1,6 @@
 import { getRedis } from "~/server/redis";
 import { canonicalizePayload } from "~/server/utils/idempotency";
-import { UnsendApiError } from "~/server/public-api/api-error";
+import { UseSendApiError } from "~/server/public-api/api-error";
 import { logger } from "~/server/logger/log";
 
 const IDEMPOTENCY_RESULT_TTL_SECONDS = 24 * 60 * 60; // 24h
@@ -98,7 +98,7 @@ export const IdempotencyService = {
 
     // Validate idempotency key length
     if (idemKey !== undefined && (idemKey.length < 1 || idemKey.length > 256)) {
-      throw new UnsendApiError({
+      throw new UseSendApiError({
         code: "BAD_REQUEST",
         message: "Invalid Idempotency-Key length",
       });
@@ -120,7 +120,7 @@ export const IdempotencyService = {
         return formatCachedResponse(existing.emailIds);
       }
 
-      throw new UnsendApiError({
+      throw new UseSendApiError({
         code: "NOT_UNIQUE",
         message: "Idempotency-Key already used with a different payload",
       });
@@ -140,13 +140,13 @@ export const IdempotencyService = {
           return formatCachedResponse(again.emailIds);
         }
 
-        throw new UnsendApiError({
+        throw new UseSendApiError({
           code: "NOT_UNIQUE",
           message: "Idempotency-Key already used with a different payload",
         });
       }
 
-      throw new UnsendApiError({
+      throw new UseSendApiError({
         code: "NOT_UNIQUE",
         message:
           "Request with same Idempotency-Key is in progress. Retry later.",

--- a/apps/web/src/server/service/suppression-service.ts
+++ b/apps/web/src/server/service/suppression-service.ts
@@ -1,6 +1,6 @@
 import { SuppressionReason, SuppressionList } from "@prisma/client";
 import { db } from "../db";
-import { UnsendApiError } from "~/server/public-api/api-error";
+import { UseSendApiError } from "~/server/public-api/api-error";
 import { logger } from "../logger/log";
 
 export type AddSuppressionParams = {
@@ -79,7 +79,7 @@ export class SuppressionService {
         "Failed to add email to suppression list"
       );
 
-      throw new UnsendApiError({
+      throw new UseSendApiError({
         code: "INTERNAL_SERVER_ERROR",
         message: "Failed to add email to suppression list",
       });
@@ -166,7 +166,7 @@ export class SuppressionService {
         "Failed to remove email from suppression list"
       );
 
-      throw new UnsendApiError({
+      throw new UseSendApiError({
         code: "INTERNAL_SERVER_ERROR",
         message: "Failed to remove email from suppression list",
       });
@@ -230,7 +230,7 @@ export class SuppressionService {
         "Failed to get suppression list"
       );
 
-      throw new UnsendApiError({
+      throw new UseSendApiError({
         code: "INTERNAL_SERVER_ERROR",
         message: "Failed to get suppression list",
       });
@@ -292,7 +292,7 @@ export class SuppressionService {
         "Failed to add multiple emails to suppression list"
       );
 
-      throw new UnsendApiError({
+      throw new UseSendApiError({
         code: "INTERNAL_SERVER_ERROR",
         message: "Failed to add multiple emails to suppression list",
       });
@@ -332,7 +332,7 @@ export class SuppressionService {
         "Failed to get suppression stats"
       );
 
-      throw new UnsendApiError({
+      throw new UseSendApiError({
         code: "INTERNAL_SERVER_ERROR",
         message: "Failed to get suppression stats",
       });

--- a/apps/web/src/server/service/team-service.ts
+++ b/apps/web/src/server/service/team-service.ts
@@ -4,7 +4,7 @@ import { db } from "~/server/db";
 import { sendMail, sendTeamInviteEmail } from "~/server/mailer";
 import { logger } from "~/server/logger/log";
 import type { Prisma, Team, TeamInvite } from "@prisma/client";
-import { UnsendApiError } from "../public-api/api-error";
+import { UseSendApiError } from "../public-api/api-error";
 import { getRedis } from "~/server/redis";
 import { LimitReason } from "~/lib/constants/plans";
 import { LimitService } from "./limit-service";
@@ -164,7 +164,7 @@ export class TeamService {
 
     const { isLimitReached } = await LimitService.checkTeamMemberLimit(teamId);
     if (isLimitReached) {
-      throw new UnsendApiError({
+      throw new UseSendApiError({
         code: "FORBIDDEN",
         message: "Team invite limit reached",
       });


### PR DESCRIPTION
## Summary
- rename the public API error class from `UnsendApiError` to `UseSendApiError` and update all usages

## Linked Issues
- None

## Screenshots
- N/A (no UI changes)

## Migration Notes
- None

## Verification
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69334aa4a1a083298042a7b25d1f3452)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the public API error class from UnsendApiError to UseSendApiError across the codebase. This is a naming cleanup with no behavior changes.

- **Refactors**
  - Updated imports, throws, and instanceof checks in public API routes, auth, middleware, and services.
  - Updated handleError to recognize UseSendApiError.

<sup>Written for commit a924a49db92eaccb8c29894c8394a251eff8480e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Internal code updates with no user-facing changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->