### PR TITLE
fix: require confirmation before campaign unsubscribe

### DIFF
--- a/apps/web/src/app/unsubscribe/page.tsx
+++ b/apps/web/src/app/unsubscribe/page.tsx
@@ -1,49 +1,182 @@
-import { unsubscribeContactFromLink } from "~/server/service/campaign-service";
+import { redirect } from "next/navigation";
+import type { ReactNode } from "react";
+import {
+  getContactFromUnsubscribeLink,
+  unsubscribeContactFromLink,
+} from "~/server/service/campaign-service";
 import ReSubscribe from "./re-subscribe";
+import UnsubscribeButton from "./unsubscribe-button";
 
 export const dynamic = "force-dynamic";
 
-async function UnsubscribePage({
-  searchParams,
+const PUBLIC_UNSUBSCRIBE_ERRORS = new Set([
+  "Invalid unsubscribe link",
+  "Contact not found",
+]);
+
+function getUnsubscribeErrorMessage(error: unknown) {
+  if (error instanceof Error && PUBLIC_UNSUBSCRIBE_ERRORS.has(error.message)) {
+    return error.message;
+  }
+
+  return "Unable to unsubscribe. Please try again.";
+}
+
+function buildUnsubscribeUrl({
+  id,
+  hash,
+  status,
+  error,
 }: {
-  searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
+  id?: string;
+  hash?: string;
+  status?: "error";
+  error?: string;
 }) {
-  const params = await searchParams;
+  const searchParams = new URLSearchParams();
 
-  const id = params.id as string;
-  const hash = params.hash as string;
+  if (id) searchParams.set("id", id);
+  if (hash) searchParams.set("hash", hash);
+  if (status) searchParams.set("status", status);
+  if (error) searchParams.set("error", error);
 
-  if (!id || !hash) {
-    return (
-      <div className="min-h-screen flex items-center justify-center">
-        <div className="max-w-md w-full space-y-8 p-10 shadow rounded-xl">
-          <h2 className="mt-6 text-center text-3xl font-extrabold ">
-            Unsubscribe
-          </h2>
-          <p className="mt-2 text-center text-sm text-gray-600">
-            Invalid unsubscribe link. Please check your URL and try again.
-          </p>
-        </div>
-      </div>
+  const queryString = searchParams.toString();
+  return queryString ? `/unsubscribe?${queryString}` : "/unsubscribe";
+}
+
+async function unsubscribeAction(formData: FormData) {
+  "use server";
+
+  const id = formData.get("id");
+  const hash = formData.get("hash");
+
+  if (typeof id !== "string" || typeof hash !== "string") {
+    redirect(
+      buildUnsubscribeUrl({
+        status: "error",
+        error: "Invalid unsubscribe link",
+      }),
     );
   }
 
-  const contact = await unsubscribeContactFromLink(id, hash);
+  let redirectUrl: string;
 
+  try {
+    await unsubscribeContactFromLink(id, hash);
+    redirectUrl = buildUnsubscribeUrl({ id, hash });
+  } catch (error) {
+    redirectUrl = buildUnsubscribeUrl({
+      id,
+      hash,
+      status: "error",
+      error: getUnsubscribeErrorMessage(error),
+    });
+  }
+
+  redirect(redirectUrl);
+}
+
+function MessageCard({
+  title,
+  message,
+}: {
+  title: string;
+  message: string;
+}) {
   return (
-    <div className="min-h-screen flex items-center justify-center ">
-      <ReSubscribe id={id} hash={hash} contact={contact} />
-
-      <div className=" fixed bottom-10  p-4">
-        <p>
-          Powered by{" "}
-          <a href="https://usesend.com" className="font-bold" target="_blank">
-            useSend
-          </a>
-        </p>
-      </div>
+    <div className="w-full max-w-md space-y-4 rounded-xl border p-8 shadow">
+      <h1 className="text-center text-2xl font-semibold">{title}</h1>
+      <p className="text-center text-sm text-muted-foreground">{message}</p>
     </div>
   );
 }
 
-export default UnsubscribePage;
+export default async function UnsubscribePage({
+  searchParams,
+}: {
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
+}) {
+  const getSingleValue = (value: string | string[] | undefined) =>
+    Array.isArray(value) ? value[0] : value;
+
+  const params = await searchParams;
+  const id = getSingleValue(params.id);
+  const hash = getSingleValue(params.hash);
+  const status = getSingleValue(params.status);
+  const error = getSingleValue(params.error);
+
+  let content: ReactNode;
+
+  if (!id || !hash) {
+    content = (
+      <MessageCard
+        title="Invalid Link"
+        message="This unsubscribe link is invalid. Please check the URL and try again."
+      />
+    );
+  } else {
+    try {
+      const contact = await getContactFromUnsubscribeLink(id, hash);
+
+      if (!contact.subscribed) {
+        content = <ReSubscribe id={id} hash={hash} contact={contact} />;
+      } else {
+        content = (
+          <div className="w-full max-w-md space-y-6 rounded-xl border p-8 shadow">
+            <div className="space-y-2">
+              <h1 className="text-center text-2xl font-semibold">
+                Unsubscribe
+              </h1>
+              <p className="text-center text-sm text-muted-foreground">
+                Are you sure you want to stop receiving emails at{" "}
+                <span className="font-medium text-foreground">
+                  {contact.email}
+                </span>
+                ?
+              </p>
+            </div>
+
+            {status === "error" ? (
+              <p role="alert" className="text-center text-sm text-destructive">
+                {getUnsubscribeErrorMessage(error ? new Error(error) : null)}
+              </p>
+            ) : null}
+
+            <form action={unsubscribeAction}>
+              <input type="hidden" name="id" value={id} />
+              <input type="hidden" name="hash" value={hash} />
+              <UnsubscribeButton />
+            </form>
+          </div>
+        );
+      }
+    } catch (linkError) {
+      content = (
+        <MessageCard
+          title="Invalid Link"
+          message={getUnsubscribeErrorMessage(linkError)}
+        />
+      );
+    }
+  }
+
+  return (
+    <main className="flex min-h-screen items-center justify-center p-6">
+      {content}
+
+      <div className="fixed bottom-10 p-4 text-sm">
+        <p>
+          Powered by{" "}
+          <a
+            href="https://usesend.com"
+            className="font-bold"
+            target="_blank"
+            rel="noreferrer"
+          >
+            useSend
+          </a>
+        </p>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/app/unsubscribe/page.unit.test.ts
+++ b/apps/web/src/app/unsubscribe/page.unit.test.ts
@@ -1,0 +1,45 @@
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import UnsubscribePage from "./page";
+
+const campaignService = vi.hoisted(() => ({
+  getContactFromUnsubscribeLink: vi.fn(async () => ({
+    id: "contact-1",
+    email: "person@example.com",
+    subscribed: true,
+  })),
+  unsubscribeContactFromLink: vi.fn(async () => undefined),
+}));
+
+vi.mock("~/server/service/campaign-service", () => campaignService);
+
+describe("unsubscribe page", () => {
+  beforeEach(() => {
+    vi.stubGlobal("React", React);
+    campaignService.getContactFromUnsubscribeLink.mockClear();
+    campaignService.unsubscribeContactFromLink.mockClear();
+  });
+
+  it("does not unsubscribe when a valid link is rendered by GET", async () => {
+    const page = await UnsubscribePage({
+      searchParams: Promise.resolve({ id: "contact-campaign", hash: "hash" }),
+    });
+
+    expect(page).toBeTruthy();
+    expect(campaignService.getContactFromUnsubscribeLink).toHaveBeenCalledWith(
+      "contact-campaign",
+      "hash",
+    );
+    expect(campaignService.unsubscribeContactFromLink).not.toHaveBeenCalled();
+  });
+
+  it("does not call campaign services for a malformed link", async () => {
+    const page = await UnsubscribePage({
+      searchParams: Promise.resolve({}),
+    });
+
+    expect(page).toBeTruthy();
+    expect(campaignService.getContactFromUnsubscribeLink).not.toHaveBeenCalled();
+    expect(campaignService.unsubscribeContactFromLink).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/unsubscribe/re-subscribe.tsx
+++ b/apps/web/src/app/unsubscribe/re-subscribe.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Contact } from "@prisma/client";
+import type { Contact } from "@prisma/client";
 import { Button } from "@usesend/ui/src/button";
 import Spinner from "@usesend/ui/src/spinner";
 import { toast } from "@usesend/ui/src/toaster";
@@ -43,9 +43,11 @@ export default function ReSubscribe({
       <div className="flex justify-center">
         {!subscribed ? (
           <Button
-            className="mx-auto w-[150px]"
+            type="button"
+            className="mx-auto min-h-11 w-[150px] touch-manipulation"
             onClick={() => reSubscribe.mutate({ id, hash })}
             disabled={reSubscribe.isPending}
+            aria-disabled={reSubscribe.isPending}
           >
             {reSubscribe.isPending ? (
               <Spinner className="w-4 h-4" />

--- a/apps/web/src/app/unsubscribe/unsubscribe-button.tsx
+++ b/apps/web/src/app/unsubscribe/unsubscribe-button.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { Button } from "@usesend/ui/src/button";
+import { useFormStatus } from "react-dom";
+
+export default function UnsubscribeButton() {
+  const { pending } = useFormStatus();
+
+  return (
+    <Button
+      type="submit"
+      variant="destructive"
+      className="min-h-11 w-full touch-manipulation"
+      disabled={pending}
+      aria-disabled={pending}
+    >
+      {pending ? "Unsubscribing…" : "Confirm unsubscribe"}
+    </Button>
+  );
+}

--- a/apps/web/src/server/service/campaign-service.ts
+++ b/apps/web/src/server/service/campaign-service.ts
@@ -554,7 +554,7 @@ export function createOneClickUnsubUrl(contactId: string, campaignId: string) {
   return `${env.NEXTAUTH_URL}/api/unsubscribe-oneclick?id=${unsubId}&hash=${unsubHash}`;
 }
 
-export async function unsubscribeContactFromLink(id: string, hash: string) {
+function verifyUnsubscribeLink(id: string, hash: string) {
   const [contactId, campaignId] = id.split("-");
 
   if (!contactId || !campaignId) {
@@ -569,6 +569,26 @@ export async function unsubscribeContactFromLink(id: string, hash: string) {
   if (hash !== expectedHash) {
     throw new Error("Invalid unsubscribe link");
   }
+
+  return { contactId, campaignId };
+}
+
+export async function getContactFromUnsubscribeLink(id: string, hash: string) {
+  const { contactId } = verifyUnsubscribeLink(id, hash);
+
+  const contact = await db.contact.findUnique({
+    where: { id: contactId },
+  });
+
+  if (!contact) {
+    throw new Error("Contact not found");
+  }
+
+  return contact;
+}
+
+export async function unsubscribeContactFromLink(id: string, hash: string) {
+  const { contactId, campaignId } = verifyUnsubscribeLink(id, hash);
 
   return await unsubscribeContact({
     contactId,


### PR DESCRIPTION
## Summary

- make campaign unsubscribe links safe to open with GET
- render a confirmation screen before changing subscription state
- perform the unsubscribe through a POST-backed server action
- preserve the existing RFC 8058 one-click POST endpoint and resubscribe flow
- add regression coverage proving GET rendering never calls the unsubscribe mutation

## Root cause

The in-body campaign unsubscribe page called `unsubscribeContactFromLink` while rendering a GET request. Email security scanners prefetch links, so they could unsubscribe contacts and increment campaign analytics without a recipient action. The signed hash could not prevent this because scanners received the complete signed URL.

## Impact

Opening or scanning an in-body unsubscribe link is now read-only. Contacts are unsubscribed only after explicitly pressing **Confirm unsubscribe**.

## Verification

- `pnpm --filter=web exec vitest run -c vitest.unit.config.ts src/app/unsubscribe/page.unit.test.ts` — 2 tests passed
- local Docker Postgres/Redis flow:
  - old GET: contact became unsubscribed and campaign counter incremented
  - fixed GET: contact remained subscribed and campaign counter stayed unchanged
  - confirmation POST: contact became unsubscribed and campaign counter incremented
- `git diff --check`

Closes #412

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make campaign unsubscribe links safe to open via GET by adding a confirmation step and moving the unsubscribe to a POST-backed server action. Prevents email scanners from auto-unsubscribing contacts.

- **Bug Fixes**
  - Render a confirmation screen on GET; no unsubscribe is executed during render.
  - Add POST server action to finalize unsubscribe; `UnsubscribeButton` uses `useFormStatus` for pending state.
  - Preserve the RFC 8058 one‑click POST endpoint and the re‑subscribe flow.
  - Validate link params and show clear, public-safe error messages.
  - Split verification and data access into `getContactFromUnsubscribeLink` and shared hash validation.
  - Add unit tests to ensure GET rendering never calls the unsubscribe mutation.

<sup>Written for commit 6ac4be12ea83339ff676ba2ae415ce40f69d51f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usesend/useSend/pull/416?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a confirmation step before unsubscribing from email communications.
  * Displays the contact’s current subscription status and offers resubscription when already unsubscribed.
  * Added clear feedback for invalid links and unsubscribe errors.
  * Added a loading state while the unsubscribe request is processing.
* **Accessibility**
  * Improved button states and touch-friendly interactions for unsubscribe and resubscribe actions.
* **Tests**
  * Added coverage for valid and malformed unsubscribe links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->