### PR TITLE
Fix version display in side navigation

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,20 +30,20 @@ RUN apk add --no-cache libc6-compat
 RUN apk update
 WORKDIR /app
 
-# Build arguments for version information
-ARG APP_VERSION=unknown
-ARG GIT_SHA=unknown
-
-# Set version as environment variables for Next.js build
-ENV NEXT_PUBLIC_APP_VERSION=$APP_VERSION
-ENV NEXT_PUBLIC_GIT_SHA=$GIT_SHA
-
 # First install the dependencies (as they change less often)
 COPY .gitignore .gitignore
 COPY --from=builder /app/out/json/ .
 COPY --from=builder /app/out/pnpm-lock.yaml ./pnpm-lock.yaml
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile
 
+# Build arguments for version information
+# Placed after install to preserve dependency cache when version changes
+ARG APP_VERSION=unknown
+ARG GIT_SHA=unknown
+
+# Set version as environment variables for Next.js build
+ENV NEXT_PUBLIC_APP_VERSION=$APP_VERSION
+ENV NEXT_PUBLIC_GIT_SHA=$GIT_SHA
 
 # Build the project
 COPY --from=builder /app/out/full/ .


### PR DESCRIPTION
The NEXT_PUBLIC_APP_VERSION and NEXT_PUBLIC_GIT_SHA environment variables need to be available during the Next.js build process to be embedded in the client-side bundle. Previously, they were only defined in the runner stage, after the build had already completed.

This moves the ARG and ENV declarations from the runner stage to the installer stage, before the build command runs, ensuring the version information is properly embedded in the built application.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes version display in the side navigation by ensuring NEXT_PUBLIC_APP_VERSION and NEXT_PUBLIC_GIT_SHA are set during the Next.js build. Moves ARG/ENV to the installer stage after pnpm install to embed the values and preserve Docker layer caching.

<sup>Written for commit b79809d98a9430b40d9f13695eabb094cfe56abf. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Introduced build-time version metadata (app version and commit SHA) and exposed it during the build process.
  * Removed duplicate version declarations from the final runtime image so version info is not propagated at runtime.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->