### PR TITLE
fix: restore pnpm deployment compatibility

### DIFF
--- a/.github/workflows/release-js-package.yml
+++ b/.github/workflows/release-js-package.yml
@@ -24,10 +24,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Set up Node.js 22.13
+      - name: Set up Node.js 22.22.2
         uses: actions/setup-node@v4
         with:
-          node-version: 22.13
+          node-version: 22.22.2
           registry-url: "https://registry.npmjs.org"
 
       - name: Set up pnpm
@@ -36,7 +36,7 @@ jobs:
           version: 11.11.0
 
       - name: Update npm for OIDC support
-        run: npm install -g npm@latest
+        run: npm install -g npm@11.6.2
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,0 +1,2 @@
+[phases.install]
+cmds = ["npm install -g corepack@0.34.5 && corepack enable", "pnpm i --frozen-lockfile"]


### PR DESCRIPTION
## Summary

- override Nixpacks 1.41.0's obsolete Corepack 0.24.1 with Corepack 0.34.5 so Railway can run pnpm 11.11.0 on Node 24.10
- update the SDK release runner from Node 22.13 to 22.22.2
- pin npm 11.6.2 for deterministic OIDC publishing instead of installing the moving `npm@latest` target

## Root causes

- Railway failed before dependency installation because Nixpacks hardcodes Corepack 0.24.1, which crashes while launching pnpm 11.11.0
- the release job failed because `npm@latest` now resolves to npm 12, which does not support Node 22.13

## Verification

- generated and inspected the merged Nixpacks 1.41.0 plan; existing Node, Chromium/system packages, caches, build command, and start command remain intact
- built the Nixpacks-generated image through pnpm 11.11.0 frozen install and all six Turbo build tasks successfully (the local OrbStack-only Nix garbage-collection permission step was skipped; repository-controlled stages were unchanged)
- reproduced the release environment with Node 22.22.2, npm 11.6.2, and pnpm 11.11.0 in a clean container
- `pnpm install --frozen-lockfile` passed
- SDK build passed
- `npm pack --dry-run` passed without publishing

No migrations were run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release environment to use Node.js 22.22.2 and npm 11.6.2.
  * Standardized package installation with Corepack and pnpm using the locked dependency versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore `pnpm` 11 deployments on Railway by overriding Nixpacks’ `corepack` and tightening CI toolchain versions. Prevents install crashes and makes OIDC publishing deterministic.

- **Bug Fixes**
  - Add `nixpacks.toml` to install `corepack@0.34.5` and enable it before `pnpm i --frozen-lockfile` (fixes Nixpacks 1.41.0 using `corepack` 0.24.1 that crashes with `pnpm` 11.11.0 on Node 24.10).
  - Update SDK release workflow to Node 22.22.2.
  - Pin `npm@11.6.2` (replaces `npm@latest`) for OIDC and Node 22 compatibility.

<sup>Written for commit f27c7d70f6eb5bba54f4b1dc680a96c571cb17ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usesend/useSend/pull/420?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

