### PR TITLE
fix: expose campaign unsubscribe variable

### DIFF
--- a/apps/docs/guides/campaign-personalization.mdx
+++ b/apps/docs/guides/campaign-personalization.mdx
@@ -46,9 +46,6 @@ Every campaign must include an unsubscribe link. Use the recipient-specific
 <a href="{{usesend_unsubscribe_url}}">Unsubscribe</a>
 ```
 
-The legacy `{{unsend_unsubscribe_url}}` variable remains supported for existing
-campaigns. Use `{{usesend_unsubscribe_url}}` for new campaigns.
-
 <Warning>
   Custom variables must be added to the contact book before they can be used in
   a campaign. Variable names can only contain letters, numbers, and underscores.

--- a/apps/docs/guides/campaign-personalization.mdx
+++ b/apps/docs/guides/campaign-personalization.mdx
@@ -35,8 +35,19 @@ These built-in variables are always available in campaigns:
 - `{{email}}`
 - `{{firstName}}`
 - `{{lastName}}`
+- `{{usesend_unsubscribe_url}}`
 
 Custom variables come from the contact book's variable list.
+
+Every campaign must include an unsubscribe link. Use the recipient-specific
+`{{usesend_unsubscribe_url}}` variable as the link destination:
+
+```html
+<a href="{{usesend_unsubscribe_url}}">Unsubscribe</a>
+```
+
+The legacy `{{unsend_unsubscribe_url}}` variable remains supported for existing
+campaigns. Use `{{usesend_unsubscribe_url}}` for new campaigns.
 
 <Warning>
   Custom variables must be added to the contact book before they can be used in
@@ -152,7 +163,7 @@ curl -X POST https://app.usesend.com/api/v1/campaigns \
     "from": "Acme <hello@acme.com>",
     "subject": "Welcome to {{company}}",
     "contactBookId": "{contactBookId}",
-    "html": "<p>Hi {{firstName,fallback=there}}, your plan is {{plan}}.</p>"
+    "html": "<p>Hi {{firstName,fallback=there}}, your plan is {{plan}}.</p><p><a href=\"{{usesend_unsubscribe_url}}\">Unsubscribe</a></p>"
   }'
 ```
 

--- a/apps/web/src/app/(dashboard)/campaigns/[campaignId]/edit/page.tsx
+++ b/apps/web/src/app/(dashboard)/campaigns/[campaignId]/edit/page.tsx
@@ -43,6 +43,7 @@ import {
 } from "@usesend/ui/src/accordion";
 import ScheduleCampaign from "../../schedule-campaign";
 import { useRouter } from "next/navigation";
