### PR TITLE
fix: forward SMTP attachments

### DIFF
--- a/apps/smtp-server/src/server.ts
+++ b/apps/smtp-server/src/server.ts
@@ -35,22 +35,19 @@ async function sendEmailToUseSend(emailData: any, apiKey: string) {
 
     if (!response.ok) {
       const errorData = await response.text();
-      const emailDataForLog = {
-        ...emailData,
-        to: emailData.to ? "[REDACTED]" : undefined,
-        from: emailData.from ? "[REDACTED]" : undefined,
-        replyTo: emailData.replyTo ? "[REDACTED]" : undefined,
-        attachments: Array.isArray(emailData.attachments)
-          ? emailData.attachments.map((attachment: any) => ({
+      const emailDataForLog = Array.isArray(emailData.attachments)
+        ? {
+            ...emailData,
+            attachments: emailData.attachments.map((attachment: any) => ({
               filename: attachment.filename,
               contentType: attachment.contentType,
               size:
                 typeof attachment.content === "string"
                   ? Buffer.byteLength(attachment.content, "base64")
                   : undefined,
-            }))
-          : undefined,
-      };
+            })),
+          }
+        : emailData;
 
       console.error(
         "useSend API error response: error:",
@@ -127,7 +124,7 @@ const serverOptions: SMTPServerOptions = {
 
       sendEmailToUseSend(emailObject, session.user)
         .then(() => callback())
-        .then(() => console.log("Email sent successfully"))
+        .then(() => console.log("Email sent successfully to: ", emailObject.to))
         .catch((error) => {
           console.error("Failed to send email:", error.message);
           callback(error);

--- a/apps/smtp-server/src/server.ts
+++ b/apps/smtp-server/src/server.ts
@@ -35,10 +35,24 @@ async function sendEmailToUseSend(emailData: any, apiKey: string) {
 
     if (!response.ok) {
       const errorData = await response.text();
+      const emailDataForLog = Array.isArray(emailData.attachments)
+        ? {
+            ...emailData,
+            attachments: emailData.attachments.map((attachment: any) => ({
+              filename: attachment.filename,
+              contentType: attachment.contentType,
+              size:
+                typeof attachment.content === "string"
+                  ? Buffer.byteLength(attachment.content, "base64")
+                  : undefined,
+            })),
+          }
+        : emailData;
+
       console.error(
         "useSend API error response: error:",
         JSON.stringify(errorData, null, 4),
-        `\nemail data: ${emailDataText}`,
+        `\nemail data: ${JSON.stringify(emailDataForLog)}`,
       );
       throw new Error(
         `Failed to send email: ${errorData || "Unknown error from server"}`,

--- a/apps/smtp-server/src/server.ts
+++ b/apps/smtp-server/src/server.ts
@@ -99,6 +99,13 @@ const serverOptions: SMTPServerOptions = {
         text: parsed.text,
         html: parsed.html,
         replyTo: parsed.replyTo?.text,
+        attachments:
+          parsed.attachments.length > 0
+            ? parsed.attachments.map((attachment, index) => ({
+                filename: attachment.filename || `attachment-${index + 1}`,
+                content: attachment.content.toString("base64"),
+              }))
+            : undefined,
       };
 
       sendEmailToUseSend(emailObject, session.user)

--- a/apps/smtp-server/src/server.ts
+++ b/apps/smtp-server/src/server.ts
@@ -35,24 +35,10 @@ async function sendEmailToUseSend(emailData: any, apiKey: string) {
 
     if (!response.ok) {
       const errorData = await response.text();
-      const emailDataForLog = Array.isArray(emailData.attachments)
-        ? {
-            ...emailData,
-            attachments: emailData.attachments.map((attachment: any) => ({
-              filename: attachment.filename,
-              contentType: attachment.contentType,
-              size:
-                typeof attachment.content === "string"
-                  ? Buffer.byteLength(attachment.content, "base64")
-                  : undefined,
-            })),
-          }
-        : emailData;
-
       console.error(
         "useSend API error response: error:",
         JSON.stringify(errorData, null, 4),
-        `\nemail data: ${JSON.stringify(emailDataForLog)}`,
+        `\nemail data: ${emailDataText}`,
       );
       throw new Error(
         `Failed to send email: ${errorData || "Unknown error from server"}`,

--- a/apps/smtp-server/src/server.ts
+++ b/apps/smtp-server/src/server.ts
@@ -35,19 +35,22 @@ async function sendEmailToUseSend(emailData: any, apiKey: string) {
 
     if (!response.ok) {
       const errorData = await response.text();
-      const emailDataForLog = Array.isArray(emailData.attachments)
-        ? {
-            ...emailData,
-            attachments: emailData.attachments.map((attachment: any) => ({
+      const emailDataForLog = {
+        ...emailData,
+        to: emailData.to ? "[REDACTED]" : undefined,
+        from: emailData.from ? "[REDACTED]" : undefined,
+        replyTo: emailData.replyTo ? "[REDACTED]" : undefined,
+        attachments: Array.isArray(emailData.attachments)
+          ? emailData.attachments.map((attachment: any) => ({
               filename: attachment.filename,
               contentType: attachment.contentType,
               size:
                 typeof attachment.content === "string"
                   ? Buffer.byteLength(attachment.content, "base64")
                   : undefined,
-            })),
-          }
-        : emailData;
+            }))
+          : undefined,
+      };
 
       console.error(
         "useSend API error response: error:",
@@ -124,7 +127,7 @@ const serverOptions: SMTPServerOptions = {
 
       sendEmailToUseSend(emailObject, session.user)
         .then(() => callback())
-        .then(() => console.log("Email sent successfully to: ", emailObject.to))
+        .then(() => console.log("Email sent successfully"))
         .catch((error) => {
           console.error("Failed to send email:", error.message);
           callback(error);


### PR DESCRIPTION
## Summary
- forward mailparser attachments from the SMTP server to the useSend email API
- encode attachment buffers as base64 content expected by the API
- provide fallback attachment filenames when SMTP messages omit them

## Verification
- pnpm --filter smtp-server exec tsc --noEmit
- pnpm exec prettier --check apps/smtp-server/src/server.ts

Closes #399

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Email attachments are now detected and forwarded with messages. Each attachment is sent with a filename (fallback name supplied when missing) and base64-encoded content. If a message has no attachments, no attachments field is included. This ensures attachments are preserved when delivering emails.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/usesend/useSend/pull/405?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->