### PR TITLE
fix: sandbox campaign preview in iframe to prevent style leakage

### DIFF
--- a/apps/web/src/app/(dashboard)/campaigns/[campaignId]/page.tsx
+++ b/apps/web/src/app/(dashboard)/campaigns/[campaignId]/page.tsx
@@ -273,8 +273,13 @@ export default function CampaignDetailsPage({
                 </Link>
               </div>
             </div>
-            <div className=" dark:bg-slate-50 overflow-auto text-black rounded py-8 border-t">
-              <div dangerouslySetInnerHTML={{ __html: campaign.html ?? "" }} />
+            <div className=" dark:bg-slate-50 overflow-auto text-black rounded border-t">
+              <iframe
+                className="w-full min-h-[600px]"
+                srcDoc={campaign.html ?? ""}
+                sandbox="allow-same-origin"
+                title="Campaign email preview"
+              />
             </div>
           </div>
         </div>


### PR DESCRIPTION
Closes #409

### Problem
The campaign detail page rendered email HTML directly into the DOM using `dangerouslySetInnerHTML`, allowing global CSS from email content to leak into the dashboard UI — breaking fonts, spacing, and layout for the entire page.

### Fix
Replaced the unsandboxed `<div dangerouslySetInnerHTML>` with a sandboxed `<iframe srcDoc>`, following the same pattern already used in `email-details.tsx`. Email styles are now fully isolated to the preview container.

### Changes
- `apps/web/src/app/(dashboard)/campaigns/[campaignId]/page.tsx`
  - Replaced `dangerouslySetInnerHTML` div with `<iframe srcDoc sandbox="allow-same-origin">`
  - Removed `py-8` padding (not applicable to an iframe container)
  - Added `min-h-[600px]` for adequate preview height

### Screenshots

<img width="1918" height="952" alt="Screenshot 2026-06-24 110834" src="https://github.com/user-attachments/assets/4164c668-aede-4d93-aa8e-5707d5fa90b6" />
<img width="1918" height="962" alt="Screenshot 2026-06-24 110845" src="https://github.com/user-attachments/assets/ee90867e-c489-4810-be9f-89604a9b50de" />

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Isolated the campaign email preview by rendering HTML in a sandboxed iframe with an accessible title. This stops email CSS from leaking into the dashboard and improves screen reader support.

- **Bug Fixes**
  - Replaced `dangerouslySetInnerHTML` with `<iframe srcDoc>` + `sandbox="allow-same-origin"` and `title="Campaign email preview"`.
  - Removed wrapper padding; set `min-h-[600px]` on the iframe for a consistent preview.
  - Confined email styles to the iframe; dashboard fonts and spacing stay intact.

<sup>Written for commit 5b2abade9e15a06c6c151e3a555c52b5478c3e62. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usesend/useSend/pull/410?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the campaign email preview by replacing direct HTML injection with an embedded, scrollable preview frame when content is available, resulting in a more reliable and consistent viewing experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->