### PR TITLE
Fix/domain regex validation

### DIFF
--- a/apps/marketing/src/app/page.tsx
+++ b/apps/marketing/src/app/page.tsx
@@ -324,7 +324,7 @@ function Pricing() {
     "Send up to 3000 emails per month",
     "Send up to 100 emails per day",
     "Can have 1 contact book",
-    "Can have 1 domain",
+    " ",
     "Can have 1 team member",
   ];
 

--- a/apps/marketing/src/app/page.tsx
+++ b/apps/marketing/src/app/page.tsx
@@ -324,7 +324,7 @@ function Pricing() {
     "Send up to 3000 emails per month",
     "Send up to 100 emails per day",
     "Can have 1 contact book",
-    " ",
+    "Can have 1 domain",
     "Can have 1 team member",
   ];
 

--- a/apps/web/src/app/wait-list/schema.ts
+++ b/apps/web/src/app/wait-list/schema.ts
@@ -6,11 +6,15 @@ export const WAITLIST_EMAIL_TYPES = [
 ] as const;
 
 export const waitlistSubmissionSchema = z.object({
-  domain: z
-    .string({ required_error: "Domain is required" })
-    .trim()
-    .min(1, "Domain is required")
-    .max(255, "Domain must be 255 characters or fewer"),
+ domain: z
+  .string({ required_error: "Domain is required" })
+  .trim()
+  .min(1, "Domain is required")
+  .max(255, "Domain must be 255 characters or fewer")
+  .regex(
+    /^(?!:\/\/)([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}$/,
+    "Please enter a valid domain (e.g. example.com)"
+  ),
   emailTypes: z
     .array(z.enum(WAITLIST_EMAIL_TYPES))
     .min(1, "Select at least one email type"),


### PR DESCRIPTION
## Summary

This PR adds regex validation to the waitlist domain field to prevent invalid inputs such as `.com`, `https://test`, or `test`.

## Changes

* Added regex validation to the `domain` field in `waitlistSubmissionSchema`
* Ensures only valid domain formats (e.g., `example.com`, `company.co.in`) are accepted
* Preserves existing length and required validations

## Testing

Tested locally using the waitlist form.

Invalid inputs (rejected):

* `.com`
* `https://test`
* `test`

Valid inputs (accepted):

* `example.com`
* `company.co.in`

## Related Issue

Fixes #307


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add strict domain validation to the waitlist form to block malformed inputs and only allow real domains (e.g., example.com). Existing required and length checks remain.

- **Bug Fixes**
  - Validate `domain` in `waitlistSubmissionSchema` with regex `^(?!:\/\/)([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}$`.
  - Rejects `.com`, `https://test`, `test`; accepts `example.com`, `company.co.in`.
  - Shows a clear error: "Please enter a valid domain (e.g. example.com)".

<sup>Written for commit d2c2ff5131d688b6c853470c82b1dadac1bc20a6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced domain field validation in the waitlist submission form to enforce proper domain formatting and reject invalid formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->