### PR TITLE
fix(domains): unblock delete when domain was removed from SES out-of-band

### DIFF
--- a/apps/web/src/app/(dashboard)/domains/[domainId]/delete-domain.tsx
+++ b/apps/web/src/app/(dashboard)/domains/[domainId]/delete-domain.tsx
@@ -33,6 +33,9 @@ export const DeleteDomain: React.FC<{ domain: Domain }> = ({ domain }) => {
           toast.success(`Domain ${domain.name} deleted`);
           router.replace("/domains");
         },
+        onError: (error) => {
+          toast.error(`Failed to delete domain: ${error.message}`);
+        },
       },
     );
   }

--- a/apps/web/src/app/(dashboard)/domains/domain-list.tsx
+++ b/apps/web/src/app/(dashboard)/domains/domain-list.tsx
@@ -9,6 +9,7 @@ import React from "react";
 import { StatusIndicator } from "./status-indicator";
 import { DomainStatusBadge } from "./domain-badge";
 import Spinner from "@usesend/ui/src/spinner";
+import { DeleteDomain } from "./[domainId]/delete-domain";
 
 export default function DomainsList() {
   const domainsQuery = api.domain.domains.useQuery();
@@ -115,6 +116,9 @@ const DomainItem: React.FC<{ domain: Domain }> = ({ domain }) => {
                 className="data-[state=checked]:bg-success"
               />
             </div>
+          </div>
+          <div className="flex items-center">
+            <DeleteDomain domain={domain} />
           </div>
         </div>
       </div>

--- a/apps/web/src/server/aws/ses.ts
+++ b/apps/web/src/server/aws/ses.ts
@@ -150,30 +150,60 @@ export async function deleteDomain(
   const sesClient = getSesClient(region);
 
   if (sesTenantId) {
-    const tenantResourceAssociationCommand =
-      new DeleteTenantResourceAssociationCommand({
-        TenantName: sesTenantId,
-        ResourceArn: await getIdentityArn(domain, region),
-      });
+    try {
+      const tenantResourceAssociationCommand =
+        new DeleteTenantResourceAssociationCommand({
+          TenantName: sesTenantId,
+          ResourceArn: await getIdentityArn(domain, region),
+        });
 
-    const tenantResourceAssociationResponse = await sesClient.send(
-      tenantResourceAssociationCommand
-    );
-
-    if (tenantResourceAssociationResponse.$metadata.httpStatusCode !== 200) {
-      logger.error(
-        { tenantResourceAssociationResponse },
-        "Failed to delete tenant resource association"
+      const tenantResourceAssociationResponse = await sesClient.send(
+        tenantResourceAssociationCommand
       );
-      throw new Error("Failed to delete tenant resource association");
+
+      if (tenantResourceAssociationResponse.$metadata.httpStatusCode !== 200) {
+        logger.error(
+          { domain, region, sesTenantId, tenantResourceAssociationResponse },
+          "[ses.deleteDomain] non-200 from DeleteTenantResourceAssociation"
+        );
+        throw new Error("Failed to delete tenant resource association");
+      }
+    } catch (error: any) {
+      if (error?.name === "NotFoundException") {
+        logger.warn(
+          { domain, region, sesTenantId, errorName: error.name },
+          "[ses.deleteDomain] tenant association already gone, continuing"
+        );
+      } else {
+        logger.error(
+          { err: error, domain, region, sesTenantId },
+          "[ses.deleteDomain] DeleteTenantResourceAssociation failed"
+        );
+        throw error;
+      }
     }
   }
 
-  const command = new DeleteEmailIdentityCommand({
-    EmailIdentity: domain,
-  });
-  const response = await sesClient.send(command);
-  return response.$metadata.httpStatusCode === 200;
+  try {
+    const command = new DeleteEmailIdentityCommand({
+      EmailIdentity: domain,
+    });
+    const response = await sesClient.send(command);
+    return response.$metadata.httpStatusCode === 200;
+  } catch (error: any) {
+    if (error?.name === "NotFoundException") {
+      logger.warn(
+        { domain, region, errorName: error.name },
+        "[ses.deleteDomain] identity already gone on SES, continuing"
+      );
+      return true;
+    }
+    logger.error(
+      { err: error, domain, region },
+      "[ses.deleteDomain] DeleteEmailIdentity failed"
+    );
+    throw error;
+  }
 }
 
 export async function getDomainIdentity(domain: string, region: string) {

--- a/apps/web/src/server/aws/ses.ts
+++ b/apps/web/src/server/aws/ses.ts
@@ -189,7 +189,14 @@ export async function deleteDomain(
       EmailIdentity: domain,
     });
     const response = await sesClient.send(command);
-    return response.$metadata.httpStatusCode === 200;
+    if (response.$metadata.httpStatusCode !== 200) {
+      logger.error(
+        { domain, region, response },
+        "[ses.deleteDomain] non-200 from DeleteEmailIdentity"
+      );
+      return false;
+    }
+    return true;
   } catch (error: any) {
     if (error?.name === "NotFoundException") {
       logger.warn(


### PR DESCRIPTION
## The bug

When a domain identity is deleted from AWS SES outside useSend (manual cleanup in the AWS console, an expired sandbox identity, an account migration, etc.), useSend gets stuck:

1. The DB still holds the `Domain` record.
2. `deleteDomain()` in `apps/web/src/server/aws/ses.ts` does not catch `NotFoundException` from `DeleteEmailIdentityCommand` / `DeleteTenantResourceAssociationCommand`. So the existing "Delete domain" button on `/domains/[id]` throws and aborts before deleting the DB row — the orphan is impossible to remove from the UI.
3. If the orphaned domain is in `isVerifying=true` state, the detail page itself becomes inaccessible: `getDomain()` calls `refreshDomainVerification()`, which calls `ses.getDomainIdentity()` unconditionally — that throws on a missing SES identity and the tRPC query errors out. So even reaching the Delete button can be blocked.
4. The only escape today is to manually edit the database (`DELETE FROM "Domain" WHERE id = ...`), which is unacceptable for self-hosters and not really an option for cloud users at all.

This is purely a useSend/SES integration issue — the SES side is consistent (identity gone), it's the app that doesn't handle a recoverable state.

## The fix

Two complementary changes:

1. **Make `deleteDomain()` idempotent against an already-removed SES identity** (the actual fix):
   - `DeleteTenantResourceAssociation` and `DeleteEmailIdentity` catch `NotFoundException`, `logger.warn` (with `{ domain, region, sesTenantId }`), and continue. The DB row gets removed in that case — exactly what an admin trying to recover wants.
   - All other SES errors are now logged with full error context (`{ err, domain, region, sesTenantId }`) before rethrow — previously the error was thrown bare with no log, so root cause was invisible.
   - The UI mutation gains an `onError` toast so failures actually surface instead of silently leaving the dialog open with no feedback.

2. **Add a "Delete domain" button on the `/domains` list page** so the action is reachable even when the detail page itself is broken (case 3 above). Reuses the existing `DeleteDomain` component (same typed-confirmation dialog, same mutation), no behavior change on the happy path.

After this PR, an admin who lost the SES identity out-of-band can recover entirely from the UI: hit Delete on the row in `/domains`, confirm, done. No DB surgery.

## Linked issues

None — drive-by fix while recovering from a manual SES cleanup. Happy to file an issue first if maintainers prefer.

## Migration notes

None — no schema changes, no env changes, no infra changes.

## Screenshot

`/domains` list with the new "Delete domain" button (domain name redacted):

<!-- screenshot will be drag-and-dropped here -->

## Verification steps

- Click "Delete domain" on a row in `/domains`, type the domain name, confirm → row disappears, success toast (regular happy-path delete still works exactly like before).
- Repeat on a domain whose SES identity was deleted out-of-band → previously stuck (mutation throws, no UI escape); now: DB row removed, success toast, server log shows `[ses.deleteDomain] identity already gone on SES, continuing`.
- Trigger a real SES error (e.g. invalid creds) → toast surfaces the error message and server log has the full error context.
- `pnpm tsc --noEmit` clean on `apps/web`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a per-domain delete action directly in the domain list for streamlined domain management.

* **Bug Fixes**
  * Improved error handling for domain deletion with user-facing failure notifications.
  * Enhanced backend resilience and handling of edge cases during domain removal operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->