### PR TITLE
feat: add Sayr bronze sponsor

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,8 +128,8 @@ We are grateful for the support of our sponsors.
 <a href="https://sayr.io/?utm_source=useSend.com" target="_blank">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://cdn.doras.to/Sayr/Sayr%20white.png" />
-    <source media="(prefers-color-scheme: light)" srcset="https://cdn.doras.to/Sayr/Sayr%20black.png" />
-    <img src="https://cdn.doras.to/Sayr/Sayr%20black.png" alt="Sayr" style="width:180px;height:auto;">
+    <source media="(prefers-color-scheme: light)" srcset="https://cdn.doras.to/Sayr/sayr%20black.png" />
+    <img src="https://cdn.doras.to/Sayr/sayr%20black.png" alt="Sayr" style="width:180px;height:auto;">
   </picture>
 </a>
 

--- a/README.md
+++ b/README.md
@@ -123,6 +123,16 @@ We are grateful for the support of our sponsors.
   <img src="https://usesend.com/coderabbit-wordmark.png" alt="coderabbit.ai" style="width:200px;height:100px;">
 </a>
 
+### Bronze Sponsors
+
+<a href="https://sayr.io/?utm_source=useSend.com" target="_blank">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://cdn.doras.to/Sayr/Sayr%20white.png" />
+    <source media="(prefers-color-scheme: light)" srcset="https://cdn.doras.to/Sayr/Sayr%20black.png" />
+    <img src="https://cdn.doras.to/Sayr/Sayr%20black.png" alt="Sayr" style="width:180px;height:auto;">
+  </picture>
+</a>
+
 ### Other Sponsors
 
 <a href="https://doras.to/?utm_source=useSend.com" target="_blank">

--- a/apps/marketing/next.config.js
+++ b/apps/marketing/next.config.js
@@ -7,6 +7,13 @@ const config = {
   images: {
     // Required for static export if using images
     unoptimized: true,
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "cdn.doras.to",
+        pathname: "/Sayr/**",
+      },
+    ],
   },
   pageExtensions: ["js", "jsx", "md", "mdx", "ts", "tsx"],
 };