+import { getCampaignEditorVariables } from "~/lib/constants/campaign";
 
 const sendSchema = z.object({
   confirmation: z.string(),
@@ -167,12 +168,10 @@ function CampaignEditor({
   const contactBook = contactBooksQuery.data?.find(
     (book) => book.id === contactBookId,
   );
-  const editorVariables = useMemo(() => {
-    const baseVariables = ["email", "firstName", "lastName"];
-    const registryVariables = contactBook?.variables ?? [];
-
-    return Array.from(new Set([...baseVariables, ...registryVariables]));
-  }, [contactBook]);
+  const editorVariables = useMemo(
+    () => getCampaignEditorVariables(contactBook?.variables),
+    [contactBook],
+  );
   const variableSuggestionsHelperText = contactBookId
     ? undefined
     : "Select the contact book for related variable";

--- a/apps/web/src/lib/constants/campaign.ts
+++ b/apps/web/src/lib/constants/campaign.ts
@@ -1,0 +1,34 @@
+export const CAMPAIGN_UNSUBSCRIBE_VARIABLE = "usesend_unsubscribe_url";
+export const LEGACY_CAMPAIGN_UNSUBSCRIBE_VARIABLE = "unsend_unsubscribe_url";
+
+export const CAMPAIGN_UNSUBSCRIBE_VARIABLES = [
+  CAMPAIGN_UNSUBSCRIBE_VARIABLE,
+  LEGACY_CAMPAIGN_UNSUBSCRIBE_VARIABLE,
+] as const;
+
+export const CAMPAIGN_UNSUBSCRIBE_PLACEHOLDER_TOKENS =
+  CAMPAIGN_UNSUBSCRIBE_VARIABLES.map((variable) => `{{${variable}}}`);
+
+const CAMPAIGN_EDITOR_BASE_VARIABLES = [
+  "email",
+  "firstName",
+  "lastName",
+  CAMPAIGN_UNSUBSCRIBE_VARIABLE,
+];
+
+export function getCampaignEditorVariables(
+  contactBookVariables: string[] = [],
+) {
+  return Array.from(
+    new Set([...CAMPAIGN_EDITOR_BASE_VARIABLES, ...contactBookVariables]),
+  );
+}
+
+export function getCampaignUnsubscribeVariableValues(unsubscribeUrl: string) {
+  return Object.fromEntries(
+    CAMPAIGN_UNSUBSCRIBE_VARIABLES.map((variable) => [
+      variable,
+      unsubscribeUrl,
+    ]),
+  );
+}

--- a/apps/web/src/lib/constants/campaign.ts
+++ b/apps/web/src/lib/constants/campaign.ts
@@ -1,4 +1,5 @@
 export const CAMPAIGN_UNSUBSCRIBE_VARIABLE = "usesend_unsubscribe_url";
+const LEGACY_CAMPAIGN_UNSUBSCRIBE_VARIABLE = "unsend_unsubscribe_url";
 
 const CAMPAIGN_EDITOR_BASE_VARIABLES = [
   "email",
@@ -16,5 +17,8 @@ export function getCampaignEditorVariables(
 }
 
 export function getCampaignUnsubscribeVariableValues(unsubscribeUrl: string) {
-  return { [CAMPAIGN_UNSUBSCRIBE_VARIABLE]: unsubscribeUrl };
+  return {
+    [CAMPAIGN_UNSUBSCRIBE_VARIABLE]: unsubscribeUrl,
+    [LEGACY_CAMPAIGN_UNSUBSCRIBE_VARIABLE]: unsubscribeUrl,
+  };
 }

--- a/apps/web/src/lib/constants/campaign.ts
+++ b/apps/web/src/lib/constants/campaign.ts
@@ -1,13 +1,4 @@
 export const CAMPAIGN_UNSUBSCRIBE_VARIABLE = "usesend_unsubscribe_url";
-export const LEGACY_CAMPAIGN_UNSUBSCRIBE_VARIABLE = "unsend_unsubscribe_url";
-
-export const CAMPAIGN_UNSUBSCRIBE_VARIABLES = [
-  CAMPAIGN_UNSUBSCRIBE_VARIABLE,
-  LEGACY_CAMPAIGN_UNSUBSCRIBE_VARIABLE,
-] as const;
-
-export const CAMPAIGN_UNSUBSCRIBE_PLACEHOLDER_TOKENS =
-  CAMPAIGN_UNSUBSCRIBE_VARIABLES.map((variable) => `{{${variable}}}`);
 
 const CAMPAIGN_EDITOR_BASE_VARIABLES = [
   "email",
@@ -25,10 +16,5 @@ export function getCampaignEditorVariables(
 }
 
 export function getCampaignUnsubscribeVariableValues(unsubscribeUrl: string) {
-  return Object.fromEntries(
-    CAMPAIGN_UNSUBSCRIBE_VARIABLES.map((variable) => [
-      variable,
-      unsubscribeUrl,
-    ]),
-  );
+  return { [CAMPAIGN_UNSUBSCRIBE_VARIABLE]: unsubscribeUrl };
 }

--- a/apps/web/src/lib/constants/campaign.unit.test.ts
+++ b/apps/web/src/lib/constants/campaign.unit.test.ts
@@ -8,9 +8,10 @@ import {
 
 describe("campaign editor variables", () => {
   it("includes the canonical unsubscribe variable", () => {
-    expect(getCampaignEditorVariables()).toContain(
-      CAMPAIGN_UNSUBSCRIBE_VARIABLE,
-    );
+    const variables = getCampaignEditorVariables();
+
+    expect(variables).toContain(CAMPAIGN_UNSUBSCRIBE_VARIABLE);
+    expect(variables).not.toContain("unsend_unsubscribe_url");
   });
 
   it("combines built-in and contact book variables without duplicates", () => {
@@ -53,5 +54,36 @@ describe("campaign editor variables", () => {
 
     expect(html).toContain(unsubscribeUrl);
     expect(html).not.toContain(`{{${CAMPAIGN_UNSUBSCRIBE_VARIABLE}}}`);
+  });
+
+  it("renders a legacy structured unsubscribe variable with the recipient URL", async () => {
+    const legacyVariable = "unsend_unsubscribe_url";
+    const renderer = new EmailRenderer({
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            {
+              type: "variable",
+              attrs: {
+                id: legacyVariable,
+                name: legacyVariable,
+                fallback: "",
+              },
+            },
+          ],
+        },
+      ],
+    });
+    const unsubscribeUrl = "https://example.com/unsubscribe/recipient";
+
+    const html = await renderer.render({
+      shouldReplaceVariableValues: true,
+      variableValues: getCampaignUnsubscribeVariableValues(unsubscribeUrl),
+    });
+
+    expect(html).toContain(unsubscribeUrl);
+    expect(html).not.toContain(`{{${legacyVariable}}}`);
   });
 });

--- a/apps/web/src/lib/constants/campaign.unit.test.ts
+++ b/apps/web/src/lib/constants/campaign.unit.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { EmailRenderer } from "@usesend/email-editor/src/renderer";
+import {
+  CAMPAIGN_UNSUBSCRIBE_VARIABLE,
+  getCampaignEditorVariables,
+  getCampaignUnsubscribeVariableValues,
+} from "~/lib/constants/campaign";
+
+describe("campaign editor variables", () => {
+  it("includes the canonical unsubscribe variable", () => {
+    expect(getCampaignEditorVariables()).toContain(
+      CAMPAIGN_UNSUBSCRIBE_VARIABLE,
+    );
+  });
+
+  it("combines built-in and contact book variables without duplicates", () => {
+    expect(getCampaignEditorVariables(["company", "email", "company"])).toEqual(
+      [
+        "email",
+        "firstName",
+        "lastName",
+        CAMPAIGN_UNSUBSCRIBE_VARIABLE,
+        "company",
+      ],
+    );
+  });
+
+  it("renders an autocomplete unsubscribe variable with the recipient URL", async () => {
+    const renderer = new EmailRenderer({
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            {
+              type: "variable",
+              attrs: {
+                id: CAMPAIGN_UNSUBSCRIBE_VARIABLE,
+                name: CAMPAIGN_UNSUBSCRIBE_VARIABLE,
+                fallback: "",
+              },
+            },
+          ],
+        },
+      ],
+    });
+    const unsubscribeUrl = "https://example.com/unsubscribe/recipient";
+
+    const html = await renderer.render({
+      shouldReplaceVariableValues: true,
+      variableValues: getCampaignUnsubscribeVariableValues(unsubscribeUrl),
+    });
+
+    expect(html).toContain(unsubscribeUrl);
+    expect(html).not.toContain(`{{${CAMPAIGN_UNSUBSCRIBE_VARIABLE}}}`);
+  });
+});

--- a/apps/web/src/server/service/campaign-service.ts
+++ b/apps/web/src/server/service/campaign-service.ts
@@ -30,14 +30,13 @@ import {
   replaceContactVariables,
 } from "../utils/contact-variable-replacement";
 import { updateContactSubscription } from "./contact-service";
-
-const CAMPAIGN_UNSUB_PLACEHOLDER_TOKENS = [
-  "{{unsend_unsubscribe_url}}",
-  "{{usesend_unsubscribe_url}}",
-] as const;
+import {
+  CAMPAIGN_UNSUBSCRIBE_PLACEHOLDER_TOKENS,
+  getCampaignUnsubscribeVariableValues,
+} from "~/lib/constants/campaign";
 
 const CAMPAIGN_UNSUB_PLACEHOLDER_REGEXES =
-  CAMPAIGN_UNSUB_PLACEHOLDER_TOKENS.map((placeholder) => {
+  CAMPAIGN_UNSUBSCRIBE_PLACEHOLDER_TOKENS.map((placeholder) => {
     const inner = placeholder.replace(/[{}]/g, "").trim();
     return new RegExp(`\\{\\{\\s*${inner}\\s*\\}}`, "i");
   });
@@ -115,7 +114,7 @@ async function renderCampaignHtmlForContact({
       const renderer = new EmailRenderer(jsonContent);
       const linkValues: Record<string, string> = {};
 
-      for (const token of CAMPAIGN_UNSUB_PLACEHOLDER_TOKENS) {
+      for (const token of CAMPAIGN_UNSUBSCRIBE_PLACEHOLDER_TOKENS) {
         linkValues[token] = unsubscribeUrl;
       }
 
@@ -139,6 +138,7 @@ async function renderCampaignHtmlForContact({
           },
           {} as Record<string, string | null | undefined>,
         ),
+        ...getCampaignUnsubscribeVariableValues(unsubscribeUrl),
       });
 
       return renderer.render({

--- a/apps/web/src/server/service/campaign-service.ts
+++ b/apps/web/src/server/service/campaign-service.ts
@@ -30,13 +30,15 @@ import {
   replaceContactVariables,
 } from "../utils/contact-variable-replacement";
 import { updateContactSubscription } from "./contact-service";
-import {
-  CAMPAIGN_UNSUBSCRIBE_PLACEHOLDER_TOKENS,
-  getCampaignUnsubscribeVariableValues,
-} from "~/lib/constants/campaign";
+import { getCampaignUnsubscribeVariableValues } from "~/lib/constants/campaign";
+
+const CAMPAIGN_UNSUB_PLACEHOLDER_TOKENS = [
+  "{{unsend_unsubscribe_url}}",
+  "{{usesend_unsubscribe_url}}",
+] as const;
 
 const CAMPAIGN_UNSUB_PLACEHOLDER_REGEXES =
-  CAMPAIGN_UNSUBSCRIBE_PLACEHOLDER_TOKENS.map((placeholder) => {
+  CAMPAIGN_UNSUB_PLACEHOLDER_TOKENS.map((placeholder) => {
     const inner = placeholder.replace(/[{}]/g, "").trim();
     return new RegExp(`\\{\\{\\s*${inner}\\s*\\}}`, "i");
   });
@@ -114,7 +116,7 @@ async function renderCampaignHtmlForContact({
       const renderer = new EmailRenderer(jsonContent);
       const linkValues: Record<string, string> = {};
 
-      for (const token of CAMPAIGN_UNSUBSCRIBE_PLACEHOLDER_TOKENS) {
+      for (const token of CAMPAIGN_UNSUB_PLACEHOLDER_TOKENS) {
         linkValues[token] = unsubscribeUrl;
       }
 


### PR DESCRIPTION
## Summary

- document `{{usesend_unsubscribe_url}}` as the required, recipient-specific campaign unsubscribe variable
- add the canonical variable to campaign editor autocomplete while preserving contact-book variable deduplication
- resolve structured unsubscribe variable nodes to each recipient's URL
- update the campaign API example so it includes the required unsubscribe link

## Impact

Campaign authors can discover the required unsubscribe variable in both the guide and editor, and autocomplete selections render to the correct per-recipient URL.

## Screenshots

Not included: the existing autocomplete menu only gains one text suggestion; there are no layout or styling changes.

## Migrations

None.

## Verification

- `pnpm exec vitest run -c vitest.unit.config.ts src/lib/constants/campaign.unit.test.ts src/server/service/campaign-service.unit.test.ts` (8 tests passed)
- `pnpm --filter=web typecheck`
- ESLint on the changed campaign constants, tests, and service with zero warnings
- Prettier check on all changed files

Closes #427

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added unsubscribe token support to campaign personalization using `{{usesend_unsubscribe_url}}`.
  * Campaign editor variables now automatically include the unsubscribe token alongside standard and contact-book variables.
* **Bug Fixes**
  * Improved email rendering so both the canonical and legacy unsubscribe placeholders are replaced with recipient-specific URLs (no unresolved tokens left behind).
* **Documentation**
  * Updated the personalization guide and the “create a campaign that uses variables” example with an unsubscribe HTML snippet.
* **Tests**
  * Added unit tests covering variable merging and unsubscribe URL replacement behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->