### PR TITLE
fix: configure GitHub OAuth issuer

### DIFF
--- a/apps/web/src/server/auth.ts
+++ b/apps/web/src/server/auth.ts
@@ -14,6 +14,8 @@ import { sendSignUpEmail } from "~/server/mailer";
 import { env } from "~/env";
 import { db } from "~/server/db";
 
+const GITHUB_OAUTH_ISSUER = "https://github.com/login/oauth";
+
 /**
  * Module augmentation for `next-auth` types. Allows us to add custom properties to the `session`
  * object and keep type safety.
@@ -54,6 +56,8 @@ function getProviders() {
       GitHubProvider({
         clientId: env.GITHUB_ID,
         clientSecret: env.GITHUB_SECRET,
+        // GitHub now includes `iss` on OAuth callbacks, so NextAuth needs the expected issuer.
+        issuer: GITHUB_OAUTH_ISSUER,
         allowDangerousEmailAccountLinking: true,
         authorization: {
           params: {

--- a/apps/web/src/server/auth.unit.test.ts
+++ b/apps/web/src/server/auth.unit.test.ts
@@ -1,23 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
 
-const { githubProviderMock } = vi.hoisted(() => ({
-  githubProviderMock: vi.fn((options: Record<string, unknown>) => ({
-    id: "github",
-    type: "oauth",
-    options,
-  })),
-}));
-
 vi.mock("next-auth", () => ({
   getServerSession: vi.fn(),
 }));
 
 vi.mock("@auth/prisma-adapter", () => ({
   PrismaAdapter: vi.fn(() => ({})),
-}));
-
-vi.mock("next-auth/providers/github", () => ({
-  default: githubProviderMock,
 }));
 
 vi.mock("next-auth/providers/google", () => ({
@@ -44,16 +32,21 @@ vi.mock("~/env", () => ({
   },
 }));
 
-import "~/server/auth";
+import { authOptions } from "~/server/auth";
 
 describe("authOptions", () => {
   it("configures the GitHub provider with an explicit issuer", () => {
-    expect(githubProviderMock).toHaveBeenCalledWith(
-      expect.objectContaining({
+    const githubProvider = authOptions.providers.find(
+      (provider) => provider.id === "github",
+    );
+
+    expect(githubProvider).toMatchObject({
+      id: "github",
+      options: {
         clientId: "github-client-id",
         clientSecret: "github-client-secret",
         issuer: "https://github.com/login/oauth",
-      }),
-    );
+      },
+    });
   });
 });

--- a/apps/web/src/server/auth.unit.test.ts
+++ b/apps/web/src/server/auth.unit.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from "vitest";
+
+const { githubProviderMock } = vi.hoisted(() => ({
+  githubProviderMock: vi.fn((options: Record<string, unknown>) => ({
+    id: "github",
+    type: "oauth",
+    options,
+  })),
+}));
+
+vi.mock("next-auth", () => ({
+  getServerSession: vi.fn(),
+}));
+
+vi.mock("@auth/prisma-adapter", () => ({
+  PrismaAdapter: vi.fn(() => ({})),
+}));
+
+vi.mock("next-auth/providers/github", () => ({
+  default: githubProviderMock,
+}));
+
+vi.mock("next-auth/providers/google", () => ({
+  default: vi.fn(),
+}));
+
+vi.mock("next-auth/providers/email", () => ({
+  default: vi.fn(),
+}));
+
+vi.mock("~/server/db", () => ({
+  db: {},
+}));
+
+vi.mock("~/server/mailer", () => ({
+  sendSignUpEmail: vi.fn(),
+}));
+
+vi.mock("~/env", () => ({
+  env: {
+    GITHUB_ID: "github-client-id",
+    GITHUB_SECRET: "github-client-secret",
+  },
+}));
+
+import "~/server/auth";
+
+describe("authOptions", () => {
+  it("configures the GitHub provider with an explicit issuer", () => {
+    expect(githubProviderMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        clientId: "github-client-id",
+        clientSecret: "github-client-secret",
+        issuer: "https://github.com/login/oauth",
+      }),
+    );
+  });
+});

--- a/apps/web/src/server/auth.unit.test.ts
+++ b/apps/web/src/server/auth.unit.test.ts
@@ -40,6 +40,7 @@ vi.mock("~/env", () => ({
   env: {
     GITHUB_ID: "github-client-id",
     GITHUB_SECRET: "github-client-secret",
+    NEXT_PUBLIC_IS_CLOUD: true,
   },
 }));
 


### PR DESCRIPTION
## Problem
GitHub OAuth sign-in fails during the callback stage with:

```txt
[next-auth][error][OAUTH_CALLBACK_ERROR]
issuer must be configured on the issuer
```

GitHub now includes an `iss` parameter in OAuth callback responses as part of RFC 9207. In NextAuth v4-style flows, the callback path validates that issuer when it is present. If the GitHub provider is configured without an explicit issuer, the callback throws before login can complete.

## Root Cause
UseSend relies on the built-in GitHub provider defaults in `next-auth@4.24.11`. That appears to have been sufficient before GitHub started returning `iss` in callback requests. Once `iss` is present, the callback path expects the provider config to declare the matching issuer metadata.

This is the same failure mode reported in Langfuse issue #13091.

## Fix
- Set the GitHub provider issuer explicitly to `https://github.com/login/oauth`
- Add a unit test that verifies the GitHub provider is configured with that explicit issuer

## Testing
- Added a targeted unit test for the provider configuration
- Not run locally

## References
- Langfuse issue: https://github.com/langfuse/langfuse/issues/13091
- Langfuse fix commit: https://github.com/langfuse/langfuse/commit/ff97a3b41336d24e71d977948333c681b850959b
- Auth.js GitHub provider docs: https://authjs.dev/reference/core/providers/github



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes GitHub OAuth sign-in failures by setting the GitHub provider `issuer` to `https://github.com/login/oauth` in `next-auth`. Restores successful callbacks now that GitHub includes `iss`.

- **Bug Fixes**
  - Configure `issuer` on the GitHub provider to satisfy `iss` validation during OAuth callbacks.
  - Add and stabilize a unit test that verifies the provider `issuer`; mock `NEXT_PUBLIC_IS_CLOUD` so the provider initializes.

<sup>Written for commit c014f7fbeab33640334786bb1a2a11aec15408e4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GitHub OAuth configuration by explicitly setting the expected issuer to make authentication callbacks more reliable.

* **Tests**
  * Added unit tests to verify the authentication provider configuration, ensuring client credentials and the explicit issuer are correctly applied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->