### PR TITLE
fix: reject invalid SES regions

### DIFF
--- a/apps/web/src/components/settings/AddSesSettings.tsx
+++ b/apps/web/src/components/settings/AddSesSettings.tsx
@@ -18,9 +18,10 @@ import { Button } from "@usesend/ui/src/button";
 import Spinner from "@usesend/ui/src/spinner";
 import { toast } from "@usesend/ui/src/toaster";
 import { isLocalhost } from "~/utils/client";
+import { sesRegionSchema } from "~/lib/zod/ses-setting-schema";
 
 const FormSchema = z.object({
-  region: z.string(),
+  region: sesRegionSchema,
   usesendUrl: z.string().url(),
   sendRate: z.coerce.number(),
   transactionalQuota: z.coerce.number().min(0).max(100),
@@ -48,14 +49,51 @@ export const AddSesSettings: React.FC<SesSettingsProps> = ({ onSuccess }) => {
 export const AddSesSettingsForm: React.FC<SesSettingsProps> = ({
   onSuccess,
 }) => {
-  const addSesSettings = api.admin.addSesSettings.useMutation();
+  const defaultRegion = api.admin.getDefaultSesRegion.useQuery();
 
+  if (defaultRegion.isLoading) {
+    return (
+      <div className="flex min-h-[500px] items-center justify-center">
+        <Spinner className="h-5 w-5" />
+      </div>
+    );
+  }
+
+  if (!defaultRegion.data) {
+    return (
+      <div className="flex min-h-[500px] flex-col items-center justify-center gap-3 text-center">
+        <p className="text-sm text-muted-foreground" role="alert">
+          Failed to load the default AWS region.
+        </p>
+        <Button
+          type="button"
+          variant="outline"
+          onClick={() => void defaultRegion.refetch()}
+        >
+          Retry
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <SesSettingsForm
+      defaultRegion={defaultRegion.data}
+      onSuccess={onSuccess}
+    />
+  );
+};
+
+const SesSettingsForm: React.FC<
+  SesSettingsProps & { defaultRegion: string }
+> = ({ defaultRegion, onSuccess }) => {
+  const addSesSettings = api.admin.addSesSettings.useMutation();
   const utils = api.useUtils();
 
   const form = useForm<z.infer<typeof FormSchema>>({
     resolver: zodResolver(FormSchema),
     defaultValues: {
-      region: "",
+      region: defaultRegion,
       usesendUrl: "",
       sendRate: 1,
       transactionalQuota: 50,
@@ -101,10 +139,12 @@ export const AddSesSettingsForm: React.FC<SesSettingsProps> = ({
   }
 
   const onRegionInputOutOfFocus = async () => {
-    const region = form.getValues("region");
+    const region = sesRegionSchema.safeParse(form.getValues("region"));
 
-    if (region) {
-      const quota = await utils.admin.getQuotaForRegion.fetch({ region });
+    if (region.success) {
+      const quota = await utils.admin.getQuotaForRegion.fetch({
+        region: region.data,
+      });
       form.setValue("sendRate", quota ?? 1);
     }
   };
@@ -113,7 +153,7 @@ export const AddSesSettingsForm: React.FC<SesSettingsProps> = ({
     <Form {...form}>
       <form
         onSubmit={form.handleSubmit(onSubmit)}
-        className=" flex flex-col gap-8 w-full"
+        className=" flex min-h-[500px] flex-col gap-8 w-full"
       >
         <FormField
           control={form.control}

--- a/apps/web/src/components/settings/AddSesSettings.tsx
+++ b/apps/web/src/components/settings/AddSesSettings.tsx
@@ -142,10 +142,19 @@ const SesSettingsForm: React.FC<
     const region = sesRegionSchema.safeParse(form.getValues("region"));
 
     if (region.success) {
-      const quota = await utils.admin.getQuotaForRegion.fetch({
-        region: region.data,
-      });
-      form.setValue("sendRate", quota ?? 1);
+      form.clearErrors("region");
+
+      try {
+        const quota = await utils.admin.getQuotaForRegion.fetch({
+          region: region.data,
+        });
+        form.setValue("sendRate", quota ?? 1);
+      } catch {
+        form.setValue("sendRate", 1);
+        form.setError("region", {
+          message: "Unable to load the SES quota for this region",
+        });
+      }
     }
   };
 

--- a/apps/web/src/env.js
+++ b/apps/web/src/env.js
@@ -1,6 +1,7 @@
 import { EmailStatus } from "@prisma/client";
 import { createEnv } from "@t3-oss/env-nextjs";
 import { z } from "zod";
+import { sesRegionSchema } from "~/lib/zod/ses-setting-schema";
 
 export const env = createEnv({
   /**
@@ -39,7 +40,7 @@ export const env = createEnv({
     GOOGLE_CLIENT_SECRET: z.string().optional(),
     AWS_SES_ENDPOINT: z.string().optional(),
     AWS_SNS_ENDPOINT: z.string().optional(),
-    AWS_DEFAULT_REGION: z.string().default("us-east-1"),
+    AWS_DEFAULT_REGION: sesRegionSchema.default("us-east-1"),
     API_RATE_LIMIT: z
       .string()
       .default("1")

--- a/apps/web/src/env.js
+++ b/apps/web/src/env.js
@@ -1,7 +1,6 @@
 import { EmailStatus } from "@prisma/client";
 import { createEnv } from "@t3-oss/env-nextjs";
 import { z } from "zod";
-import { sesRegionSchema } from "~/lib/zod/ses-setting-schema";
 
 export const env = createEnv({
   /**
@@ -40,7 +39,11 @@ export const env = createEnv({
     GOOGLE_CLIENT_SECRET: z.string().optional(),
     AWS_SES_ENDPOINT: z.string().optional(),
     AWS_SNS_ENDPOINT: z.string().optional(),
-    AWS_DEFAULT_REGION: sesRegionSchema.default("us-east-1"),
+    AWS_DEFAULT_REGION: z
+      .string()
+      .trim()
+      .min(1, "Region is required")
+      .default("us-east-1"),
     API_RATE_LIMIT: z
       .string()
       .default("1")

--- a/apps/web/src/lib/zod/ses-setting-schema.ts
+++ b/apps/web/src/lib/zod/ses-setting-schema.ts
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const sesRegionSchema = z.string().trim().min(1, "Region is required");
+
+export function getValidSesRegions(regions: string[]) {
+  return [...new Set(regions.map((region) => region.trim()).filter(Boolean))];
+}

--- a/apps/web/src/lib/zod/ses-setting-schema.unit.test.ts
+++ b/apps/web/src/lib/zod/ses-setting-schema.unit.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import {
+  getValidSesRegions,
+  sesRegionSchema,
+} from "~/lib/zod/ses-setting-schema";
+
+describe("sesRegionSchema", () => {
+  it("rejects empty regions", () => {
+    expect(sesRegionSchema.safeParse("").success).toBe(false);
+    expect(sesRegionSchema.safeParse("   ").success).toBe(false);
+  });
+
+  it("normalizes valid regions", () => {
+    expect(sesRegionSchema.parse(" us-east-1 ")).toBe("us-east-1");
+  });
+});
+
+describe("getValidSesRegions", () => {
+  it("filters legacy empty regions and removes duplicates", () => {
+    expect(
+      getValidSesRegions(["", "  ", "us-east-1", " us-east-1 ", "eu-west-1"]),
+    ).toEqual(["us-east-1", "eu-west-1"]);
+  });
+});

--- a/apps/web/src/server/api/routers/admin.ts
+++ b/apps/web/src/server/api/routers/admin.ts
@@ -11,6 +11,7 @@ import { logger } from "~/server/logger/log";
 import { UseSend } from "usesend-js";
 import { isCloud } from "~/utils/common";
 import { toPlainHtml } from "~/server/utils/email-content";
+import { sesRegionSchema } from "~/lib/zod/ses-setting-schema";
 
 const waitlistUserSelection = {
   id: true,
@@ -67,10 +68,12 @@ export const adminRouter = createTRPCRouter({
     return SesSettingsService.getAllSettings();
   }),
 
+  getDefaultSesRegion: adminProcedure.query(() => env.AWS_DEFAULT_REGION),
+
   getQuotaForRegion: adminProcedure
     .input(
       z.object({
-        region: z.string(),
+        region: sesRegionSchema,
       }),
     )
     .query(async ({ input }) => {
@@ -81,7 +84,7 @@ export const adminRouter = createTRPCRouter({
   addSesSettings: adminProcedure
     .input(
       z.object({
-        region: z.string(),
+        region: sesRegionSchema,
         usesendUrl: z.string().url(),
         sendRate: z.number(),
         transactionalQuota: z.number(),

--- a/apps/web/src/server/api/routers/domain.ts
+++ b/apps/web/src/server/api/routers/domain.ts
@@ -16,15 +16,19 @@ import {
 } from "~/server/service/domain-service";
 import { sendEmail } from "~/server/service/email-service";
 import { SesSettingsService } from "~/server/service/ses-settings-service";
+import {
+  getValidSesRegions,
+  sesRegionSchema,
+} from "~/lib/zod/ses-setting-schema";
 
 export const domainRouter = createTRPCRouter({
   getAvailableRegions: protectedProcedure.query(async () => {
     const settings = await SesSettingsService.getAllSettings();
-    return settings.map((setting) => setting.region);
+    return getValidSesRegions(settings.map((setting) => setting.region));
   }),
 
   createDomain: teamProcedure
-    .input(z.object({ name: z.string(), region: z.string() }))
+    .input(z.object({ name: z.string(), region: sesRegionSchema }))
     .mutation(async ({ ctx, input }) => {
       return createDomain(
         ctx.team.id,

--- a/apps/web/src/server/service/ses-settings-service.ts
+++ b/apps/web/src/server/service/ses-settings-service.ts
@@ -7,6 +7,7 @@ import { EventType } from "@aws-sdk/client-sesv2";
 import { EmailQueueService } from "./email-queue-service";
 import { smallNanoid } from "../nanoid";
 import { logger } from "../logger/log";
+import { sesRegionSchema } from "~/lib/zod/ses-setting-schema";
 
 const GENERAL_EVENTS: EventType[] = [
   "BOUNCE",
@@ -62,6 +63,8 @@ export class SesSettingsService {
     sendingRateLimit: number;
     transactionalQuota: number;
   }) {
+    region = sesRegionSchema.parse(region);
+
     await this.checkInitialized();
     if (this.cache[region]) {
       throw new Error(`SesSetting for region ${region} already exists`);

--- a/apps/web/src/server/service/ses-settings-service.ts
+++ b/apps/web/src/server/service/ses-settings-service.ts
@@ -28,10 +28,12 @@ export class SesSettingsService {
   public static async getSetting(
     region = env.AWS_DEFAULT_REGION
   ): Promise<SesSetting | null> {
+    const normalizedRegion = sesRegionSchema.parse(region);
+
     await this.checkInitialized();
 
-    if (this.cache[region]) {
-      return this.cache[region] as SesSetting;
+    if (this.cache[normalizedRegion]) {
+      return this.cache[normalizedRegion] as SesSetting;
     }
     return null;
   }


### PR DESCRIPTION
Closes #85

## What changed

- validate and normalize SES regions consistently in the form, tRPC inputs, environment configuration, and service layer
- load `AWS_DEFAULT_REGION` before mounting the SES settings form, with stable loading and retry states
- filter blank legacy regions and deduplicate valid regions before rendering the Add Domain selector
- reject blank regions when creating domains
- add unit coverage for blank, whitespace, normalization, and legacy-region filtering

## Root cause

The SES settings form initialized `region` as an empty string while displaying `us-east-1` only as a placeholder. Both client and server schemas used `z.string()`, which accepts empty and whitespace-only values. Older versions could persist that invalid setting before AWS provisioning failed. When a valid setting was added later, the Add Domain dialog rendered both regions and passed the blank one to Radix as `<SelectItem value="">`, causing the client-side exception.

## Impact

New blank SES regions are rejected before AWS side effects. Existing installations with a legacy blank row can open Add Domain safely; only normalized, valid region choices are shown. The invalid row remains visible in Admin for deliberate cleanup.

## Verification

- `pnpm --filter=web exec vitest run -c vitest.unit.config.ts src/lib/zod/ses-setting-schema.unit.test.ts` (3 tests passed)
- ESLint passed for all changed TypeScript/TSX files
- `apps/web/src/env.js` passed ESLint with `--quiet`
- no build or database migrations run

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject invalid SES regions and normalize them across the form, API, env, and service to stop blank-region crashes in Add Domain. The default region now loads before the form; region choices are cleaned and deduped so existing installs can open Add Domain safely.

- **Bug Fixes**
  - Added shared `sesRegionSchema` to trim/validate regions and reject blanks; `AWS_DEFAULT_REGION` is validated inline (trim + required) to keep env loading Node-compatible.
  - Load `AWS_DEFAULT_REGION` before rendering the SES settings form with loading/retry states.
  - Clean and dedupe region options in Add Domain; enforce schema when creating domains.
  - Handle SES quota lookup failures: show a field error and fall back to a safe default send rate.
  - Unit tests cover normalization, empty values, and legacy-region filtering.

<sup>Written for commit c9432f7f4feb8170c1401405e9bb9da0bc0a685c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usesend/useSend/pull/424?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The SES settings form now loads and preselects the default region, showing a loading state and a Retry option if it fails.
  * Sending quota now updates automatically based on the entered region.
  * Available SES regions are cleaned up, deduplicated, and presented consistently.

* **Bug Fixes**
  * SES region values are now trimmed and validated consistently across settings and domain creation, with clearer handling of invalid/blank inputs.
  * Server-side `AWS_DEFAULT_REGION` validation was tightened to reject blank/whitespace-only values.

* **Tests**
  * Added unit tests covering SES region validation and normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->