### PR TITLE
Fix bar chart hover on zero delivery days

### DIFF
--- a/apps/web/src/app/(dashboard)/dashboard/email-chart.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/email-chart.tsx
@@ -151,7 +151,16 @@ export default function EmailChart({ days, domain }: EmailChartProps) {
                     number
                   > & { date: string };
 
-                  if (!data || !data.sent || data.sent === 0) return null;
+                  if (!data) return null;
+
+                  const hasAnyData =
+                    (data.delivered || 0) > 0 ||
+                    (data.bounced || 0) > 0 ||
+                    (data.complained || 0) > 0 ||
+                    (data.opened || 0) > 0 ||
+                    (data.clicked || 0) > 0;
+
+                  if (!hasAnyData) return null;
 
                   return (
                     <div className=" bg-background border shadow-lg p-2 rounded-xl flex flex-col gap-2 px-4">


### PR DESCRIPTION
Fixed tooltip not appearing when hovering over days with 0 delivered emails but non-zero opened/clicked metrics. Added defensive checks to handle edge cases in payload structure and improved null handling for data.sent validation.

- Added payload existence and length validation before accessing
- Improved data.sent null/undefined handling
- Ensures tooltip appears correctly for all valid data points



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed the email chart tooltip so it shows on days with 0 delivered emails when other metrics exist. Added payload/length guards and replaced the sent-based check with an any-metric check (delivered, bounced, complained, opened, clicked) to safely render valid tooltips.

<sup>Written for commit ea0776f9bd87871ad1d22ee49545f76caf68ccc7. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved email chart stability by adding proper validation for missing or empty data. Fixed an issue where the chart could render incorrectly when sent count information was unavailable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->