### PR TITLE
Hide infinity percentage when no emails sent

### DIFF
--- a/apps/web/src/app/(dashboard)/dashboard/email-chart.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/email-chart.tsx
@@ -286,7 +286,7 @@ const DashboardItemCard: React.FC<DashboardItemCardProps> = ({
         <div className="text-foreground font-light text-2xl  font-mono">
           {count}
         </div>
-        {status !== "total" ? (
+        {status !== "total" && isFinite(percentage) ? (
           <div className="text-sm pb-1">
             {count > 0 ? (percentage * 100).toFixed(0) : 0}%
           </div>
@@ -337,7 +337,7 @@ const EmailChartItem: React.FC<DashboardItemCardProps> = ({
         <div className="mt-1 -ml-0.5 ">
           <span className="text-xl font-mono">{count}</span>
           <span className="text-xs ml-2 font-mono">
-            {status !== "total"
+            {status !== "total" && isFinite(percentage)
               ? `(${count > 0 ? (percentage * 100).toFixed(0) : 0}%)`
               : null}
           </span>


### PR DESCRIPTION
When there are clicks or opens but no emails sent in the period, the percentage calculation results in Infinity. This fix hides the percentage display when it's not a finite number.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide the percentage in the email chart when the computed value is not finite, preventing "Infinity%" when there are clicks/opens but zero emails sent.
Adds an isFinite(percentage) check to non-"total" stats in DashboardItemCard and EmailChartItem.

<sup>Written for commit c45e30b34a7d77ea265327b064067f5434781e1a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where invalid percentage values could display in the email chart by adding validation to ensure only finite numbers are rendered.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->