### PR TITLE
feat: add USESEND_INVITE_ONLY flag for invite-restricted signup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,3 +26,10 @@ AUTH_EMAIL_RATE_LIMIT=5
 # REDIS_KEY_PREFIX=""
 
 NEXT_PUBLIC_IS_CLOUD=true
+
+# Restrict new signups.
+#   false    (default) — anyone can sign up (cloud variant still routes uninvited users to the waitlist)
+#   waitlist          — uninvited users always land on the waitlist for admin approval
+#   true              — hard block: uninvited users are rejected at sign-in (no DB entry, no waitlist).
+#                       Existing users and ADMIN_EMAIL can still sign in.
+# USESEND_INVITE_ONLY=false

--- a/apps/web/src/env.js
+++ b/apps/web/src/env.js
@@ -71,6 +71,9 @@ export const env = createEnv({
         .string()
         .optional()
         .transform((str) => (str ? parseInt(str, 10) : undefined)),
+    USESEND_INVITE_ONLY: z
+      .enum(["false", "waitlist", "true"])
+      .default("false"),
   },
 
   /**
@@ -133,6 +136,7 @@ export const env = createEnv({
     SMTP_USER: process.env.SMTP_USER,
     CONTACT_BOOK_ID: process.env.CONTACT_BOOK_ID,
     EMAIL_CLEANUP_DAYS: process.env.EMAIL_CLEANUP_DAYS,
+    USESEND_INVITE_ONLY: process.env.USESEND_INVITE_ONLY,
   },
   /**
    * Run `build` or `dev` with `SKIP_ENV_VALIDATION` to skip env validation. This is especially

--- a/apps/web/src/server/auth.ts
+++ b/apps/web/src/server/auth.ts
@@ -116,6 +116,22 @@ export const authOptions: NextAuthOptions = {
         isWaitlisted: user.isWaitlisted,
       },
     }),
+    signIn: async ({ user }) => {
+      if (env.USESEND_INVITE_ONLY !== "true") return true;
+      if (!user.email) return false;
+
+      const existing = await db.user.findUnique({
+        where: { email: user.email },
+      });
+      if (existing) return true;
+
+      if (env.ADMIN_EMAIL && user.email === env.ADMIN_EMAIL) return true;
+
+      const invites = await db.teamInvite.findMany({
+        where: { email: user.email },
+      });
+      return invites.length > 0;
+    },
   },
   adapter: PrismaAdapter(db) as Adapter,
   pages: {
@@ -131,6 +147,14 @@ export const authOptions: NextAuthOptions = {
         });
 
         invitesAvailable = invites.length > 0;
+      }
+
+      if (env.USESEND_INVITE_ONLY === "waitlist" && !invitesAvailable) {
+        await db.user.update({
+          where: { id: user.id },
+          data: { isBetaUser: true, isWaitlisted: true },
+        });
+        return;
       }
 
       if (


### PR DESCRIPTION
Adds a tri-state env var to control who can register: keep the current open behavior (false), route uninvited users to the waitlist (waitlist), or hard-block them in the signIn callback before any user record is created (true). Existing users and ADMIN_EMAIL can always sign in.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a tri-state `USESEND_INVITE_ONLY` env flag to control new signups: open, waitlist, or invite-only hard block. Existing users and `ADMIN_EMAIL` can always sign in.

- **New Features**
  - `USESEND_INVITE_ONLY` supports `false` (default), `waitlist`, and `true`.
  - Hard block in NextAuth `signIn` when set to `true`: no user record is created; only invited emails, existing users, and `ADMIN_EMAIL` are allowed.
  - Waitlist mode flags uninvited signups as `isWaitlisted` (and `isBetaUser`) for review.
  - Env validation updated in `apps/web/src/env.js` and documented in `.env.example`.

<sup>Written for commit e73c9e96ed915794d139668afe5cb1dff838f06e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable invite-only signup mode with three options: allow open signups (default), place uninvited users on a waitlist, or block uninvited sign-ups entirely.
  * Sign-in now validates user eligibility based on invite status when invite-only mode is enabled.
  * Admin users retain access regardless of invite configuration.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/usesend/useSend/pull/398)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->