### PR TITLE
fix: type-check engagement event detection

### DIFF
--- a/.github/workflows/test-web.yml
+++ b/.github/workflows/test-web.yml
@@ -70,6 +70,9 @@ jobs:
       - name: Generate Prisma client
         run: pnpm --filter=web db:generate
 
+      - name: Type check
+        run: pnpm --filter=web typecheck
+
       - name: Prepare test database schema
         run: pnpm --filter=web test:integration:prepare
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -19,6 +19,7 @@
     "test:integration": "RUN_INTEGRATION=true vitest run -c vitest.integration.config.ts",
     "test:integration:full": "pnpm test:integration:prepare:local && pnpm test:integration",
     "test:coverage": "vitest run -c vitest.default.config.ts --coverage",
+    "typecheck": "tsc --noEmit --pretty false",
     "db:post-install": "prisma generate",
     "db:generate": "prisma generate",
     "db:push": "prisma db push --skip-generate",

--- a/apps/web/src/server/service/ses-hook-parser.ts
+++ b/apps/web/src/server/service/ses-hook-parser.ts
@@ -101,9 +101,8 @@ export async function parseSesHook(data: SesEvent) {
     return true;
   }
 
-  const isEngagementEvent = [EmailStatus.OPENED, EmailStatus.CLICKED].includes(
-    mailStatus,
-  );
+  const isEngagementEvent =
+    mailStatus === EmailStatus.OPENED || mailStatus === EmailStatus.CLICKED;
   const existingMailEvent =
     email.campaignId || isEngagementEvent
       ? await db.emailEvent.findFirst({


### PR DESCRIPTION
## Summary

- replace the narrowed array `includes` call with explicit enum comparisons
- restore successful web TypeScript validation after #425
- add a reusable `typecheck` script for the web app
- run TypeScript validation in the Web Tests GitHub Actions workflow

## Root cause

The engagement status array was inferred as accepting only `OPENED | CLICKED`, while `mailStatus` can contain any parsed SES status. Unit tests and ESLint do not run the TypeScript compiler, so the mismatch surfaced during the production Next.js build.

## Verification

- `cd apps/web && ./node_modules/.bin/tsc --noEmit --pretty false`
- `cd apps/web && ./node_modules/.bin/eslint src/server/service/ses-hook-parser.ts --max-warnings 0`
- `cd apps/web && ./node_modules/.bin/vitest run -c vitest.unit.config.ts src/server/service/ses-hook-parser.unit.test.ts` — 2 passed
- GitHub Actions Web Tests — passed, including the new Type check step and all existing test suites
- `git diff --check`

No database migration required.
