### PR TITLE
fix: variable popover no longer opens on range selection in email editor

### DIFF
--- a/packages/email-editor/src/nodes/variable.tsx
+++ b/packages/email-editor/src/nodes/variable.tsx
@@ -9,6 +9,7 @@ import { Input } from "@usesend/ui/src/input";
 import { Button } from "@usesend/ui/src/button";
 import { forwardRef, useEffect, useImperativeHandle, useState } from "react";
 import { SuggestionOptions } from "@tiptap/suggestion";
+import { NodeSelection } from "@tiptap/pm/state";
 import tippy, { GetReferenceClientRect } from "tippy.js";
 import { CheckIcon, TriangleAlert } from "lucide-react";
 
@@ -170,8 +171,26 @@ export function VariableComponent(props: NodeViewProps) {
   const { name, fallback } = props.node.attrs as VariableOptions;
   const [fallbackValue, setFallbackValue] = useState(fallback);
   const { getPos, editor } = props;
+  // `props.selected` is true whenever the node falls inside any selection
+  // range, so it can't drive the popover: dragging over text would open the
+  // fallback input on every variable in the range. Only a NodeSelection
+  // pointing at this node (a direct click on the chip) should open it.
+  const [popoverOpen, setPopoverOpen] = useState(false);
 
-  console.log(props.selected);
+  useEffect(() => {
+    const updatePopoverState = () => {
+      const { selection } = editor.state;
+      setPopoverOpen(
+        selection instanceof NodeSelection && selection.from === getPos(),
+      );
+    };
+
+    updatePopoverState();
+    editor.on("selectionUpdate", updatePopoverState);
+    return () => {
+      editor.off("selectionUpdate", updatePopoverState);
+    };
+  }, [editor, getPos]);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -188,7 +207,7 @@ export function VariableComponent(props: NodeViewProps) {
       draggable="false"
       data-drag-handle=""
     >
-      <Popover open={props.selected}>
+      <Popover open={popoverOpen}>
         <PopoverTrigger asChild>
           <button
             className={cn(


### PR DESCRIPTION
Closes #277

## Problem
Selecting text in the email editor that contains variable chips popped open the fallback-value input on every variable in the selection, making it impossible to cleanly select and copy content in or out of the editor (see the screen recording in the issue).

Root cause: the popover was bound directly to tiptap's `selected` NodeView prop (`<Popover open={props.selected}>`). tiptap sets `selected` whenever the node is covered by **any** selection range, including drag and keyboard range selections, not just direct clicks on the node.

## Fix
Track popover visibility in component state driven by the editor's `selectionUpdate` event, and open it only when the current selection is a `NodeSelection` whose position matches this node, i.e. the user actually clicked the variable chip.

- Range selections over variables now behave like plain text selection: no popovers, copy works.
- Clicking a chip still opens the fallback input exactly as before.
- The chip keeps its `ProseMirror-selectednode` highlight when inside a range selection (still uses `props.selected`), so visual selection feedback is unchanged.
- Listening to `selectionUpdate` (rather than a render-time check) also covers the edge where tiptap skips re-rendering because `selected` didn't change, e.g. extending a node selection into a range selection with shift+arrows.

## Changes
- `packages/email-editor/src/nodes/variable.tsx`: popover state from `selectionUpdate` + `NodeSelection` check; removed a stray `console.log`

## Verification
- `tsc --noEmit` on `packages/email-editor` passes
- Manual: in the template editor, drag-select across text containing `{{variables}}`, no popovers appear and copy/paste works; click a chip and the fallback popover opens as before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Summary

* **Bug Fixes**
  * Updated the variable fallback popover to open only when the variable node itself is directly selected.
  * Prevented the popover from appearing for unrelated selections or cursor positions.
  * Removed unintended console output related to variable selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->