### PR TITLE
fix: allow self-hosted GitHub users without email

### DIFF
--- a/apps/docs/self-hosting/overview.mdx
+++ b/apps/docs/self-hosting/overview.mdx
@@ -38,6 +38,10 @@ Use this link to [create an github app](https://docs.github.com/en/apps/creating
 
 Callback URL : `https://<your-usesend-instance>/api/auth/callback/github`
 
+Under **Permissions & events**, set **Account permissions → Email addresses**
+to **Read-only**. useSend needs the authenticated user's email address to match
+new accounts to team invitations.
+
 ![github app](/images/github-callback.png)
 
 Add the following environment variables.

--- a/apps/docs/self-hosting/railway.mdx
+++ b/apps/docs/self-hosting/railway.mdx
@@ -49,6 +49,10 @@ Use this link to [create a GitHub app](https://docs.github.com/en/apps/creating-
 
 Callback URL : `https://<your-railway-domain>/api/auth/callback/github`
 
+Under **Permissions & events**, set **Account permissions → Email addresses**
+to **Read-only**. useSend needs the authenticated user's email address to match
+new accounts to team invitations.
+
 ![github app](/images/github-callback.png)
 
 Add the following environment variables in Railway.

--- a/apps/web/src/server/auth.ts
+++ b/apps/web/src/server/auth.ts
@@ -1,6 +1,7 @@
 import { PrismaAdapter } from "@auth/prisma-adapter";
 import {
   getServerSession,
+  type Account,
   type DefaultSession,
   type NextAuthOptions,
 } from "next-auth";
@@ -34,30 +35,52 @@ export class SelfHostedRegistrationError extends Error {
   }
 }
 
-export async function canRegisterSelfHostedUser(email?: string | null) {
+export async function canRegisterSelfHostedUser(
+  email?: string | null,
+  account?: Pick<Account, "provider" | "providerAccountId" | "type"> | null,
+) {
   if (env.NEXT_PUBLIC_IS_CLOUD) {
+    return true;
+  }
+
+  if (account?.type === "oauth") {
+    const existingAccount = await db.account.findUnique({
+      where: {
+        provider_providerAccountId: {
+          provider: account.provider,
+          providerAccountId: account.providerAccountId,
+        },
+      },
+      select: { id: true },
+    });
+
+    if (existingAccount) {
+      return true;
+    }
+  }
+
+  if (email) {
+    const existingUser = await db.user.findUnique({
+      where: { email },
+      select: { id: true },
+    });
+
+    if (existingUser) {
+      return true;
+    }
+  }
+
+  const registeredUser = await db.user.findFirst({
+    select: { id: true },
+  });
+
+  // An empty installation always allows its bootstrap account.
+  if (!registeredUser) {
     return true;
   }
 
   if (!email) {
     return false;
-  }
-
-  const existingUser = await db.user.findUnique({
-    where: { email },
-    select: { id: true },
-  });
-
-  if (existingUser) {
-    return true;
-  }
-
-  const firstUser = await db.user.findFirst({
-    select: { id: true },
-  });
-
-  if (!firstUser) {
-    return true;
   }
 
   const invite = await db.teamInvite.findFirst({
@@ -158,7 +181,8 @@ function getProviders() {
  */
 export const authOptions: NextAuthOptions = {
   callbacks: {
-    signIn: async ({ user }) => canRegisterSelfHostedUser(user.email),
+    signIn: async ({ user, account }) =>
+      canRegisterSelfHostedUser(user.email, account),
     session: ({ session, user }) => ({
       ...session,
       user: {
@@ -184,21 +208,21 @@ export const authOptions: NextAuthOptions = {
           return prismaAdapter.createUser(user);
         }
 
-        if (!user.email) {
-          throw new SelfHostedRegistrationError();
-        }
-
         return db.$transaction(async (tx) => {
           // Acquire the lock before checking for the first user. Without this,
           // two concurrent callbacks could both observe an empty User table and
           // both create an account without an invitation.
           await tx.$executeRaw`SELECT pg_advisory_xact_lock(${SELF_HOSTED_REGISTRATION_LOCK_ID})`;
 
-          const firstUser = await tx.user.findFirst({
+          const registeredUser = await tx.user.findFirst({
             select: { id: true },
           });
 
-          if (firstUser) {
+          if (registeredUser) {
+            if (!user.email) {
+              throw new SelfHostedRegistrationError();
+            }
+
             const invite = await tx.teamInvite.findFirst({
               where: { email: user.email },
               select: { id: true },

--- a/apps/web/src/server/auth.unit.test.ts
+++ b/apps/web/src/server/auth.unit.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AdapterUser } from "next-auth/adapters";
 
 const mocks = vi.hoisted(() => {
   const env = {
@@ -8,6 +9,7 @@ const mocks = vi.hoisted(() => {
   };
 
   const baseCreateUser = vi.fn();
+  const accountFindUnique = vi.fn();
   const userFindUnique = vi.fn();
   const userFindFirst = vi.fn();
   const inviteFindFirst = vi.fn();
@@ -31,6 +33,7 @@ const mocks = vi.hoisted(() => {
   return {
     env,
     baseCreateUser,
+    accountFindUnique,
     userFindUnique,
     userFindFirst,
     inviteFindFirst,
@@ -64,6 +67,9 @@ vi.mock("next-auth/providers/email", () => ({
 
 vi.mock("~/server/db", () => ({
   db: {
+    account: {
+      findUnique: mocks.accountFindUnique,
+    },
     user: {
       findUnique: mocks.userFindUnique,
       findFirst: mocks.userFindFirst,
@@ -98,10 +104,16 @@ const newUser = {
   isAdmin: false,
 };
 
+const newUserWithoutEmail = {
+  ...newUser,
+  email: null,
+} as unknown as AdapterUser;
+
 describe("authOptions", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.env.NEXT_PUBLIC_IS_CLOUD = true;
+    mocks.accountFindUnique.mockResolvedValue(null);
     mocks.userFindUnique.mockResolvedValue(null);
     mocks.userFindFirst.mockResolvedValue(null);
     mocks.inviteFindFirst.mockResolvedValue(null);
@@ -149,6 +161,29 @@ describe("authOptions", () => {
       expect(mocks.inviteFindFirst).not.toHaveBeenCalled();
     });
 
+    it("allows an existing OAuth account to sign in without an email", async () => {
+      mocks.accountFindUnique.mockResolvedValue({ id: "account_1" });
+
+      await expect(
+        canRegisterSelfHostedUser(null, {
+          provider: "github",
+          providerAccountId: "github-user-id",
+          type: "oauth",
+        }),
+      ).resolves.toBe(true);
+
+      expect(mocks.accountFindUnique).toHaveBeenCalledWith({
+        where: {
+          provider_providerAccountId: {
+            provider: "github",
+            providerAccountId: "github-user-id",
+          },
+        },
+        select: { id: true },
+      });
+      expect(mocks.userFindFirst).not.toHaveBeenCalled();
+    });
+
     it("allows a new user with a matching invite", async () => {
       mocks.userFindFirst.mockResolvedValue({ id: 1 });
       mocks.inviteFindFirst.mockResolvedValue({ id: "invite_1" });
@@ -171,9 +206,16 @@ describe("authOptions", () => {
       ).resolves.toBe(false);
     });
 
-    it("rejects a new account that has no email", async () => {
-      await expect(canRegisterSelfHostedUser(null)).resolves.toBe(false);
+    it("allows the first account when the provider returns no email", async () => {
+      await expect(canRegisterSelfHostedUser(null)).resolves.toBe(true);
       expect(mocks.userFindUnique).not.toHaveBeenCalled();
+    });
+
+    it("rejects a later account when the provider returns no email", async () => {
+      mocks.userFindFirst.mockResolvedValue({ id: 1 });
+
+      await expect(canRegisterSelfHostedUser(null)).resolves.toBe(false);
+      expect(mocks.inviteFindFirst).not.toHaveBeenCalled();
     });
   });
 
@@ -217,6 +259,29 @@ describe("authOptions", () => {
       });
     });
 
+    it("atomically creates the first self-hosted user without an email", async () => {
+      mocks.env.NEXT_PUBLIC_IS_CLOUD = false;
+      mocks.transactionUserCreate.mockResolvedValueOnce({
+        ...newUserWithoutEmail,
+        id: 1,
+      });
+
+      await expect(createUser(newUserWithoutEmail)).resolves.toMatchObject({
+        id: 1,
+        email: null,
+      });
+
+      expect(mocks.transactionInviteFindFirst).not.toHaveBeenCalled();
+      expect(mocks.transactionUserCreate).toHaveBeenCalledWith({
+        data: {
+          name: newUser.name,
+          email: null,
+          emailVerified: newUser.emailVerified,
+          image: newUser.image,
+        },
+      });
+    });
+
     it("atomically creates an invited self-hosted user", async () => {
       mocks.env.NEXT_PUBLIC_IS_CLOUD = false;
       mocks.transactionUserFindFirst.mockResolvedValue({ id: 1 });
@@ -252,14 +317,16 @@ describe("authOptions", () => {
       expect(mocks.transactionUserCreate).not.toHaveBeenCalled();
     });
 
-    it("does not create a self-hosted user without an email", async () => {
+    it("does not create a later self-hosted user without an email", async () => {
       mocks.env.NEXT_PUBLIC_IS_CLOUD = false;
+      mocks.transactionUserFindFirst.mockResolvedValue({ id: 1 });
 
-      await expect(
-        createUser({ ...newUser, email: "" }),
-      ).rejects.toBeInstanceOf(SelfHostedRegistrationError);
+      await expect(createUser(newUserWithoutEmail)).rejects.toBeInstanceOf(
+        SelfHostedRegistrationError,
+      );
 
-      expect(mocks.transaction).not.toHaveBeenCalled();
+      expect(mocks.transaction).toHaveBeenCalledOnce();
+      expect(mocks.transactionUserCreate).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## Summary

- allow existing linked OAuth accounts to sign in when GitHub does not return an email
- allow the first user to bootstrap an empty self-hosted instance without an email
- continue rejecting later no-email or uninvited accounts, including inside the transaction lock
- document the GitHub App `Email addresses: Read-only` permission required for invitation matching
- add focused unit regression coverage for the permanent policy branches

## Root cause

GitHub Apps without the `Email addresses: Read-only` account permission return no email for users whose address is private. The self-hosted registration policy added in 1.9.5 rejected a missing email before checking whether the OAuth account was already linked or whether the installation had no users yet. That caused both upgraded installations and fresh installations to redirect to `AccessDenied`.

## Impact

Existing self-hosted GitHub users can sign in again, and a fresh instance can bootstrap its owner even if GitHub omits the email. The invitation-only policy remains enforced for every later account.

## Verification

- `pnpm --filter=web exec vitest run -c vitest.unit.config.ts src/server/auth.unit.test.ts` — 14 passed
- reproduced the 1.9.5 `AccessDenied` with a temporary NextAuth HTTP callback harness and the exact no-email GitHub response
- verified the fix against real PostgreSQL and Redis: user/account/session persistence, repeat login, and rejection of a second uninvited no-email identity
- ran the complete integration suite with the temporary harness — 5 files and 12 tests passed; the one-off harness was removed after verification
- `pnpm --filter=web exec tsc --noEmit --pretty false`
- ESLint and Prettier checks for all touched files

No application build or database schema migration is required.

Fixes #434


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved self-hosted login and registration handling for OAuth sign-ins, including cases where the provider doesn’t return an email.
  * Updated account creation rules to better handle first-user bootstrap and invitation gating, improving reliability during self-hosted sign-in.
* **Documentation**
  * Added clearer GitHub App credential guidance for self-hosting, setting Email addresses to read-only for account matching and team invitations.
* **Tests**
  * Expanded unit test coverage for self-hosted OAuth and no-email edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->