### PR TITLE
fix: emit webhooks for campaign subscription changes

### DIFF
--- a/apps/web/src/server/service/campaign-service.ts
+++ b/apps/web/src/server/service/campaign-service.ts
@@ -29,6 +29,7 @@ import {
   getContactReplacementValue,
   replaceContactVariables,
 } from "../utils/contact-variable-replacement";
+import { updateContactSubscription } from "./contact-service";
 
 const CAMPAIGN_UNSUB_PLACEHOLDER_TOKENS = [
   "{{unsend_unsubscribe_url}}",
@@ -597,9 +598,10 @@ export async function unsubscribeContact({
     }
 
     if (contact.subscribed) {
-      await db.contact.update({
-        where: { id: contactId },
-        data: { subscribed: false, unsubscribeReason: reason },
+      const updatedContact = await updateContactSubscription({
+        contactId,
+        subscribed: false,
+        unsubscribeReason: reason,
       });
 
       if (campaignId) {
@@ -612,6 +614,8 @@ export async function unsubscribeContact({
           },
         });
       }
+
+      return updatedContact;
     }
 
     return contact;
@@ -648,9 +652,10 @@ export async function subscribeContact(id: string, hash: string) {
     }
 
     if (!contact.subscribed) {
-      await db.contact.update({
-        where: { id: contactId },
-        data: { subscribed: true },
+      await updateContactSubscription({
+        contactId,
+        subscribed: true,
+        unsubscribeReason: null,
       });
 
       await db.campaign.update({

--- a/apps/web/src/server/service/campaign-service.unit.test.ts
+++ b/apps/web/src/server/service/campaign-service.unit.test.ts
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createHash } from "crypto";
+import { UnsubscribeReason } from "@prisma/client";
 
-const { mockDb, mockTx } = vi.hoisted(() => {
+const { mockDb, mockTx, mockUpdateContactSubscription } = vi.hoisted(() => {
   const mockTx = {
     campaignEmail: {
       findUnique: vi.fn(),
@@ -22,7 +24,14 @@ const { mockDb, mockTx } = vi.hoisted(() => {
       $transaction: vi.fn(async (callback: ReturnType<typeof vi.fn>) =>
         callback(mockTx),
       ),
+      contact: {
+        findUnique: vi.fn(),
+      },
+      campaign: {
+        update: vi.fn(),
+      },
     },
+    mockUpdateContactSubscription: vi.fn(),
   };
 });
 
@@ -35,7 +44,13 @@ vi.mock("@usesend/email-editor/src/renderer", () => ({
 }));
 
 vi.mock("~/env", () => ({
-  env: {},
+  env: {
+    NEXTAUTH_SECRET: "test-secret",
+  },
+}));
+
+vi.mock("~/server/service/contact-service", () => ({
+  updateContactSubscription: mockUpdateContactSubscription,
 }));
 
 vi.mock("bullmq", () => ({
@@ -76,7 +91,11 @@ vi.mock("~/server/logger/log", () => ({
   },
 }));
 
-import { recordCampaignContactFailure } from "~/server/service/campaign-service";
+import {
+  recordCampaignContactFailure,
+  subscribeContact,
+  unsubscribeContact,
+} from "~/server/service/campaign-service";
 
 const input = {
   contact: {
@@ -173,6 +192,64 @@ describe("recordCampaignContactFailure", () => {
     expect(mockTx.email.update).toHaveBeenCalledWith({
       where: { id: "email_3" },
       data: { latestStatus: "FAILED" },
+    });
+  });
+});
+
+describe("campaign contact subscription changes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("updates the contact through the webhook-emitting service on unsubscribe", async () => {
+    const contact = {
+      id: "contact_1",
+      contactBookId: "book_1",
+      email: "alice@example.com",
+      subscribed: true,
+    };
+    const updatedContact = { ...contact, subscribed: false };
+    mockDb.contact.findUnique.mockResolvedValue(contact);
+    mockUpdateContactSubscription.mockResolvedValue(updatedContact);
+
+    const result = await unsubscribeContact({
+      contactId: "contact_1",
+      campaignId: "campaign_1",
+      reason: UnsubscribeReason.UNSUBSCRIBED,
+    });
+
+    expect(mockUpdateContactSubscription).toHaveBeenCalledWith({
+      contactId: "contact_1",
+      subscribed: false,
+      unsubscribeReason: UnsubscribeReason.UNSUBSCRIBED,
+    });
+    expect(mockDb.campaign.update).toHaveBeenCalledWith({
+      where: { id: "campaign_1" },
+      data: { unsubscribed: { increment: 1 } },
+    });
+    expect(result).toBe(updatedContact);
+  });
+
+  it("updates the contact through the webhook-emitting service on re-subscribe", async () => {
+    mockDb.contact.findUnique.mockResolvedValue({
+      id: "contact_1",
+      contactBookId: "book_1",
+      email: "alice@example.com",
+      subscribed: false,
+    });
+    const id = "contact_1-campaign_1";
+    const hash = createHash("sha256").update(`${id}-test-secret`).digest("hex");
+
+    await subscribeContact(id, hash);
+
+    expect(mockUpdateContactSubscription).toHaveBeenCalledWith({
+      contactId: "contact_1",
+      subscribed: true,
+      unsubscribeReason: null,
+    });
+    expect(mockDb.campaign.update).toHaveBeenCalledWith({
+      where: { id: "campaign_1" },
+      data: { unsubscribed: { decrement: 1 } },
     });
   });
 });

--- a/apps/web/src/server/service/contact-service.ts
+++ b/apps/web/src/server/service/contact-service.ts
@@ -366,6 +366,27 @@ export async function subscribeContact(contactId: string) {
   });
 }
 
+export async function updateContactSubscription({
+  contactId,
+  subscribed,
+  unsubscribeReason,
+  teamId,
+}: {
+  contactId: string;
+  subscribed: boolean;
+  unsubscribeReason: UnsubscribeReason | null;
+  teamId?: number;
+}) {
+  const updatedContact = await db.contact.update({
+    where: { id: contactId },
+    data: { subscribed, unsubscribeReason },
+  });
+
+  await emitContactEvent(updatedContact, "contact.updated", teamId);
+
+  return updatedContact;
+}
+
 function buildContactPayload(contact: Contact): ContactPayload {
   return {
     id: contact.id,

--- a/apps/web/src/server/service/contact-service.unit.test.ts
+++ b/apps/web/src/server/service/contact-service.unit.test.ts
@@ -55,6 +55,7 @@ import {
   addOrUpdateContact,
   resendDoubleOptInConfirmationInContactBook,
   updateContactInContactBook,
+  updateContactSubscription,
 } from "~/server/service/contact-service";
 
 const createdAt = new Date("2026-02-08T00:00:00.000Z");
@@ -71,6 +72,58 @@ describe("contact-service addOrUpdateContact", () => {
     mockLogger.warn.mockReset();
     mockLogger.error.mockReset();
   });
+
+  it.each([
+    {
+      subscribed: false,
+      unsubscribeReason: "UNSUBSCRIBED" as const,
+    },
+    {
+      subscribed: true,
+      unsubscribeReason: null,
+    },
+  ])(
+    "emits contact.updated after setting subscribed to $subscribed",
+    async ({ subscribed, unsubscribeReason }) => {
+      const updatedAt = new Date("2026-02-09T00:00:00.000Z");
+      mockDb.contact.update.mockResolvedValue({
+        id: "contact_subscription",
+        email: "alice@example.com",
+        contactBookId: "book_1",
+        subscribed,
+        unsubscribeReason,
+        properties: {},
+        firstName: "Alice",
+        lastName: "Smith",
+        createdAt,
+        updatedAt,
+      });
+      mockDb.contactBook.findUnique.mockResolvedValue({ teamId: 7 });
+
+      const result = await updateContactSubscription({
+        contactId: "contact_subscription",
+        subscribed,
+        unsubscribeReason,
+      });
+
+      expect(mockDb.contact.update).toHaveBeenCalledWith({
+        where: { id: "contact_subscription" },
+        data: { subscribed, unsubscribeReason },
+      });
+      expect(mockWebhookEmit).toHaveBeenCalledWith(7, "contact.updated", {
+        id: "contact_subscription",
+        email: "alice@example.com",
+        contactBookId: "book_1",
+        subscribed,
+        properties: {},
+        firstName: "Alice",
+        lastName: "Smith",
+        createdAt: createdAt.toISOString(),
+        updatedAt: updatedAt.toISOString(),
+      });
+      expect(result.subscribed).toBe(subscribed);
+    },
+  );
 
   it("creates pending contacts and sends double opt-in confirmation", async () => {
     mockDb.contactBook.findUnique.mockResolvedValue({


### PR DESCRIPTION
## Summary

- emit `contact.updated` after campaign unsubscribe and re-subscribe state changes
- preserve bounce/complaint unsubscribe reasons and clear the reason on re-subscribe
- return the updated contact after unsubscribe
- cover subscribed and unsubscribed webhook payloads with unit tests

Fixes #413.

## Impact

Webhook consumers can now synchronize per-contact suppression state when subscription status changes through campaign links, RFC 8058 one-click unsubscribe, or campaign delivery events. Existing campaign unsubscribe counters remain unchanged.

## Verification

- `pnpm --filter=web exec vitest run -c vitest.unit.config.ts src/server/service/contact-service.unit.test.ts` (16 passed)
- `pnpm --filter=web exec eslint src/server/service/contact-service.ts src/server/service/campaign-service.ts src/server/service/contact-service.unit.test.ts --max-warnings 0`
- `git diff --check`

## Migration notes

No database migrations or configuration changes.

## Screenshots

Not applicable; server-side behavior only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emit `contact.updated` webhooks when campaign actions change a contact’s subscription so downstream systems can sync suppression state in real time. Also standardizes unsubscribe reason handling and returns the updated contact on unsubscribe.

- **Bug Fixes**
  - Emit `contact.updated` after unsubscribe and re-subscribe via campaign flows (including RFC 8058 one-click).
  - Preserve bounce/complaint reasons on unsubscribe and clear on re-subscribe.
  - `unsubscribeContact` now returns the updated contact.

- **Refactors**
  - Added `updateContactSubscription` to centralize subscription updates and webhook emission; used by campaign `unsubscribeContact` and `subscribeContact`.

<sup>Written for commit 3d78b2ab7f303ba819c6d1f38f53237e9ec10fa1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usesend/useSend/pull/417?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved contact subscription handling for both subscribing and unsubscribing, including consistent recording of unsubscribe reasons.
  * Ensure resubscribing correctly clears prior unsubscribe reasons and updates subscription status reliably.
  * Contact subscription changes now trigger consistent update notifications, keeping integrations synchronized, while campaign subscription counters are adjusted correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->