### PR TITLE
fix: secure self-hosted registration

### DIFF
--- a/apps/web/prisma/migrations/20260711000000_secure_self_hosted_registration/migration.sql
+++ b/apps/web/prisma/migrations/20260711000000_secure_self_hosted_registration/migration.sql
@@ -1,0 +1,34 @@
+-- Persist instance-level authorization instead of treating every authenticated
+-- self-hosted user as an administrator.
+ALTER TABLE "User" ADD COLUMN "isInstanceAdmin" BOOLEAN NOT NULL DEFAULT false;
+
+-- Preserve access for existing installations by promoting the oldest team
+-- administrator. Fall back to the oldest user for installations that have not
+-- completed team setup yet.
+-- Fresh installations have no users at migration time; their first user is
+-- promoted atomically by the authentication adapter.
+UPDATE "User"
+SET "isInstanceAdmin" = true
+WHERE "id" = (
+  COALESCE(
+    (
+      SELECT u."id"
+      FROM "User" u
+      INNER JOIN "TeamUser" tu ON tu."userId" = u."id"
+      WHERE tu."role" = 'ADMIN'
+      ORDER BY u."createdAt" ASC, u."id" ASC
+      LIMIT 1
+    ),
+    (
+      SELECT "id"
+      FROM "User"
+      ORDER BY "createdAt" ASC, "id" ASC
+      LIMIT 1
+    )
+  )
+);
+
+-- Existing invitations receive the same seven-day lifetime as new invites.
+ALTER TABLE "TeamInvite" ADD COLUMN "expiresAt" TIMESTAMP(3);
+UPDATE "TeamInvite" SET "expiresAt" = "createdAt" + INTERVAL '7 days';
+ALTER TABLE "TeamInvite" ALTER COLUMN "expiresAt" SET NOT NULL;

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -86,6 +86,7 @@ model User {
   image            String?
   isBetaUser       Boolean    @default(false)
   isWaitlisted     Boolean    @default(false)
+  isInstanceAdmin  Boolean    @default(false)
   createdAt        DateTime   @default(now())
   accounts         Account[]
   sessions         Session[]
@@ -132,6 +133,7 @@ model TeamInvite {
   teamId    Int
   email     String
   role      Role
+  expiresAt DateTime
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 

--- a/apps/web/src/components/AppSideBar.tsx
+++ b/apps/web/src/components/AppSideBar.tsx
@@ -114,13 +114,11 @@ const settingsItems = [
     url: "/settings",
     icon: Cog,
   },
-  // Admin item shows if user is admin OR if it's self-hosted
   {
     title: "Admin",
     url: "/admin",
     icon: Server,
     isAdmin: true,
-    isSelfHosted: true,
   },
 ];
 
@@ -205,20 +203,8 @@ export function AppSidebar() {
               {settingsItems.map((item) => {
                 const isActive = pathname?.startsWith(item.url);
 
-                // Special case for Admin item: show if user is admin OR if it's self-hosted
-                if (item.isAdmin && item.isSelfHosted) {
-                  if (!session?.user.isAdmin && !isSelfHosted()) {
-                    return null;
-                  }
-                } else {
-                  // Regular admin-only items
-                  if (item.isAdmin && !session?.user.isAdmin) {
-                    return null;
-                  }
-                  // Regular self-hosted-only items
-                  if (item.isSelfHosted && !isSelfHosted()) {
-                    return null;
-                  }
+                if (item.isAdmin && !session?.user.isAdmin) {
+                  return null;
                 }
                 return (
                   <SidebarMenuItem key={item.title}>

--- a/apps/web/src/providers/dashboard-provider.tsx
+++ b/apps/web/src/providers/dashboard-provider.tsx
@@ -4,7 +4,6 @@ import { useSession } from "next-auth/react";
 import { FullScreenLoading } from "~/components/FullScreenLoading";
 import { AddSesSettings } from "~/components/settings/AddSesSettings";
 import CreateTeam from "~/components/team/CreateTeam";
-import { env } from "~/env";
 import { api } from "~/trpc/react";
 import { TeamProvider } from "./team-context";
 
@@ -17,20 +16,17 @@ export const DashboardProvider = ({
   const { data: teams, status } = api.team.getTeams.useQuery();
   const { data: settings, status: settingsStatus } =
     api.admin.getSesSettings.useQuery(undefined, {
-      enabled: !env.NEXT_PUBLIC_IS_CLOUD || session?.user.isAdmin,
+      enabled: session?.user.isAdmin === true,
     });
 
   if (
     status === "pending" ||
-    (settingsStatus === "pending" && !env.NEXT_PUBLIC_IS_CLOUD)
+    (settingsStatus === "pending" && session?.user.isAdmin)
   ) {
     return <FullScreenLoading />;
   }
 
-  if (
-    settings?.length === 0 &&
-    (!env.NEXT_PUBLIC_IS_CLOUD || session?.user.isAdmin)
-  ) {
+  if (settings?.length === 0 && session?.user.isAdmin) {
     return <AddSesSettings />;
   }
 

--- a/apps/web/src/server/api/routers/invitation-security.trpc.test.ts
+++ b/apps/web/src/server/api/routers/invitation-security.trpc.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockDb } = vi.hoisted(() => {
+  const db = {
+    teamInvite: {
+      findMany: vi.fn(),
+      findFirst: vi.fn(),
+      delete: vi.fn(),
+    },
+    teamUser: {
+      create: vi.fn(),
+    },
+    $transaction: vi.fn(),
+  };
+
+  return { mockDb: db };
+});
+
+vi.mock("~/server/db", () => ({ db: mockDb }));
+vi.mock("~/server/auth", () => ({ getServerAuthSession: vi.fn() }));
+
+import { createCallerFactory } from "~/server/api/trpc";
+import { invitationRouter } from "./invitiation";
+
+const createCaller = createCallerFactory(invitationRouter);
+
+function getContext(email = "member@example.com") {
+  return {
+    db: mockDb,
+    headers: new Headers(),
+    session: {
+      user: {
+        id: 2,
+        email,
+        isAdmin: false,
+        isBetaUser: true,
+        isWaitlisted: false,
+      },
+    },
+  } as never;
+}
+
+describe("invitation authorization", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDb.$transaction.mockImplementation(
+      async (callback: CallableFunction) => callback(mockDb),
+    );
+  });
+
+  it("scopes an invite-link lookup to the signed-in email and expiry", async () => {
+    mockDb.teamInvite.findMany.mockResolvedValue([]);
+    const caller = createCaller(getContext());
+
+    await caller.getUserInvites({ inviteId: "invite_1" });
+
+    expect(mockDb.teamInvite.findMany).toHaveBeenCalledWith({
+      where: {
+        id: "invite_1",
+        email: { equals: "member@example.com", mode: "insensitive" },
+        expiresAt: { gt: expect.any(Date) },
+      },
+      include: { team: true },
+    });
+  });
+
+  it("does not accept an invite that does not match the signed-in user", async () => {
+    mockDb.teamInvite.findFirst.mockResolvedValue(null);
+    const caller = createCaller(getContext("stranger@example.com"));
+
+    await expect(
+      caller.acceptTeamInvite({ inviteId: "invite_1" }),
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+
+    expect(mockDb.teamUser.create).not.toHaveBeenCalled();
+    expect(mockDb.teamInvite.delete).not.toHaveBeenCalled();
+  });
+
+  it("adds membership and consumes a matching invite atomically", async () => {
+    mockDb.teamInvite.findFirst.mockResolvedValue({
+      id: "invite_1",
+      teamId: 10,
+      email: "member@example.com",
+      role: "MEMBER",
+    });
+    mockDb.teamUser.create.mockResolvedValue({});
+    mockDb.teamInvite.delete.mockResolvedValue({});
+    const caller = createCaller(getContext());
+
+    await expect(
+      caller.acceptTeamInvite({ inviteId: "invite_1" }),
+    ).resolves.toBe(true);
+
+    expect(mockDb.teamUser.create).toHaveBeenCalledWith({
+      data: { teamId: 10, userId: 2, role: "MEMBER" },
+    });
+    expect(mockDb.teamInvite.delete).toHaveBeenCalledWith({
+      where: { id: "invite_1" },
+    });
+  });
+});

--- a/apps/web/src/server/api/routers/invitiation.ts
+++ b/apps/web/src/server/api/routers/invitiation.ts
@@ -17,9 +17,9 @@ export const invitationRouter = createTRPCRouter({
 
       const invites = await ctx.db.teamInvite.findMany({
         where: {
-          ...(input.inviteId
-            ? { id: input.inviteId }
-            : { email: ctx.session.user.email }),
+          ...(input.inviteId ? { id: input.inviteId } : {}),
+          email: { equals: ctx.session.user.email, mode: "insensitive" },
+          expiresAt: { gt: new Date() },
         },
         include: {
           team: true,
@@ -32,9 +32,13 @@ export const invitationRouter = createTRPCRouter({
   getInvite: protectedProcedure
     .input(z.object({ inviteId: z.string() }))
     .query(async ({ ctx, input }) => {
-      const invite = await ctx.db.teamInvite.findUnique({
+      if (!ctx.session.user.email) return null;
+
+      const invite = await ctx.db.teamInvite.findFirst({
         where: {
           id: input.inviteId,
+          email: { equals: ctx.session.user.email, mode: "insensitive" },
+          expiresAt: { gt: new Date() },
         },
       });
 
@@ -44,33 +48,42 @@ export const invitationRouter = createTRPCRouter({
   acceptTeamInvite: protectedProcedure
     .input(z.object({ inviteId: z.string() }))
     .mutation(async ({ ctx, input }) => {
-      const invite = await ctx.db.teamInvite.findUnique({
-        where: {
-          id: input.inviteId,
-        },
-      });
-
-      if (!invite) {
+      if (!ctx.session.user.email) {
         throw new TRPCError({
           code: "NOT_FOUND",
           message: "Invite not found",
         });
       }
 
-      await ctx.db.teamUser.create({
-        data: {
-          teamId: invite.teamId,
-          userId: ctx.session.user.id,
-          role: invite.role,
-        },
-      });
+      await ctx.db.$transaction(async (tx) => {
+        const invite = await tx.teamInvite.findFirst({
+          where: {
+            id: input.inviteId,
+            email: {
+              equals: ctx.session.user.email!,
+              mode: "insensitive",
+            },
+            expiresAt: { gt: new Date() },
+          },
+        });
 
-      await ctx.db.teamInvite.delete({
-        where: {
-          id: input.inviteId,
-        },
+        if (!invite) {
+          throw new TRPCError({
+            code: "NOT_FOUND",
+            message: "Invite not found",
+          });
+        }
+
+        await tx.teamUser.create({
+          data: {
+            teamId: invite.teamId,
+            userId: ctx.session.user.id,
+            role: invite.role,
+          },
+        });
+
+        await tx.teamInvite.delete({ where: { id: invite.id } });
       });
-      // No need to invalidate cache here again
 
       return true;
     }),

--- a/apps/web/src/server/api/trpc.trpc.test.ts
+++ b/apps/web/src/server/api/trpc.trpc.test.ts
@@ -19,6 +19,7 @@ vi.mock("~/server/auth", () => ({
 
 import {
   authedProcedure,
+  adminProcedure,
   createCallerFactory,
   createTRPCRouter,
   protectedProcedure,
@@ -31,6 +32,9 @@ const testRouter = createTRPCRouter({
     userId: ctx.session.user.id,
   })),
   protectedPing: protectedProcedure.query(({ ctx }) => ({
+    userId: ctx.session.user.id,
+  })),
+  adminPing: adminProcedure.query(({ ctx }) => ({
     userId: ctx.session.user.id,
   })),
   teamPing: teamProcedure.query(({ ctx }) => ({ teamId: ctx.team.id })),
@@ -80,6 +84,22 @@ describe("tRPC middleware procedures", () => {
     await expect(caller.protectedPing()).rejects.toMatchObject({
       code: "UNAUTHORIZED",
     });
+  });
+
+  it("blocks instance administration for ordinary authenticated users", async () => {
+    const caller = createCaller(getContext({ user: baseUser }));
+
+    await expect(caller.adminPing()).rejects.toMatchObject({
+      code: "UNAUTHORIZED",
+    });
+  });
+
+  it("allows persisted instance administrators", async () => {
+    const caller = createCaller(
+      getContext({ user: { ...baseUser, isAdmin: true } }),
+    );
+
+    await expect(caller.adminPing()).resolves.toEqual({ userId: 1 });
   });
 
   it("loads team context for team procedure", async () => {

--- a/apps/web/src/server/api/trpc.ts
+++ b/apps/web/src/server/api/trpc.ts
@@ -10,7 +10,6 @@
 import { initTRPC, TRPCError } from "@trpc/server";
 import superjson from "superjson";
 import { z, ZodError } from "zod";
-import { env } from "~/env";
 
 import { getServerAuthSession } from "~/server/auth";
 import { db } from "~/server/db";
@@ -261,11 +260,9 @@ export const templateProcedure = teamProcedure
     return next({ ctx: { ...ctx, template } });
   });
 
-/**
- * To manage application settings, for hosted version, authenticated users will be considered as admin
- */
+/** Manage instance-wide settings. */
 export const adminProcedure = protectedProcedure.use(async ({ ctx, next }) => {
-  if (env.NEXT_PUBLIC_IS_CLOUD && ctx.session.user.email !== env.ADMIN_EMAIL) {
+  if (!ctx.session.user.isAdmin) {
     throw new TRPCError({ code: "UNAUTHORIZED" });
   }
   return next();

--- a/apps/web/src/server/auth.ts
+++ b/apps/web/src/server/auth.ts
@@ -4,15 +4,20 @@ import {
   type DefaultSession,
   type NextAuthOptions,
 } from "next-auth";
-import { type Adapter } from "next-auth/adapters";
+import { type Adapter, type AdapterUser } from "next-auth/adapters";
 import GitHubProvider from "next-auth/providers/github";
 import EmailProvider from "next-auth/providers/email";
 import GoogleProvider from "next-auth/providers/google";
 import { Provider } from "next-auth/providers/index";
+import { Prisma } from "@prisma/client";
 
 import { sendSignUpEmail } from "~/server/mailer";
 import { env } from "~/env";
 import { db } from "~/server/db";
+import {
+  canRegisterSelfHostedUser,
+  normalizeAuthEmail,
+} from "~/server/auth/registration-policy";
 
 const GITHUB_OAUTH_ISSUER = "https://github.com/login/oauth";
 
@@ -41,8 +46,56 @@ declare module "next-auth" {
     isBetaUser: boolean;
     isAdmin: boolean;
     isWaitlisted: boolean;
+    isInstanceAdmin: boolean;
   }
 }
+
+const prismaAdapter = PrismaAdapter(db) as Adapter;
+
+const createUser: NonNullable<Adapter["createUser"]> = async (user) => {
+  if (env.NEXT_PUBLIC_IS_CLOUD) {
+    return prismaAdapter.createUser!(user);
+  }
+
+  if (!user.email) {
+    throw new Error("Self-hosted registration requires an email address");
+  }
+
+  const email = normalizeAuthEmail(user.email);
+
+  return db.$transaction(
+    async (tx) => {
+      const userCount = await tx.user.count();
+
+      if (userCount > 0) {
+        const invite = await tx.teamInvite.findFirst({
+          where: {
+            email: { equals: email, mode: "insensitive" },
+            expiresAt: { gt: new Date() },
+          },
+          select: { id: true },
+        });
+
+        if (!invite) {
+          throw new Error("Self-hosted registration is invite-only");
+        }
+      }
+
+      const createdUser = await tx.user.create({
+        data: {
+          name: user.name,
+          email,
+          emailVerified: user.emailVerified,
+          image: user.image,
+          isInstanceAdmin: userCount === 0,
+        },
+      });
+
+      return createdUser as unknown as AdapterUser;
+    },
+    { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
+  );
+};
 
 /**
  * Auth providers
@@ -106,18 +159,29 @@ function getProviders() {
  */
 export const authOptions: NextAuthOptions = {
   callbacks: {
+    signIn: async ({ user }) => {
+      if (env.NEXT_PUBLIC_IS_CLOUD) return true;
+      if (!user.email) return false;
+
+      return canRegisterSelfHostedUser(db, user.email);
+    },
     session: ({ session, user }) => ({
       ...session,
       user: {
         ...session.user,
         id: user.id,
         isBetaUser: user.isBetaUser,
-        isAdmin: user.email === env.ADMIN_EMAIL,
+        isAdmin: env.NEXT_PUBLIC_IS_CLOUD
+          ? user.email === env.ADMIN_EMAIL
+          : user.isInstanceAdmin || user.email === env.ADMIN_EMAIL,
         isWaitlisted: user.isWaitlisted,
       },
     }),
   },
-  adapter: PrismaAdapter(db) as Adapter,
+  adapter: {
+    ...prismaAdapter,
+    createUser,
+  },
   pages: {
     signIn: "/login",
   },
@@ -127,7 +191,10 @@ export const authOptions: NextAuthOptions = {
 
       if (user.email) {
         const invites = await db.teamInvite.findMany({
-          where: { email: user.email },
+          where: {
+            email: { equals: user.email, mode: "insensitive" },
+            expiresAt: { gt: new Date() },
+          },
         });
 
         invitesAvailable = invites.length > 0;

--- a/apps/web/src/server/auth/registration-policy.ts
+++ b/apps/web/src/server/auth/registration-policy.ts
@@ -1,0 +1,42 @@
+import type { Prisma, PrismaClient } from "@prisma/client";
+
+export const TEAM_INVITE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+type RegistrationClient = PrismaClient | Prisma.TransactionClient;
+
+export function normalizeAuthEmail(email: string) {
+  return email.trim().toLowerCase();
+}
+
+export function getTeamInviteExpiry(now = new Date()) {
+  return new Date(now.getTime() + TEAM_INVITE_TTL_MS);
+}
+
+export async function canRegisterSelfHostedUser(
+  client: RegistrationClient,
+  email: string,
+  now = new Date(),
+) {
+  const normalizedEmail = normalizeAuthEmail(email);
+  const existingUser = await client.user.findFirst({
+    where: {
+      email: { equals: normalizedEmail, mode: "insensitive" },
+    },
+    select: { id: true },
+  });
+
+  if (existingUser) return true;
+
+  const userCount = await client.user.count();
+  if (userCount === 0) return true;
+
+  const invite = await client.teamInvite.findFirst({
+    where: {
+      email: { equals: normalizedEmail, mode: "insensitive" },
+      expiresAt: { gt: now },
+    },
+    select: { id: true },
+  });
+
+  return Boolean(invite);
+}

--- a/apps/web/src/server/auth/registration-policy.unit.test.ts
+++ b/apps/web/src/server/auth/registration-policy.unit.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  canRegisterSelfHostedUser,
+  getTeamInviteExpiry,
+  normalizeAuthEmail,
+} from "./registration-policy";
+
+const client = {
+  user: {
+    findFirst: vi.fn(),
+    count: vi.fn(),
+  },
+  teamInvite: {
+    findFirst: vi.fn(),
+  },
+};
+
+describe("self-hosted registration policy", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    client.user.findFirst.mockResolvedValue(null);
+    client.user.count.mockResolvedValue(1);
+    client.teamInvite.findFirst.mockResolvedValue(null);
+  });
+
+  it("always permits an existing user to log in", async () => {
+    client.user.findFirst.mockResolvedValue({ id: 42 });
+
+    await expect(
+      canRegisterSelfHostedUser(client as never, " Existing@Example.com "),
+    ).resolves.toBe(true);
+
+    expect(client.user.count).not.toHaveBeenCalled();
+  });
+
+  it("permits the first user on a fresh installation", async () => {
+    client.user.count.mockResolvedValue(0);
+
+    await expect(
+      canRegisterSelfHostedUser(client as never, "owner@example.com"),
+    ).resolves.toBe(true);
+
+    expect(client.teamInvite.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("permits a new user with an unexpired matching invitation", async () => {
+    client.teamInvite.findFirst.mockResolvedValue({ id: "invite_1" });
+
+    await expect(
+      canRegisterSelfHostedUser(client as never, "MEMBER@example.com"),
+    ).resolves.toBe(true);
+
+    expect(client.teamInvite.findFirst).toHaveBeenCalledWith({
+      where: {
+        email: { equals: "member@example.com", mode: "insensitive" },
+        expiresAt: { gt: expect.any(Date) },
+      },
+      select: { id: true },
+    });
+  });
+
+  it("rejects an uninvited new user after bootstrap", async () => {
+    await expect(
+      canRegisterSelfHostedUser(client as never, "stranger@example.com"),
+    ).resolves.toBe(false);
+  });
+
+  it("normalizes emails and gives invitations a seven-day lifetime", () => {
+    const now = new Date("2026-07-11T00:00:00.000Z");
+
+    expect(normalizeAuthEmail(" User@Example.COM ")).toBe("user@example.com");
+    expect(getTeamInviteExpiry(now)).toEqual(
+      new Date("2026-07-18T00:00:00.000Z"),
+    );
+  });
+});

--- a/apps/web/src/server/service/team-service.ts
+++ b/apps/web/src/server/service/team-service.ts
@@ -10,6 +10,7 @@ import { LimitReason } from "~/lib/constants/plans";
 import { LimitService } from "./limit-service";
 import { renderUsageLimitReachedEmail } from "../email-templates/UsageLimitReachedEmail";
 import { renderUsageWarningEmail } from "../email-templates/UsageWarningEmail";
+import { getTeamInviteExpiry } from "../auth/registration-policy";
 
 // Cache stores exactly Prisma Team shape (no counts)
 
@@ -162,6 +163,8 @@ export class TeamService {
       });
     }
 
+    const normalizedEmail = email.trim().toLowerCase();
+
     const { isLimitReached } = await LimitService.checkTeamMemberLimit(teamId);
     if (isLimitReached) {
       throw new UnsendApiError({
@@ -170,9 +173,9 @@ export class TeamService {
       });
     }
 
-    const user = await db.user.findUnique({
+    const user = await db.user.findFirst({
       where: {
-        email,
+        email: { equals: normalizedEmail, mode: "insensitive" },
       },
       include: {
         teamUsers: true,
@@ -189,15 +192,16 @@ export class TeamService {
     const teamInvite = await db.teamInvite.create({
       data: {
         teamId,
-        email,
+        email: normalizedEmail,
         role,
+        expiresAt: getTeamInviteExpiry(),
       },
     });
 
     const teamUrl = `${env.NEXTAUTH_URL}/join-team?inviteId=${teamInvite.id}`;
 
     if (sendEmail) {
-      await sendTeamInviteEmail(email, teamUrl, teamName);
+      await sendTeamInviteEmail(normalizedEmail, teamUrl, teamName);
     }
 
     return teamInvite;
@@ -327,6 +331,11 @@ export class TeamService {
         message: "Invite not found",
       });
     }
+
+    await db.teamInvite.update({
+      where: { id: invite.id },
+      data: { expiresAt: getTeamInviteExpiry() },
+    });
 
     const teamUrl = `${env.NEXTAUTH_URL}/join-team?inviteId=${invite.id}`;
 


### PR DESCRIPTION
## What changed

- make self-hosted registration invite-only after the first account
- persist an instance-admin role and atomically grant it to the first self-hosted user
- preserve existing installations by promoting the oldest team administrator during migration
- expire team invitations after seven days and renew expiry when resending
- require invite IDs to match the authenticated email and consume accepted invites transactionally
- restrict instance-wide admin APIs and UI to actual instance administrators

## Why

Self-hosted deployments currently allow any reachable user to create an account, bypass the cloud waitlist, and pass instance-wide admin authorization. Invite links also do not verify that the authenticated user's email matches the invitation.

## Impact

Fresh installations bootstrap with one instance administrator. Existing users continue to sign in normally. New users on initialized self-hosted installations must have a matching, unexpired invitation.

The migration adds `User.isInstanceAdmin` and `TeamInvite.expiresAt`. Existing installations promote the oldest team administrator, falling back to the oldest user when team setup is incomplete.

## Verification

- registration policy unit tests: 5 passed
- instance-admin and invitation authorization TRPC tests: 10 passed
- targeted ESLint: no errors; two unrelated pre-existing warnings remain in `AppSideBar.tsx` and `trpc.ts`
- `git diff --check` passed
- GitHub Web Tests passed
- Cloudflare and Vercel preview deployments passed

No database migration was executed locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added secure self-hosted registration, allowing the first user to become the instance administrator.
  - Added instance-level administrator permissions for accessing administrative settings.
  - Added seven-day expiration dates for team invitations, refreshed when invitations are resent.

- **Bug Fixes**
  - Restricted invitation viewing and acceptance to the intended email address.
  - Prevented expired or mismatched invitations from being accepted.
  - Improved email normalization for registration and team invitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->