### PR TITLE
fix: forward List-Unsubscribe headers through SMTP proxy

### DIFF
--- a/apps/smtp-server/src/server.ts
+++ b/apps/smtp-server/src/server.ts
@@ -16,6 +16,39 @@ const SSL_KEY_PATH =
 const SSL_CERT_PATH =
   process.env.USESEND_API_CERT_PATH ?? process.env.UNSEND_API_CERT_PATH;
 
+// Forwarded headers that mailparser's normalized Map can't be trusted for.
+// Read from headerLines (raw) instead.
+const FORWARDED_HEADERS = ["list-unsubscribe", "list-unsubscribe-post"];
+
+function canonicalHeaderName(name: string): string {
+  return name
+    .split("-")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join("-");
+}
+
+function extractForwardedHeaders(
+  headerLines: readonly { key: string; line: string }[] | undefined,
+): Record<string, string> | undefined {
+  const result: Record<string, string> = {};
+
+  for (const { key, line } of headerLines || []) {
+    if (!FORWARDED_HEADERS.includes(key)) {
+      continue;
+    }
+    const colonIndex = line.indexOf(":");
+    if (colonIndex === -1) {
+      continue;
+    }
+    const value = line.slice(colonIndex + 1).trim();
+    if (value.length > 0) {
+      result[canonicalHeaderName(key)] = value;
+    }
+  }
+
+  return Object.keys(result).length > 0 ? result : undefined;
+}
+
 async function sendEmailToUseSend(emailData: any, apiKey: string) {
   try {
     const apiEndpoint = "/api/v1/emails";
@@ -88,6 +121,8 @@ const serverOptions: SMTPServerOptions = {
         return callback(new Error("No API key found in session"));
       }
 
+      const forwardedHeaders = extractForwardedHeaders(parsed.headerLines);
+
       const emailObject = {
         to: Array.isArray(parsed.to)
           ? parsed.to.map((addr) => addr.text).join(", ")
@@ -99,6 +134,7 @@ const serverOptions: SMTPServerOptions = {
         text: parsed.text,
         html: parsed.html,
         replyTo: parsed.replyTo?.text,
+        headers: forwardedHeaders,
         attachments:
           parsed.attachments.length > 0
             ? parsed.attachments.map((attachment, index) => ({


### PR DESCRIPTION
This PR modifies the SMTP proxy to allow `List-Unsubscribe` and `List-Unsubscribe-Post` headers to forwarded to the useSend API.

Mailparser transforms `List-*` headers [into its own internal list structure](https://github.com/nodemailer/mailparser/blob/v3.9.14/lib/mail-parser.js#L391-L395) and drops them from the headers map, so this reads them `headerLines`, splits on `:`, and trims + canonicalizes the names.

I’ve been using useSend for sending all kinds of email, most recently including [Listmonk](https://listmonk.app/) campaigns for the first time. mail-tester.com flagged missing `List-Unsubscribe` and `List-Unsubscribe-Post` headers as negative score impacts, even though Listmonk adds them. There’s no easy way to use a useSend driver rather than SMTP with Listmonk, so this adjustment at least lets the proxy pass them through.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Forward `List-Unsubscribe` and `List-Unsubscribe-Post` headers through the SMTP proxy to the useSend API so unsubscribe metadata is preserved and deliverability scores improve.

- **Bug Fixes**
  - Read raw `headerLines` to extract these headers since `mailparser` moves `List-*` into an internal structure and drops them from the headers map.
  - Canonicalize names and include them in the `headers` field sent to `/api/v1/emails`.

<sup>Written for commit 71022ba23237489d724e5d4220368bffdfc95688. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usesend/useSend/pull/428?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved `List-Unsubscribe` and `List-Unsubscribe-Post` headers when forwarding outgoing emails.
  * Improved compatibility with email clients and services that rely on unsubscribe headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->