### PR TITLE
docs: add v1.9.x changelog entry

### DIFF
--- a/apps/docs/changelog.mdx
+++ b/apps/docs/changelog.mdx
@@ -3,29 +3,23 @@ title: "Changelog"
 description: "Product updates and announcements from Unsend"
 ---
 
-<Update label="March 2026" description="v1.9.x">
+<Update label="March 2026" description="v1.9.0">
 
 ### Campaign Personalization with Contact Books
 
-Campaigns now support contact-book variable registry for personalization, so you can compose messages with richer recipient data.
+Personalize campaigns with contact-book variables so each message can include richer subscriber data.
 
 ### Double Opt-In Customization
 
-Double opt-in now supports customizable confirmation flows and copy to better match your onboarding and compliance needs.
+Customize the double opt-in experience with your own confirmation flow and messaging.
 
 ### API and SDK Coverage
 
-Contact book support was expanded in the SDK, dashboard analytics is now available in both the public API and SDK, and a public endpoint to delete campaigns was added.
+The API and SDK now cover more of your workflow, including contact books, dashboard analytics, and campaign deletion.
 
 ### Webhook Filtering by Domain
 
-Webhooks now support multi-domain filtering, making it easier to route and monitor events per domain.
-
-### Other improvements
-
-- Added `REDIS_KEY_PREFIX` for Redis ACL namespace isolation.
-- Submit contact add form with `Cmd/Ctrl+Enter`.
-- Restored contact search behavior after pagination.
+Filter webhooks by multiple domains to keep event routing and monitoring organized across projects.
 
 </Update>
 

--- a/apps/docs/changelog.mdx
+++ b/apps/docs/changelog.mdx
@@ -3,6 +3,32 @@ title: "Changelog"
 description: "Product updates and announcements from Unsend"
 ---
 
+<Update label="March 2026" description="v1.9.x">
+
+### Campaign Personalization with Contact Books
+
+Campaigns now support contact-book variable registry for personalization, so you can compose messages with richer recipient data.
+
+### Double Opt-In Customization
+
+Double opt-in now supports customizable confirmation flows and copy to better match your onboarding and compliance needs.
+
+### API and SDK Coverage
+
+Contact book support was expanded in the SDK, dashboard analytics is now available in both the public API and SDK, and a public endpoint to delete campaigns was added.
+
+### Webhook Filtering by Domain
+
+Webhooks now support multi-domain filtering, making it easier to route and monitor events per domain.
+
+### Other improvements
+
+- Added `REDIS_KEY_PREFIX` for Redis ACL namespace isolation.
+- Submit contact add form with `Cmd/Ctrl+Enter`.
+- Restored contact search behavior after pagination.
+
+</Update>
+
 <Update label="February 2025" description="v1.8.0">
 
 <Frame>

--- a/apps/docs/changelog.mdx
+++ b/apps/docs/changelog.mdx
@@ -7,19 +7,19 @@ description: "Product updates and announcements from Unsend"
 
 ### Campaign Personalization with Contact Books
 
-Personalize campaigns with contact-book variables so each message can include richer subscriber data.
+Campaigns now support contact-book variables for personalization, so you can tailor each message with richer subscriber data.
 
 ### Double Opt-In Customization
 
-Customize the double opt-in experience with your own confirmation flow and messaging.
+Double opt-in now supports customizable confirmation flows and copy, making it easier to match your onboarding experience and compliance requirements.
 
 ### API and SDK Coverage
 
-The API and SDK now cover more of your workflow, including contact books, dashboard analytics, and campaign deletion.
+Contact book support has been expanded in the SDK, dashboard analytics is now available in both the public API and SDK, and a public endpoint to delete campaigns has been added.
 
 ### Webhook Filtering by Domain
 
-Filter webhooks by multiple domains to keep event routing and monitoring organized across projects.
+Webhooks now support multi-domain filtering, making it easier to route, monitor, and manage events across different projects.
 
 </Update>
 


### PR DESCRIPTION
## Summary
- add a new March 2026 `v1.9.x` changelog section to `apps/docs/changelog.mdx`
- capture the main additions from `v1.9.0` and `v1.9.1` (campaign personalization, double opt-in customization, broader API/SDK coverage, and multi-domain webhook filters)
- include notable supporting improvements such as Redis key prefix support and key UX/search fixes

## Testing
- not run (docs-only change)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add the March 2026 v1.9.0 changelog to `apps/docs/changelog.mdx`, with expanded copy covering campaign personalization with contact-book variables, customizable double opt-in, broader API/SDK coverage (contact books, dashboard analytics, campaign deletion), and multi-domain webhook filtering.

<sup>Written for commit ddbd86cff5da5aedc506a53c5f8b9c44822ee850. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Campaign personalization using contact-book variables
  * Double opt-in customization with configurable confirmation flow and copy
  * Expanded contact-book support across the SDK
  * Dashboard analytics available via public API and SDK
  * Public endpoint to delete campaigns
  * Multi-domain filtering for webhooks

* **Bug Fixes**
  * Restored contact search behavior after pagination
<!-- end of auto-generated comment: release notes by coderabbit.ai -->