### PR TITLE
fix: deduplicate dashboard engagement usage

### DIFF
--- a/apps/web/src/server/service/ses-hook-parser.ts
+++ b/apps/web/src/server/service/ses-hook-parser.ts
@@ -101,6 +101,19 @@ export async function parseSesHook(data: SesEvent) {
     return true;
   }
 
+  const isEngagementEvent = [EmailStatus.OPENED, EmailStatus.CLICKED].includes(
+    mailStatus,
+  );
+  const existingMailEvent =
+    email.campaignId || isEngagementEvent
+      ? await db.emailEvent.findFirst({
+          where: {
+            emailId: email.id,
+            status: mailStatus,
+          },
+        })
+      : null;
+
   // Update the latest status and to avoid race conditions
   await db.$executeRaw`
       UPDATE "Email"
@@ -190,7 +203,10 @@ export async function parseSesHook(data: SesEvent) {
     }
   }
 
+  const isDuplicateEngagement = Boolean(existingMailEvent) && isEngagementEvent;
+
   if (
+    !isDuplicateEngagement &&
     [
       "DELIVERED",
       "OPENED",
@@ -274,14 +290,7 @@ export async function parseSesHook(data: SesEvent) {
         mailData: data,
       });
 
-      const mailEvent = await db.emailEvent.findFirst({
-        where: {
-          emailId: email.id,
-          status: mailStatus,
-        },
-      });
-
-      if (!mailEvent) {
+      if (!existingMailEvent) {
         await updateCampaignAnalytics(
           email.campaignId,
           mailStatus,

--- a/apps/web/src/server/service/ses-hook-parser.unit.test.ts
+++ b/apps/web/src/server/service/ses-hook-parser.unit.test.ts
@@ -1,0 +1,186 @@
+import { EmailStatus } from "@prisma/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SesEvent } from "~/types/aws-types";
+
+const { mockDb, mockUpdateCampaignAnalytics, mockWebhookEmit } = vi.hoisted(
+  () => ({
+    mockDb: {
+      $executeRaw: vi.fn(),
+      email: {
+        findUnique: vi.fn(),
+        update: vi.fn(),
+      },
+      emailEvent: {
+        findFirst: vi.fn(),
+        create: vi.fn(),
+      },
+      dailyEmailUsage: {
+        upsert: vi.fn(),
+      },
+      cumulatedMetrics: {
+        upsert: vi.fn(),
+      },
+    },
+    mockUpdateCampaignAnalytics: vi.fn(),
+    mockWebhookEmit: vi.fn(),
+  }),
+);
+
+vi.mock("~/server/db", () => ({
+  db: mockDb,
+}));
+
+vi.mock("~/env", () => ({
+  env: {
+    NEXTAUTH_URL: "https://usesend.example",
+  },
+}));
+
+vi.mock("~/server/service/campaign-service", () => ({
+  unsubscribeContact: vi.fn(),
+  updateCampaignAnalytics: mockUpdateCampaignAnalytics,
+}));
+
+vi.mock("~/server/service/webhook-service", () => ({
+  WebhookService: {
+    emit: mockWebhookEmit,
+  },
+}));
+
+vi.mock("~/server/service/suppression-service", () => ({
+  SuppressionService: {
+    addSuppression: vi.fn(),
+  },
+}));
+
+vi.mock("bullmq", () => ({
+  Queue: class {
+    add = vi.fn();
+  },
+  Worker: class {},
+}));
+
+vi.mock("~/server/redis", () => ({
+  BULL_PREFIX: "test",
+  getRedis: vi.fn(() => ({})),
+}));
+
+vi.mock("~/server/logger/log", () => ({
+  getChildLogger: vi.fn(),
+  logger: {
+    error: vi.fn(),
+    info: vi.fn(),
+    setBindings: vi.fn(),
+    warn: vi.fn(),
+  },
+  withLogger: vi.fn(),
+}));
+
+import { parseSesHook } from "~/server/service/ses-hook-parser";
+
+const email = {
+  id: "email_1",
+  sesEmailId: "ses_1",
+  from: "sender@example.com",
+  to: ["recipient@example.com"],
+  replyTo: [],
+  cc: [],
+  bcc: [],
+  subject: "Hello",
+  text: null,
+  html: null,
+  latestStatus: EmailStatus.DELIVERED,
+  teamId: 7,
+  domainId: 11,
+  apiId: null,
+  createdAt: new Date("2026-07-13T00:00:00.000Z"),
+  updatedAt: new Date("2026-07-13T00:00:00.000Z"),
+  scheduledAt: null,
+  attachments: null,
+  campaignId: null,
+  contactId: null,
+  inReplyToId: null,
+  headers: null,
+};
+
+function buildEvent(eventType: "Open" | "Click"): SesEvent {
+  const event = {
+    eventType,
+    mail: {
+      timestamp: "2026-07-13T01:00:00.000Z",
+      source: "sender@example.com",
+      messageId: "ses_1",
+      destination: ["recipient@example.com"],
+      headersTruncated: false,
+      headers: [],
+      commonHeaders: {
+        from: ["sender@example.com"],
+        to: ["recipient@example.com"],
+        messageId: "message_1",
+      },
+      tags: {},
+    },
+  } as SesEvent;
+
+  if (eventType === "Open") {
+    event.open = {
+      ipAddress: "192.0.2.1",
+      timestamp: "2026-07-13T01:00:00.000Z",
+      userAgent: "test-agent",
+    };
+  } else {
+    event.click = {
+      ipAddress: "192.0.2.1",
+      timestamp: "2026-07-13T01:00:00.000Z",
+      userAgent: "test-agent",
+      link: "https://example.com",
+      linkTags: {},
+    };
+  }
+
+  return event;
+}
+
+describe("parseSesHook dashboard engagement usage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDb.email.findUnique.mockResolvedValue(email);
+    mockDb.emailEvent.create.mockResolvedValue({});
+    mockDb.dailyEmailUsage.upsert.mockResolvedValue({});
+    mockWebhookEmit.mockResolvedValue(undefined);
+  });
+
+  it.each([
+    ["Open", EmailStatus.OPENED],
+    ["Click", EmailStatus.CLICKED],
+  ] as const)(
+    "counts only the first %s event for an email",
+    async (eventType, status) => {
+      mockDb.emailEvent.findFirst
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce({ id: "existing_event", status });
+
+      const event = buildEvent(eventType);
+      await parseSesHook(event);
+      await parseSesHook(event);
+
+      expect(mockDb.emailEvent.findFirst).toHaveBeenNthCalledWith(1, {
+        where: {
+          emailId: email.id,
+          status,
+        },
+      });
+      expect(mockDb.dailyEmailUsage.upsert).toHaveBeenCalledTimes(1);
+      expect(mockDb.dailyEmailUsage.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          update: {
+            [status.toLowerCase()]: {
+              increment: 1,
+            },
+          },
+        }),
+      );
+      expect(mockDb.emailEvent.create).toHaveBeenCalledTimes(2);
+    },
+  );
+});


### PR DESCRIPTION
## Summary

- check existing email events before updating dashboard engagement usage
- count only the first open and first click per email while preserving the full event history
- reuse the same event lookup for campaign analytics
- add regression coverage for duplicate open and click webhooks

## Root cause

The SES webhook parser incremented `DailyEmailUsage` before checking whether an event with the same email and status already existed. Campaign analytics performed this deduplication, but dashboard usage did not, so repeated open and click webhooks inflated dashboard totals.

## Verification

- `eslint src/server/service/ses-hook-parser.ts src/server/service/ses-hook-parser.unit.test.ts --max-warnings 0`
- focused unit tests: 2 passed
- complete web unit suite: 113 passed
- `git diff --check`

## Migration notes

No database migration required.

Closes #101


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes inflated dashboard engagement metrics by deduplicating SES open/click events. Only the first open and first click per email increment usage; the same event lookup is reused for campaign analytics to keep counts consistent.

- **Bug Fixes**
  - Check for an existing email event before updating `DailyEmailUsage` for `OPENED`/`CLICKED`.
  - Keep full event history but ignore duplicate opens/clicks for usage totals.
  - Add regression tests for duplicate open/click webhooks.

<sup>Written for commit 90f205cc1729231fde82c7648d9c794c16103cab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usesend/useSend/pull/425?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented duplicate engagement events from inflating daily email usage counters.
  - Improved campaign analytics handling for repeated email opens and clicks.

- **Tests**
  - Added coverage for repeated open and click events.
  - Verified that engagement usage is counted once while event records continue to be captured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->