--- a/apps/marketing/src/app/page.tsx
+++ b/apps/marketing/src/app/page.tsx
@@ -95,7 +95,7 @@ function Hero() {
               rel="noopener noreferrer"
             >
               <Image
-                src="https://cdn.doras.to/Sayr/Sayr%20black.png"
+                src="https://cdn.doras.to/Sayr/sayr%20black.png"
                 alt="Sayr"
                 width={144}
                 height={40}

--- a/apps/marketing/src/app/page.tsx
+++ b/apps/marketing/src/app/page.tsx
@@ -60,34 +60,56 @@ function Hero() {
           Open source • Self-host in minutes • Free tier
         </p>
 
-        <div className="mt-12 text-center text-xs text-muted-foreground flex flex-col items-center justify-center gap-2">
+        <div className="mt-12 text-center text-xs text-muted-foreground flex flex-col items-center justify-center gap-4">
           <p className="text-xs">Proudly sponsored by</p>
-          <a
-            href="https://coderabbit.ai/?utm_source=useSend.com"
-            target="_blank"
-          >
-            <Image
-              src="/code-rabbit-usesend-dark.svg"
-              alt="Code Rabbit"
-              width={200}
-              height={100}
-              className="dark:hidden"
+          <div className="flex flex-col items-center gap-2">
+            <a
+              href="https://coderabbit.ai/?utm_source=useSend.com"
+              target="_blank"
               rel="noopener noreferrer"
-            />
-          </a>
-          <a
-            href="https://coderabbit.ai/?utm_source=useSend.com"
-            target="_blank"
-          >
-            <Image
-              src="/code-rabbit-usesend-light.svg"
-              alt="Code Rabbit"
-              width={200}
-              height={100}
-              className="hidden dark:block"
+            >
+              <Image
+                src="/code-rabbit-usesend-dark.svg"
+                alt="Code Rabbit"
+                width={200}
+                height={100}
+                className="dark:hidden"
+              />
+              <Image
+                src="/code-rabbit-usesend-light.svg"
+                alt="Code Rabbit"
+                width={200}
+                height={100}
+                className="hidden dark:block"
+              />
+            </a>
+          </div>
+
+          <div className="flex flex-col items-center gap-2">
+            <p className="text-[11px] uppercase tracking-[0.25em] text-muted-foreground/80">
+              Bronze sponsor
+            </p>
+            <a
+              href="https://sayr.io/?utm_source=useSend.com"
+              target="_blank"
               rel="noopener noreferrer"
-            />
-          </a>
+            >
+              <Image
+                src="https://cdn.doras.to/Sayr/Sayr%20black.png"
+                alt="Sayr"
+                width={144}
+                height={40}
+                className="h-10 w-auto dark:hidden"
+              />
+              <Image
+                src="https://cdn.doras.to/Sayr/Sayr%20white.png"
+                alt="Sayr"
+                width={144}
+                height={40}
+                className="hidden h-10 w-auto dark:block"
+              />
+            </a>
+          </div>
         </div>
 
         <div className=" mt-32 mx-auto max-w-5xl">
@@ -189,7 +211,7 @@ function TrustedBy() {
                 <Avatar className="rounded-lg border-2 border-primary/50 h-8 w-8">
                   <AvatarImage src={t.image} alt={`${t.author} avatar`} />
                   <AvatarFallback className="rounded-lg text-xs">{t.author.charAt(0).toUpperCase()}</AvatarFallback>
-                </Avatar> 
+                </Avatar>
                 <figcaption className="text-sm">
                   <span className="font-medium">{t.author}</span>
                   <a

--- a/apps/marketing/src/app/page.tsx
+++ b/apps/marketing/src/app/page.tsx
@@ -85,7 +85,7 @@ function Hero() {
             </a>
           </div>
 
-          <div className="flex flex-col items-center gap-2">
+          <div className="flex flex-col items-center gap-2 mt-4">
             <p className="text-[11px] uppercase tracking-[0.25em] text-muted-foreground/80">
               Bronze sponsor
             </p>
@@ -97,16 +97,16 @@ function Hero() {
               <Image
                 src="https://cdn.doras.to/Sayr/sayr%20black.png"
                 alt="Sayr"
-                width={144}
-                height={40}
-                className="h-10 w-auto dark:hidden"
+                width={80}
+                height={32}
+                className="h-8 w-auto dark:hidden"
               />
               <Image
                 src="https://cdn.doras.to/Sayr/Sayr%20white.png"
                 alt="Sayr"
-                width={144}
-                height={40}
-                className="hidden h-10 w-auto dark:block"
+                width={80}
+                height={32}
+                className="hidden h-8 w-auto dark:block"
               />
             </a>
           </div>
@@ -210,7 +210,9 @@ function TrustedBy() {
               <div className="mt-5 flex items-center gap-3">
                 <Avatar className="rounded-lg border-2 border-primary/50 h-8 w-8">
                   <AvatarImage src={t.image} alt={`${t.author} avatar`} />
-                  <AvatarFallback className="rounded-lg text-xs">{t.author.charAt(0).toUpperCase()}</AvatarFallback>
+                  <AvatarFallback className="rounded-lg text-xs">
+                    {t.author.charAt(0).toUpperCase()}
+                  </AvatarFallback>
                 </Avatar>
                 <figcaption className="text-sm">
                   <span className="font-medium">{t.author}</span>
@@ -241,7 +243,9 @@ function TrustedBy() {
               <div className="mt-5 flex items-center gap-3">
                 <Avatar className="rounded-lg border-2 border-primary/50 h-8 w-8">
                   <AvatarImage src={t.image} alt={`${t.author} avatar`} />
-                  <AvatarFallback className="rounded-lg text-xs">{t.author.charAt(0).toUpperCase()}</AvatarFallback>
+                  <AvatarFallback className="rounded-lg text-xs">
+                    {t.author.charAt(0).toUpperCase()}
+                  </AvatarFallback>
                 </Avatar>
                 <figcaption className="text-sm">
                   <span className="font-medium">{t.author}</span>


### PR DESCRIPTION
## Summary
- add Sayr as a bronze sponsor on the marketing landing page with light and dark logo variants
- allow the marketing app to load the hosted Sayr images from `cdn.doras.to`
- add Sayr to the GitHub-facing sponsor list in `README.md`

## Testing
- not run (not requested)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Sayr as a bronze sponsor on the marketing landing page and in the README, with light/dark logos from the CDN. Updates the sponsor section layout (grouped CodeRabbit logos, “Bronze sponsor” label) and fixes the black logo URL.

- **New Features**
  - Enable remote images from `cdn.doras.to` in Next.js for Sayr logos.

<sup>Written for commit 21505157327b27c1e5275ff996cab0b041a9af26. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Bronze Sponsors subsection to the README.

* **New Features**
  * Added a Bronze sponsor (Sayr) with dark/light mode image support.
  * Improved sponsor area layout: grouped logos and increased spacing for better visual balance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->