### PR TITLE
feat: add gradual campaign delivery

### DIFF
--- a/apps/docs/api-reference/openapi.json
+++ b/apps/docs/api-reference/openapi.json
@@ -2085,6 +2085,39 @@
                     "type": "integer",
                     "minimum": 1,
                     "maximum": 100000
+                  },
+                  "delivery": {
+                    "oneOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "strategy": {
+                            "type": "string",
+                            "enum": ["all_at_once"]
+                          }
+                        },
+                        "required": ["strategy"]
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "strategy": {
+                            "type": "string",
+                            "enum": ["gradual"]
+                          },
+                          "batchPercentage": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50
+                          },
+                          "interval": {
+                            "type": "string",
+                            "enum": ["minute", "hour"]
+                          }
+                        },
+                        "required": ["strategy", "batchPercentage", "interval"]
+                      }
+                    ]
                   }
                 },
                 "required": ["name", "from", "subject", "contactBookId"]
@@ -2116,6 +2149,29 @@
                     },
                     "batchSize": { "type": "integer" },
                     "batchWindowMinutes": { "type": "integer" },
+                    "deliveryMode": {
+                      "type": "string",
+                      "enum": ["ALL_AT_ONCE", "GRADUAL"]
+                    },
+                    "deliveryBatchPercentage": {
+                      "type": "integer",
+                      "nullable": true
+                    },
+                    "deliveryIntervalMinutes": {
+                      "type": "integer",
+                      "nullable": true
+                    },
+                    "deliveryBatchSize": {
+                      "type": "integer",
+                      "nullable": true
+                    },
+                    "currentDeliveryBatch": { "type": "integer" },
+                    "deliveryBatchProcessed": { "type": "integer" },
+                    "nextDeliveryAt": {
+                      "type": "string",
+                      "nullable": true,
+                      "format": "date-time"
+                    },
                     "total": { "type": "integer" },
                     "sent": { "type": "integer" },
                     "delivered": { "type": "integer" },
@@ -2147,6 +2203,13 @@
                     "scheduledAt",
                     "batchSize",
                     "batchWindowMinutes",
+                    "deliveryMode",
+                    "deliveryBatchPercentage",
+                    "deliveryIntervalMinutes",
+                    "deliveryBatchSize",
+                    "currentDeliveryBatch",
+                    "deliveryBatchProcessed",
+                    "nextDeliveryAt",
                     "total",
                     "sent",
                     "delivered",
@@ -2302,6 +2365,29 @@
                     },
                     "batchSize": { "type": "integer" },
                     "batchWindowMinutes": { "type": "integer" },
+                    "deliveryMode": {
+                      "type": "string",
+                      "enum": ["ALL_AT_ONCE", "GRADUAL"]
+                    },
+                    "deliveryBatchPercentage": {
+                      "type": "integer",
+                      "nullable": true
+                    },
+                    "deliveryIntervalMinutes": {
+                      "type": "integer",
+                      "nullable": true
+                    },
+                    "deliveryBatchSize": {
+                      "type": "integer",
+                      "nullable": true
+                    },
+                    "currentDeliveryBatch": { "type": "integer" },
+                    "deliveryBatchProcessed": { "type": "integer" },
+                    "nextDeliveryAt": {
+                      "type": "string",
+                      "nullable": true,
+                      "format": "date-time"
+                    },
                     "total": { "type": "integer" },
                     "sent": { "type": "integer" },
                     "delivered": { "type": "integer" },
@@ -2333,6 +2419,13 @@
                     "scheduledAt",
                     "batchSize",
                     "batchWindowMinutes",
+                    "deliveryMode",
+                    "deliveryBatchPercentage",
+                    "deliveryIntervalMinutes",
+                    "deliveryBatchSize",
+                    "currentDeliveryBatch",
+                    "deliveryBatchProcessed",
+                    "nextDeliveryAt",
                     "total",
                     "sent",
                     "delivered",
@@ -2391,6 +2484,29 @@
                     },
                     "batchSize": { "type": "integer" },
                     "batchWindowMinutes": { "type": "integer" },
+                    "deliveryMode": {
+                      "type": "string",
+                      "enum": ["ALL_AT_ONCE", "GRADUAL"]
+                    },
+                    "deliveryBatchPercentage": {
+                      "type": "integer",
+                      "nullable": true
+                    },
+                    "deliveryIntervalMinutes": {
+                      "type": "integer",
+                      "nullable": true
+                    },
+                    "deliveryBatchSize": {
+                      "type": "integer",
+                      "nullable": true
+                    },
+                    "currentDeliveryBatch": { "type": "integer" },
+                    "deliveryBatchProcessed": { "type": "integer" },
+                    "nextDeliveryAt": {
+                      "type": "string",
+                      "nullable": true,
+                      "format": "date-time"
+                    },
                     "total": { "type": "integer" },
                     "sent": { "type": "integer" },
                     "delivered": { "type": "integer" },
@@ -2422,6 +2538,13 @@
                     "scheduledAt",
                     "batchSize",
                     "batchWindowMinutes",
+                    "deliveryMode",
+                    "deliveryBatchPercentage",
+                    "deliveryIntervalMinutes",
+                    "deliveryBatchSize",
+                    "currentDeliveryBatch",
+                    "deliveryBatchProcessed",
+                    "nextDeliveryAt",
                     "total",
                     "sent",
                     "delivered",
@@ -2473,6 +2596,39 @@
                     "type": "integer",
                     "minimum": 1,
                     "maximum": 100000
+                  },
+                  "delivery": {
+                    "oneOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "strategy": {
+                            "type": "string",
+                            "enum": ["all_at_once"]
+                          }
+                        },
+                        "required": ["strategy"]
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "strategy": {
+                            "type": "string",
+                            "enum": ["gradual"]
+                          },
+                          "batchPercentage": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50
+                          },
+                          "interval": {
+                            "type": "string",
+                            "enum": ["minute", "hour"]
+                          }
+                        },
+                        "required": ["strategy", "batchPercentage", "interval"]
+                      }
+                    ]
                   }
                 }
               }

--- a/apps/web/prisma/migrations/20260721120000_add_gradual_campaign_sending/migration.sql
+++ b/apps/web/prisma/migrations/20260721120000_add_gradual_campaign_sending/migration.sql
@@ -2,17 +2,15 @@
 CREATE TYPE "CampaignDeliveryMode" AS ENUM ('ALL_AT_ONCE', 'GRADUAL');
 
 -- CreateEnum
-CREATE TYPE "CampaignRecipientStatus" AS ENUM ('PENDING', 'QUEUED', 'SUPPRESSED', 'SKIPPED', 'FAILED');
+CREATE TYPE "CampaignRecipientStatus" AS ENUM ('PENDING', 'PROCESSING', 'QUEUED', 'SUPPRESSED', 'SKIPPED', 'FAILED');
 
 -- AlterTable
 ALTER TABLE "CampaignEmail" ALTER COLUMN "emailId" DROP NOT NULL;
-ALTER TABLE "CampaignEmail" ADD COLUMN "status" "CampaignRecipientStatus";
+-- PostgreSQL 11+ stores a constant default as metadata instead of rewriting
+-- every existing row. Existing recipients are already queued, while new rows
+-- created by the gradual delivery worker should default to pending.
+ALTER TABLE "CampaignEmail" ADD COLUMN "status" "CampaignRecipientStatus" NOT NULL DEFAULT 'QUEUED';
 ALTER TABLE "CampaignEmail" ADD COLUMN "processedAt" TIMESTAMP(3);
-
-UPDATE "CampaignEmail"
-SET "status" = 'QUEUED', "processedAt" = "createdAt";
-
-ALTER TABLE "CampaignEmail" ALTER COLUMN "status" SET NOT NULL;
 ALTER TABLE "CampaignEmail" ALTER COLUMN "status" SET DEFAULT 'PENDING';
 
 -- AlterTable

--- a/apps/web/prisma/migrations/20260721120000_add_gradual_campaign_sending/migration.sql
+++ b/apps/web/prisma/migrations/20260721120000_add_gradual_campaign_sending/migration.sql
@@ -24,9 +24,3 @@ ALTER TABLE "Campaign" ADD COLUMN "nextDeliveryAt" TIMESTAMP(3);
 ALTER TABLE "Campaign" ADD COLUMN "audienceCapturedAt" TIMESTAMP(3);
 ALTER TABLE "Campaign" ADD COLUMN "audiencePreparedAt" TIMESTAMP(3);
 ALTER TABLE "Campaign" ADD COLUMN "pausedAt" TIMESTAMP(3);
-
--- CreateIndex
-CREATE INDEX "CampaignEmail_campaignId_status_contactId_idx" ON "CampaignEmail"("campaignId", "status", "contactId");
-
--- CreateIndex
-CREATE INDEX "Campaign_status_nextDeliveryAt_idx" ON "Campaign"("status", "nextDeliveryAt");

--- a/apps/web/prisma/migrations/20260721120000_add_gradual_campaign_sending/migration.sql
+++ b/apps/web/prisma/migrations/20260721120000_add_gradual_campaign_sending/migration.sql
@@ -1,0 +1,34 @@
+-- CreateEnum
+CREATE TYPE "CampaignDeliveryMode" AS ENUM ('ALL_AT_ONCE', 'GRADUAL');
+
+-- CreateEnum
+CREATE TYPE "CampaignRecipientStatus" AS ENUM ('PENDING', 'QUEUED', 'SUPPRESSED', 'SKIPPED', 'FAILED');
+
+-- AlterTable
+ALTER TABLE "CampaignEmail" ALTER COLUMN "emailId" DROP NOT NULL;
+ALTER TABLE "CampaignEmail" ADD COLUMN "status" "CampaignRecipientStatus";
+ALTER TABLE "CampaignEmail" ADD COLUMN "processedAt" TIMESTAMP(3);
+
+UPDATE "CampaignEmail"
+SET "status" = 'QUEUED', "processedAt" = "createdAt";
+
+ALTER TABLE "CampaignEmail" ALTER COLUMN "status" SET NOT NULL;
+ALTER TABLE "CampaignEmail" ALTER COLUMN "status" SET DEFAULT 'PENDING';
+
+-- AlterTable
+ALTER TABLE "Campaign" ADD COLUMN "deliveryMode" "CampaignDeliveryMode" NOT NULL DEFAULT 'ALL_AT_ONCE';
+ALTER TABLE "Campaign" ADD COLUMN "deliveryBatchPercentage" INTEGER;
+ALTER TABLE "Campaign" ADD COLUMN "deliveryIntervalMinutes" INTEGER;
+ALTER TABLE "Campaign" ADD COLUMN "deliveryBatchSize" INTEGER;
+ALTER TABLE "Campaign" ADD COLUMN "currentDeliveryBatch" INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE "Campaign" ADD COLUMN "deliveryBatchProcessed" INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE "Campaign" ADD COLUMN "nextDeliveryAt" TIMESTAMP(3);
+ALTER TABLE "Campaign" ADD COLUMN "audienceCapturedAt" TIMESTAMP(3);
+ALTER TABLE "Campaign" ADD COLUMN "audiencePreparedAt" TIMESTAMP(3);
+ALTER TABLE "Campaign" ADD COLUMN "pausedAt" TIMESTAMP(3);
+
+-- CreateIndex
+CREATE INDEX "CampaignEmail_campaignId_status_contactId_idx" ON "CampaignEmail"("campaignId", "status", "contactId");
+
+-- CreateIndex
+CREATE INDEX "Campaign_status_nextDeliveryAt_idx" ON "Campaign"("status", "nextDeliveryAt");

--- a/apps/web/prisma/migrations/20260721170000_add_campaign_email_recipient_status_index/migration.sql
+++ b/apps/web/prisma/migrations/20260721170000_add_campaign_email_recipient_status_index/migration.sql
@@ -1,0 +1,4 @@
+-- CreateIndex
+-- Keep this as the migration's only SQL statement so PostgreSQL can build the
+-- index without blocking inserts or updates.
+CREATE INDEX CONCURRENTLY "CampaignEmail_campaignId_status_contactId_idx" ON "CampaignEmail"("campaignId", "status", "contactId");

--- a/apps/web/prisma/migrations/20260721180000_add_campaign_next_delivery_index/migration.sql
+++ b/apps/web/prisma/migrations/20260721180000_add_campaign_next_delivery_index/migration.sql
@@ -1,0 +1,4 @@
+-- CreateIndex
+-- Keep this as the migration's only SQL statement so PostgreSQL can build the
+-- index without blocking inserts or updates.
+CREATE INDEX CONCURRENTLY "Campaign_status_nextDeliveryAt_idx" ON "Campaign"("status", "nextDeliveryAt");

--- a/apps/web/prisma/migrations/20260721190000_add_campaign_email_status_index/migration.sql
+++ b/apps/web/prisma/migrations/20260721190000_add_campaign_email_status_index/migration.sql
@@ -1,0 +1,4 @@
+-- CreateIndex
+-- Keep this as the migration's only SQL statement so Prisma runs it outside a
+-- transaction and PostgreSQL can build it without blocking inserts or updates.
+CREATE INDEX CONCURRENTLY "Email_campaignId_latestStatus_idx" ON "Email"("campaignId", "latestStatus");

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -271,12 +271,15 @@ model Email {
 }
 
 model CampaignEmail {
-  campaignId String
-  contactId  String
-  emailId    String
-  createdAt  DateTime @default(now())
+  campaignId  String
+  contactId   String
+  emailId     String?
+  status      CampaignRecipientStatus @default(PENDING)
+  processedAt DateTime?
+  createdAt   DateTime                @default(now())
 
   @@id([campaignId, contactId])
+  @@index([campaignId, status, contactId])
 }
 
 model EmailEvent {
@@ -349,43 +352,67 @@ enum CampaignStatus {
   SENT
 }
 
+enum CampaignDeliveryMode {
+  ALL_AT_ONCE
+  GRADUAL
+}
+
+enum CampaignRecipientStatus {
+  PENDING
+  QUEUED
+  SUPPRESSED
+  SKIPPED
+  FAILED
+}
+
 model Campaign {
-  id                 String         @id @default(cuid())
-  name               String
-  teamId             Int
-  from               String
-  cc                 String[]
-  bcc                String[]
-  replyTo            String[]
-  domainId           Int
-  subject            String
-  previewText        String?
-  html               String?
-  content            String?
-  contactBookId      String?
-  scheduledAt        DateTime?
-  total              Int            @default(0)
-  sent               Int            @default(0)
-  delivered          Int            @default(0)
-  opened             Int            @default(0)
-  clicked            Int            @default(0)
-  unsubscribed       Int            @default(0)
-  bounced            Int            @default(0)
-  hardBounced        Int            @default(0)
-  complained         Int            @default(0)
-  isApi              Boolean        @default(false)
-  status             CampaignStatus @default(DRAFT)
-  batchSize          Int            @default(500)
-  batchWindowMinutes Int            @default(0)
-  lastCursor         String?
-  lastSentAt         DateTime?
-  createdAt          DateTime       @default(now())
-  updatedAt          DateTime       @updatedAt
+  id                      String               @id @default(cuid())
+  name                    String
+  teamId                  Int
+  from                    String
+  cc                      String[]
+  bcc                     String[]
+  replyTo                 String[]
+  domainId                Int
+  subject                 String
+  previewText             String?
+  html                    String?
+  content                 String?
+  contactBookId           String?
+  scheduledAt             DateTime?
+  total                   Int                  @default(0)
+  sent                    Int                  @default(0)
+  delivered               Int                  @default(0)
+  opened                  Int                  @default(0)
+  clicked                 Int                  @default(0)
+  unsubscribed            Int                  @default(0)
+  bounced                 Int                  @default(0)
+  hardBounced             Int                  @default(0)
+  complained              Int                  @default(0)
+  isApi                   Boolean              @default(false)
+  status                  CampaignStatus       @default(DRAFT)
+  batchSize               Int                  @default(500)
+  batchWindowMinutes      Int                  @default(0)
+  lastCursor              String?
+  lastSentAt              DateTime?
+  deliveryMode            CampaignDeliveryMode @default(ALL_AT_ONCE)
+  deliveryBatchPercentage Int?
+  deliveryIntervalMinutes Int?
+  deliveryBatchSize       Int?
+  currentDeliveryBatch    Int                  @default(0)
+  deliveryBatchProcessed  Int                  @default(0)
+  nextDeliveryAt          DateTime?
+  audienceCapturedAt      DateTime?
+  audiencePreparedAt      DateTime?
+  pausedAt                DateTime?
+  createdAt               DateTime             @default(now())
+  updatedAt               DateTime             @updatedAt
 
   team Team @relation(fields: [teamId], references: [id], onDelete: Cascade)
 
   @@index([createdAt(sort: Desc)])
   @@index([status, scheduledAt])
+  @@index([status, nextDeliveryAt])
 }
 
 model Template {

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -267,6 +267,7 @@ model Email {
   emailEvents  EmailEvent[]
 
   @@index([campaignId, contactId])
+  @@index([campaignId, latestStatus])
   @@index([createdAt(sort: Desc)])
 }
 
@@ -359,6 +360,7 @@ enum CampaignDeliveryMode {
 
 enum CampaignRecipientStatus {
   PENDING
+  PROCESSING
   QUEUED
   SUPPRESSED
   SKIPPED

--- a/apps/web/src/app/(dashboard)/campaigns/[campaignId]/page.tsx
+++ b/apps/web/src/app/(dashboard)/campaigns/[campaignId]/page.tsx
@@ -22,6 +22,7 @@ import { Button } from "@usesend/ui/src/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@usesend/ui/src/card";
 import { EmailStatusBadge } from "../../emails/email-status-badge";
 import { AnimatePresence, motion } from "framer-motion";
+import { Clock3, Send } from "lucide-react";
 
 export default function CampaignDetailsPage({
   params,
@@ -45,7 +46,7 @@ export default function CampaignDetailsPage({
         }
         return false;
       },
-    }
+    },
   );
 
   const { data: latestEmails, isLoading: latestEmailsLoading } =
@@ -53,8 +54,19 @@ export default function CampaignDetailsPage({
       { campaignId: campaignId },
       {
         refetchInterval: 5000,
-      }
+      },
     );
+
+  const { data: deliveryProgress } = api.campaign.getDeliveryProgress.useQuery(
+    { campaignId },
+    {
+      refetchInterval:
+        campaign?.status === CampaignStatus.RUNNING ||
+        campaign?.status === CampaignStatus.PAUSED
+          ? 5000
+          : false,
+    },
+  );
 
   if (isLoading) {
     return (
@@ -100,7 +112,31 @@ export default function CampaignDetailsPage({
   ];
 
   const total = campaign.total ?? 0;
-  const processed = campaign.sent ?? 0;
+  const processed = deliveryProgress?.processed ?? campaign.sent ?? 0;
+  const awaiting = Math.max(deliveryProgress?.pending ?? 0, total - processed);
+  const completionPercentage =
+    total > 0 ? Math.min(100, (processed / total) * 100) : 0;
+  const deliveryBatchSize = campaign.deliveryBatchSize ?? 0;
+  const totalDeliveryBatches =
+    deliveryBatchSize > 0 ? Math.ceil(total / deliveryBatchSize) : 0;
+  const currentDeliveryBatch = campaign.currentDeliveryBatch ?? 0;
+  const isGradualDelivery = campaign.deliveryMode === "GRADUAL";
+  const nextDeliveryAt = campaign.nextDeliveryAt
+    ? new Date(campaign.nextDeliveryAt)
+    : null;
+  const nextDeliveryLabel = nextDeliveryAt
+    ? nextDeliveryAt.getTime() <= Date.now()
+      ? "Due now"
+      : formatDistanceToNow(nextDeliveryAt, { addSuffix: true })
+    : null;
+
+  const deliveryMetrics = [
+    { label: "Awaiting", value: awaiting },
+    { label: "Queued", value: deliveryProgress?.queued ?? 0 },
+    { label: "Sent", value: deliveryProgress?.sent ?? campaign.sent ?? 0 },
+    { label: "Failed", value: deliveryProgress?.failed ?? 0 },
+    { label: "Suppressed", value: deliveryProgress?.suppressed ?? 0 },
+  ];
 
   return (
     <div className="container mx-auto">
@@ -134,7 +170,90 @@ export default function CampaignDetailsPage({
         )}
       </div>
 
-      <div className="mt-10">
+      <div className="mt-10 space-y-6">
+        <Card>
+          <CardHeader className="gap-4 sm:flex-row sm:items-start sm:justify-between sm:space-y-0">
+            <div className="space-y-1">
+              <CardTitle className="text-sm font-mono">Delivery</CardTitle>
+              <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                {isGradualDelivery ? (
+                  <Clock3 className="h-4 w-4" />
+                ) : (
+                  <Send className="h-4 w-4" />
+                )}
+                <span>
+                  {isGradualDelivery
+                    ? (campaign.deliveryBatchPercentage ?? 0) +
+                      "% every " +
+                      (campaign.deliveryIntervalMinutes === 1
+                        ? "minute"
+                        : "hour")
+                    : "All at once"}
+                </span>
+              </div>
+            </div>
+
+            {isGradualDelivery && totalDeliveryBatches > 0 ? (
+              <div className="text-left sm:text-right">
+                <div className="text-sm font-mono">
+                  {currentDeliveryBatch > 0 ? (
+                    <>
+                      Wave {currentDeliveryBatch} of {totalDeliveryBatches}
+                    </>
+                  ) : (
+                    <>{totalDeliveryBatches} waves planned</>
+                  )}
+                </div>
+                {nextDeliveryLabel && campaign.status === "RUNNING" ? (
+                  <div className="mt-1 text-xs text-muted-foreground">
+                    Next wave {nextDeliveryLabel}
+                  </div>
+                ) : null}
+              </div>
+            ) : null}
+          </CardHeader>
+
+          <CardContent className="space-y-5">
+            <div className="space-y-2">
+              <div className="flex items-center justify-between gap-4 text-xs text-muted-foreground">
+                <span>
+                  {processed.toLocaleString()} of {total.toLocaleString()}{" "}
+                  processed
+                </span>
+                <span className="font-mono">
+                  {completionPercentage.toFixed(0)}%
+                </span>
+              </div>
+              <div
+                className="h-2 overflow-hidden rounded-full bg-muted"
+                role="progressbar"
+                aria-label="Campaign delivery progress"
+                aria-valuemin={0}
+                aria-valuemax={total}
+                aria-valuenow={Math.min(processed, total)}
+              >
+                <div
+                  className="h-full rounded-full bg-foreground transition-[width] duration-300"
+                  style={{ width: completionPercentage + "%" }}
+                />
+              </div>
+            </div>
+
+            <div className="grid grid-cols-2 gap-px overflow-hidden rounded-md border bg-border sm:grid-cols-5">
+              {deliveryMetrics.map((metric) => (
+                <div key={metric.label} className="bg-background px-3 py-3">
+                  <div className="text-xs text-muted-foreground">
+                    {metric.label}
+                  </div>
+                  <div className="mt-1 font-mono text-sm">
+                    {metric.value.toLocaleString()}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+
         <div className="grid gap-6 lg:grid-cols-2">
           <Card>
             <CardHeader className="space-y-4">

--- a/apps/web/src/app/(dashboard)/campaigns/[campaignId]/page.tsx
+++ b/apps/web/src/app/(dashboard)/campaigns/[campaignId]/page.tsx
@@ -39,6 +39,7 @@ export default function CampaignDetailsPage({
         if (!c) return false;
 
         if (
+          c.status === CampaignStatus.SCHEDULED ||
           c.status === CampaignStatus.RUNNING ||
           c.status === CampaignStatus.PAUSED
         ) {
@@ -60,11 +61,29 @@ export default function CampaignDetailsPage({
   const { data: deliveryProgress } = api.campaign.getDeliveryProgress.useQuery(
     { campaignId },
     {
-      refetchInterval:
-        campaign?.status === CampaignStatus.RUNNING ||
-        campaign?.status === CampaignStatus.PAUSED
-          ? 5000
-          : false,
+      refetchInterval: (query) => {
+        if (
+          campaign?.status === CampaignStatus.SCHEDULED ||
+          campaign?.status === CampaignStatus.RUNNING
+        ) {
+          return 5000;
+        }
+
+        const progress = query.state.data;
+        if (
+          campaign?.status === CampaignStatus.PAUSED &&
+          progress?.processing
+        ) {
+          return 5000;
+        }
+
+        const needsFinalSnapshot =
+          campaign?.status === CampaignStatus.SENT &&
+          progress != null &&
+          progress.pending > 0;
+
+        return needsFinalSnapshot ? 5000 : false;
+      },
     },
   );
 
@@ -121,6 +140,10 @@ export default function CampaignDetailsPage({
     deliveryBatchSize > 0 ? Math.ceil(total / deliveryBatchSize) : 0;
   const currentDeliveryBatch = campaign.currentDeliveryBatch ?? 0;
   const isGradualDelivery = campaign.deliveryMode === "GRADUAL";
+  const showDeliveryCard =
+    campaign.status === CampaignStatus.SCHEDULED ||
+    campaign.status === CampaignStatus.RUNNING ||
+    campaign.status === CampaignStatus.PAUSED;
   const nextDeliveryAt = campaign.nextDeliveryAt
     ? new Date(campaign.nextDeliveryAt)
     : null;
@@ -137,6 +160,18 @@ export default function CampaignDetailsPage({
     { label: "Failed", value: deliveryProgress?.failed ?? 0 },
     { label: "Suppressed", value: deliveryProgress?.suppressed ?? 0 },
   ];
+
+  const completedDeliverySummary = [
+    isGradualDelivery && totalDeliveryBatches > 0
+      ? `Sent in ${totalDeliveryBatches.toLocaleString()} ${
+          totalDeliveryBatches === 1 ? "wave" : "waves"
+        }`
+      : "Sent all at once",
+    `${processed.toLocaleString()} processed`,
+    ...(deliveryProgress?.failed
+      ? [`${deliveryProgress.failed.toLocaleString()} failed`]
+      : []),
+  ].join(" · ");
 
   return (
     <div className="container mx-auto">
@@ -171,7 +206,7 @@ export default function CampaignDetailsPage({
       </div>
 
       <div className="mt-10 space-y-6">
-        <Card>
+        <Card hidden={!showDeliveryCard}>
           <CardHeader className="gap-4 sm:flex-row sm:items-start sm:justify-between sm:space-y-0">
             <div className="space-y-1">
               <CardTitle className="text-sm font-mono">Delivery</CardTitle>
@@ -259,7 +294,11 @@ export default function CampaignDetailsPage({
             <CardHeader className="space-y-4">
               <div className="flex flex-col gap-1">
                 <CardTitle className="text-sm font-mono">Statistics</CardTitle>
-                {total > 0 ? (
+                {campaign.status === CampaignStatus.SENT ? (
+                  <div className="text-sm text-muted-foreground font-mono">
+                    {completedDeliverySummary}
+                  </div>
+                ) : total > 0 ? (
                   <div className="text-sm text-muted-foreground font-mono">
                     {processed.toLocaleString()} of {total.toLocaleString()}{" "}
                     processed

--- a/apps/web/src/app/(dashboard)/campaigns/schedule-campaign.tsx
+++ b/apps/web/src/app/(dashboard)/campaigns/schedule-campaign.tsx
@@ -18,11 +18,25 @@ import * as chrono from "chrono-node";
 import { api } from "~/trpc/react";
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "@usesend/ui/src/toaster";
-import { Calendar as CalendarIcon } from "lucide-react";
+import { Calendar as CalendarIcon, Clock3, Send } from "lucide-react";
 import { Calendar } from "@usesend/ui/src/calendar";
-import { Campaign } from "@prisma/client";
+import type { Campaign } from "@prisma/client";
 import { format } from "date-fns";
 import { Spinner } from "@usesend/ui/src/spinner";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@usesend/ui/src/select";
+import {
+  calculateGradualDelivery,
+  GRADUAL_DELIVERY_INTERVAL_MINUTES,
+} from "~/lib/campaign-delivery";
+import type { GradualDeliveryInterval } from "~/lib/campaign-delivery";
+
+type DeliveryMode = "ALL_AT_ONCE" | "GRADUAL";
 
 export const ScheduleCampaign: React.FC<{
   campaign: Partial<Campaign> & { id: string };
@@ -42,7 +56,21 @@ export const ScheduleCampaign: React.FC<{
   );
   const [isConfirmNow, setIsConfirmNow] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [deliveryMode, setDeliveryMode] = useState<DeliveryMode>(
+    campaign.deliveryMode ?? "ALL_AT_ONCE",
+  );
+  const [batchPercentage, setBatchPercentage] = useState(
+    String(campaign.deliveryBatchPercentage ?? 10),
+  );
+  const [deliveryInterval, setDeliveryInterval] =
+    useState<GradualDeliveryInterval>(
+      campaign.deliveryIntervalMinutes === 1 ? "minute" : "hour",
+    );
   const scheduleMutation = api.campaign.scheduleCampaign.useMutation();
+  const audienceQuery = api.campaign.getAudienceCount.useQuery(
+    { campaignId: campaign.id },
+    { enabled: open },
+  );
   const utils = api.useUtils();
   const scheduledAtTimestamp = campaign.scheduledAt
     ? new Date(campaign.scheduledAt).getTime()
@@ -50,6 +78,12 @@ export const ScheduleCampaign: React.FC<{
 
   useEffect(() => {
     if (!open) return;
+
+    setDeliveryMode(campaign.deliveryMode ?? "ALL_AT_ONCE");
+    setBatchPercentage(String(campaign.deliveryBatchPercentage ?? 10));
+    setDeliveryInterval(
+      campaign.deliveryIntervalMinutes === 1 ? "minute" : "hour",
+    );
 
     if (scheduledAtTimestamp != null) {
       const scheduledDate = new Date(scheduledAtTimestamp);
@@ -61,15 +95,66 @@ export const ScheduleCampaign: React.FC<{
     const now = new Date();
     setSelectedDate(now);
     setScheduleInput("");
-  }, [open, scheduledAtTimestamp]);
+  }, [
+    campaign.deliveryBatchPercentage,
+    campaign.deliveryIntervalMinutes,
+    campaign.deliveryMode,
+    open,
+    scheduledAtTimestamp,
+  ]);
+
+  const parsedBatchPercentage = Number(batchPercentage);
+  const isBatchPercentageValid =
+    batchPercentage.trim().length > 0 &&
+    Number.isInteger(parsedBatchPercentage) &&
+    parsedBatchPercentage >= 1 &&
+    parsedBatchPercentage <= 50;
+
+  const deliveryEstimate = useMemo(() => {
+    if (
+      deliveryMode !== "GRADUAL" ||
+      !isBatchPercentageValid ||
+      audienceQuery.data == null
+    ) {
+      return null;
+    }
+
+    return calculateGradualDelivery({
+      audienceSize: audienceQuery.data.total,
+      batchPercentage: parsedBatchPercentage,
+      intervalMinutes: GRADUAL_DELIVERY_INTERVAL_MINUTES[deliveryInterval],
+      startsAt: selectedDate ?? new Date(),
+    });
+  }, [
+    audienceQuery.data,
+    batchPercentage,
+    deliveryInterval,
+    deliveryMode,
+    isBatchPercentageValid,
+    selectedDate,
+  ]);
 
   const onSchedule = (scheduledAt?: Date) => {
     if (error) setError(null);
+
+    if (deliveryMode === "GRADUAL" && !isBatchPercentageValid) {
+      setError("Batch percentage must be a whole number between 1 and 50");
+      return;
+    }
+
     scheduleMutation.mutate(
       {
         campaignId: campaign.id,
         // Never send free text to backend; only a Date
         scheduledAt: scheduledAt ? scheduledAt : undefined,
+        delivery:
+          deliveryMode === "GRADUAL"
+            ? {
+                strategy: "GRADUAL",
+                batchPercentage: parsedBatchPercentage,
+                interval: deliveryInterval,
+              }
+            : { strategy: "ALL_AT_ONCE" },
       },
       {
         onSuccess: () => {
@@ -162,11 +247,14 @@ export const ScheduleCampaign: React.FC<{
         <DialogTrigger asChild>
           <Button variant="default">Schedule Campaign</Button>
         </DialogTrigger>
-        <DialogContent ref={dialogContentRef}>
+        <DialogContent
+          ref={dialogContentRef}
+          className="max-h-[90vh] overflow-y-auto sm:max-w-[560px]"
+        >
           <DialogHeader>
             <DialogTitle>Schedule Campaign</DialogTitle>
           </DialogHeader>
-          <div className="py-2 space-y-8">
+          <div className="space-y-7 py-2">
             <div>
               <label htmlFor="scheduledAt" className="block mb-2">
                 Schedule at
@@ -251,6 +339,155 @@ export const ScheduleCampaign: React.FC<{
               </div>
             </div>
 
+            <div className="space-y-3">
+              <div>
+                <div className="text-sm font-medium">Delivery</div>
+                <div className="mt-1 text-sm text-muted-foreground">
+                  Choose how quickly recipients enter the sending queue.
+                </div>
+              </div>
+
+              <div className="grid gap-3 sm:grid-cols-2">
+                <button
+                  type="button"
+                  aria-pressed={deliveryMode === "ALL_AT_ONCE"}
+                  onClick={() => setDeliveryMode("ALL_AT_ONCE")}
+                  className={`rounded-md border p-3 text-left transition-colors hover:border-foreground/40 ${
+                    deliveryMode === "ALL_AT_ONCE"
+                      ? "border-foreground bg-muted/60"
+                      : "border-border"
+                  }`}
+                >
+                  <Send className="mb-3 h-4 w-4" />
+                  <div className="text-sm font-medium">All at once</div>
+                  <div className="mt-1 text-xs leading-5 text-muted-foreground">
+                    Queue the full audience when sending starts.
+                  </div>
+                </button>
+
+                <button
+                  type="button"
+                  aria-pressed={deliveryMode === "GRADUAL"}
+                  onClick={() => setDeliveryMode("GRADUAL")}
+                  className={`rounded-md border p-3 text-left transition-colors hover:border-foreground/40 ${
+                    deliveryMode === "GRADUAL"
+                      ? "border-foreground bg-muted/60"
+                      : "border-border"
+                  }`}
+                >
+                  <Clock3 className="mb-3 h-4 w-4" />
+                  <div className="text-sm font-medium">Gradual</div>
+                  <div className="mt-1 text-xs leading-5 text-muted-foreground">
+                    Release a percentage of recipients in timed waves.
+                  </div>
+                </button>
+              </div>
+
+              {deliveryMode === "GRADUAL" ? (
+                <div className="space-y-4 rounded-md border bg-muted/20 p-4">
+                  <div className="grid gap-4 sm:grid-cols-2">
+                    <div className="space-y-2">
+                      <label
+                        htmlFor="deliveryBatchPercentage"
+                        className="text-sm font-medium"
+                      >
+                        Audience per wave
+                      </label>
+                      <div className="relative">
+                        <Input
+                          id="deliveryBatchPercentage"
+                          type="number"
+                          min={1}
+                          max={50}
+                          step={1}
+                          value={batchPercentage}
+                          onChange={(event) =>
+                            setBatchPercentage(event.target.value)
+                          }
+                          aria-invalid={!isBatchPercentageValid}
+                          className="pr-8 font-mono"
+                        />
+                        <span className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-sm text-muted-foreground">
+                          %
+                        </span>
+                      </div>
+                      {!isBatchPercentageValid ? (
+                        <p className="text-xs text-destructive">
+                          Enter a whole number from 1 to 50.
+                        </p>
+                      ) : null}
+                    </div>
+
+                    <div className="space-y-2">
+                      <label className="text-sm font-medium">
+                        Time between waves
+                      </label>
+                      <Select
+                        value={deliveryInterval}
+                        onValueChange={(value) =>
+                          setDeliveryInterval(value as GradualDeliveryInterval)
+                        }
+                      >
+                        <SelectTrigger>
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="minute">Every minute</SelectItem>
+                          <SelectItem value="hour">Every hour</SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </div>
+                  </div>
+
+                  <div className="border-t pt-4">
+                    {audienceQuery.isLoading ? (
+                      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                        <Spinner className="h-4 w-4" />
+                        Calculating delivery plan
+                      </div>
+                    ) : deliveryEstimate && deliveryEstimate.batchSize > 0 ? (
+                      <div className="space-y-2">
+                        <div className="grid grid-cols-3 gap-3 font-mono">
+                          <div>
+                            <div className="text-xs text-muted-foreground">
+                              Per wave
+                            </div>
+                            <div className="mt-1 text-sm">
+                              {deliveryEstimate.batchSize.toLocaleString()}
+                            </div>
+                          </div>
+                          <div>
+                            <div className="text-xs text-muted-foreground">
+                              Waves
+                            </div>
+                            <div className="mt-1 text-sm">
+                              {deliveryEstimate.totalBatches.toLocaleString()}
+                            </div>
+                          </div>
+                          <div>
+                            <div className="text-xs text-muted-foreground">
+                              Estimated end
+                            </div>
+                            <div className="mt-1 text-sm">
+                              {format(deliveryEstimate.completesAt, "MMM d, p")}
+                            </div>
+                          </div>
+                        </div>
+                        <p className="text-xs leading-5 text-muted-foreground">
+                          Based on the current subscribed audience. The final
+                          audience is captured when sending starts.
+                        </p>
+                      </div>
+                    ) : (
+                      <p className="text-sm text-muted-foreground">
+                        No subscribed recipients to preview yet.
+                      </p>
+                    )}
+                  </div>
+                </div>
+              ) : null}
+            </div>
+
             {error && (
               <div className="text-sm text-destructive bg-destructive/10 p-3 rounded-md border border-destructive">
                 {error}
@@ -261,14 +498,17 @@ export const ScheduleCampaign: React.FC<{
               {isConfirmNow ? (
                 <div className="flex items-center gap-2">
                   <span className="text-sm text-muted-foreground">
-                    Are you sure you want to send this campaign now?
+                    Are you sure you want to start this campaign now?
                   </span>
                   <Button
                     size="sm"
                     onClick={() => {
                       onSchedule(new Date());
                     }}
-                    disabled={scheduleMutation.isPending}
+                    disabled={
+                      scheduleMutation.isPending ||
+                      (deliveryMode === "GRADUAL" && !isBatchPercentageValid)
+                    }
                   >
                     Yes
                   </Button>
@@ -298,6 +538,9 @@ export const ScheduleCampaign: React.FC<{
                     }}
                     isLoading={scheduleMutation.isPending}
                     showSpinner={true}
+                    disabled={
+                      deliveryMode === "GRADUAL" && !isBatchPercentageValid
+                    }
                   >
                     {scheduleMutation.isPending ? "Scheduling" : "Schedule"}
                   </Button>

--- a/apps/web/src/app/(dashboard)/campaigns/schedule-campaign.tsx
+++ b/apps/web/src/app/(dashboard)/campaigns/schedule-campaign.tsx
@@ -69,7 +69,7 @@ export const ScheduleCampaign: React.FC<{
   const scheduleMutation = api.campaign.scheduleCampaign.useMutation();
   const audienceQuery = api.campaign.getAudienceCount.useQuery(
     { campaignId: campaign.id },
-    { enabled: open },
+    { enabled: open && deliveryMode === "GRADUAL" },
   );
   const utils = api.useUtils();
   const scheduledAtTimestamp = campaign.scheduledAt
@@ -240,7 +240,16 @@ export const ScheduleCampaign: React.FC<{
         onOpenChange={(_open) => {
           if (_open !== open) {
             setOpen(_open);
-            if (!_open) setError(null);
+            if (!_open) {
+              setError(null);
+              setDeliveryMode(campaign.deliveryMode ?? "ALL_AT_ONCE");
+              setBatchPercentage(
+                String(campaign.deliveryBatchPercentage ?? 10),
+              );
+              setDeliveryInterval(
+                campaign.deliveryIntervalMinutes === 1 ? "minute" : "hour",
+              );
+            }
           }
         }}
       >
@@ -419,7 +428,10 @@ export const ScheduleCampaign: React.FC<{
                     </div>
 
                     <div className="space-y-2">
-                      <label className="text-sm font-medium">
+                      <label
+                        htmlFor="deliveryInterval"
+                        className="text-sm font-medium"
+                      >
                         Time between waves
                       </label>
                       <Select
@@ -428,7 +440,7 @@ export const ScheduleCampaign: React.FC<{
                           setDeliveryInterval(value as GradualDeliveryInterval)
                         }
                       >
-                        <SelectTrigger>
+                        <SelectTrigger id="deliveryInterval">
                           <SelectValue />
                         </SelectTrigger>
                         <SelectContent>
@@ -444,6 +456,24 @@ export const ScheduleCampaign: React.FC<{
                       <div className="flex items-center gap-2 text-sm text-muted-foreground">
                         <Spinner className="h-4 w-4" />
                         Calculating delivery plan
+                      </div>
+                    ) : audienceQuery.isError ? (
+                      <div
+                        className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between"
+                        role="alert"
+                      >
+                        <p className="text-sm text-destructive">
+                          Couldn&apos;t load the audience preview.
+                        </p>
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="sm"
+                          onClick={() => void audienceQuery.refetch()}
+                          disabled={audienceQuery.isFetching}
+                        >
+                          {audienceQuery.isFetching ? "Retrying" : "Retry"}
+                        </Button>
                       </div>
                     ) : deliveryEstimate && deliveryEstimate.batchSize > 0 ? (
                       <div className="space-y-2">
@@ -478,11 +508,11 @@ export const ScheduleCampaign: React.FC<{
                           audience is captured when sending starts.
                         </p>
                       </div>
-                    ) : (
+                    ) : isBatchPercentageValid ? (
                       <p className="text-sm text-muted-foreground">
                         No subscribed recipients to preview yet.
                       </p>
-                    )}
+                    ) : null}
                   </div>
                 </div>
               ) : null}

--- a/apps/web/src/app/(dashboard)/campaigns/toggle-pause-campaign.tsx
+++ b/apps/web/src/app/(dashboard)/campaigns/toggle-pause-campaign.tsx
@@ -25,9 +25,12 @@ export const TogglePauseCampaign: React.FC<{
           onSuccess: () => {
             utils.campaign.getCampaigns.invalidate();
             utils.campaign.getCampaign.invalidate();
+            utils.campaign.getDeliveryProgress.invalidate({
+              campaignId: campaign.id,
+            });
             toast.success("Campaign resumed");
           },
-        }
+        },
       );
     } else {
       pauseMutation.mutate(
@@ -36,9 +39,12 @@ export const TogglePauseCampaign: React.FC<{
           onSuccess: () => {
             utils.campaign.getCampaigns.invalidate();
             utils.campaign.getCampaign.invalidate();
+            utils.campaign.getDeliveryProgress.invalidate({
+              campaignId: campaign.id,
+            });
             toast.success("Campaign paused");
           },
-        }
+        },
       );
     }
   };

--- a/apps/web/src/lib/campaign-delivery.ts
+++ b/apps/web/src/lib/campaign-delivery.ts
@@ -1,0 +1,58 @@
+export const GRADUAL_DELIVERY_MIN_PERCENTAGE = 1;
+export const GRADUAL_DELIVERY_MAX_PERCENTAGE = 50;
+
+export const GRADUAL_DELIVERY_INTERVAL_MINUTES = {
+  minute: 1,
+  hour: 60,
+} as const;
+
+export type GradualDeliveryInterval =
+  keyof typeof GRADUAL_DELIVERY_INTERVAL_MINUTES;
+
+export function calculateGradualDelivery({
+  audienceSize,
+  batchPercentage,
+  intervalMinutes,
+  startsAt,
+}: {
+  audienceSize: number;
+  batchPercentage: number;
+  intervalMinutes: number;
+  startsAt: Date;
+}) {
+  if (!Number.isInteger(audienceSize) || audienceSize < 0) {
+    throw new Error("Audience size must be a non-negative integer");
+  }
+
+  if (
+    !Number.isInteger(batchPercentage) ||
+    batchPercentage < GRADUAL_DELIVERY_MIN_PERCENTAGE ||
+    batchPercentage > GRADUAL_DELIVERY_MAX_PERCENTAGE
+  ) {
+    throw new Error(
+      `Batch percentage must be between ${GRADUAL_DELIVERY_MIN_PERCENTAGE} and ${GRADUAL_DELIVERY_MAX_PERCENTAGE}`,
+    );
+  }
+
+  if (!Number.isInteger(intervalMinutes) || intervalMinutes <= 0) {
+    throw new Error("Delivery interval must be a positive number of minutes");
+  }
+
+  const batchSize =
+    audienceSize === 0
+      ? 0
+      : Math.max(1, Math.ceil((audienceSize * batchPercentage) / 100));
+  const totalBatches =
+    batchSize === 0 ? 0 : Math.ceil(audienceSize / batchSize);
+  const durationMinutes = Math.max(0, totalBatches - 1) * intervalMinutes;
+  const completesAt = new Date(
+    startsAt.getTime() + durationMinutes * 60 * 1000,
+  );
+
+  return {
+    batchSize,
+    totalBatches,
+    durationMinutes,
+    completesAt,
+  };
+}

--- a/apps/web/src/lib/campaign-delivery.unit.test.ts
+++ b/apps/web/src/lib/campaign-delivery.unit.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { calculateGradualDelivery } from "~/lib/campaign-delivery";
+
+describe("calculateGradualDelivery", () => {
+  const startsAt = new Date("2026-07-21T09:00:00.000Z");
+
+  it("calculates percentage-based batches and completion from the first wave", () => {
+    const result = calculateGradualDelivery({
+      audienceSize: 50_000,
+      batchPercentage: 10,
+      intervalMinutes: 60,
+      startsAt,
+    });
+
+    expect(result).toEqual({
+      batchSize: 5_000,
+      totalBatches: 10,
+      durationMinutes: 540,
+      completesAt: new Date("2026-07-21T18:00:00.000Z"),
+    });
+  });
+
+  it("rounds the batch size up and leaves the remainder for the final batch", () => {
+    const result = calculateGradualDelivery({
+      audienceSize: 3,
+      batchPercentage: 50,
+      intervalMinutes: 1,
+      startsAt,
+    });
+
+    expect(result.batchSize).toBe(2);
+    expect(result.totalBatches).toBe(2);
+    expect(result.completesAt).toEqual(
+      new Date("2026-07-21T09:01:00.000Z"),
+    );
+  });
+
+  it("returns an empty schedule for an empty audience", () => {
+    const result = calculateGradualDelivery({
+      audienceSize: 0,
+      batchPercentage: 10,
+      intervalMinutes: 60,
+      startsAt,
+    });
+
+    expect(result.batchSize).toBe(0);
+    expect(result.totalBatches).toBe(0);
+    expect(result.completesAt).toEqual(startsAt);
+  });
+
+  it.each([0, 51, 10.5])("rejects an invalid percentage of %s", (value) => {
+    expect(() =>
+      calculateGradualDelivery({
+        audienceSize: 100,
+        batchPercentage: value,
+        intervalMinutes: 60,
+        startsAt,
+      }),
+    ).toThrow("Batch percentage must be between 1 and 50");
+  });
+});

--- a/apps/web/src/lib/campaign-delivery.unit.test.ts
+++ b/apps/web/src/lib/campaign-delivery.unit.test.ts
@@ -30,9 +30,7 @@ describe("calculateGradualDelivery", () => {
 
     expect(result.batchSize).toBe(2);
     expect(result.totalBatches).toBe(2);
-    expect(result.completesAt).toEqual(
-      new Date("2026-07-21T09:01:00.000Z"),
-    );
+    expect(result.completesAt).toEqual(new Date("2026-07-21T09:01:00.000Z"));
   });
 
   it("returns an empty schedule for an empty audience", () => {

--- a/apps/web/src/server/api/routers/campaign-delivery.trpc.test.ts
+++ b/apps/web/src/server/api/routers/campaign-delivery.trpc.test.ts
@@ -79,6 +79,7 @@ describe("campaign delivery procedures", () => {
   it("returns delivery progress across recipient and email states", async () => {
     mockDb.campaignEmail.groupBy.mockResolvedValue([
       { status: "PENDING", _count: { _all: 40 } },
+      { status: "PROCESSING", _count: { _all: 4 } },
       { status: "QUEUED", _count: { _all: 30 } },
       { status: "SUPPRESSED", _count: { _all: 2 } },
       { status: "SKIPPED", _count: { _all: 3 } },
@@ -95,12 +96,21 @@ describe("campaign delivery procedures", () => {
     });
 
     expect(result).toEqual({
-      pending: 40,
+      pending: 44,
+      processing: 4,
       processed: 36,
       queued: 30,
       sent: 15,
       failed: 1,
       suppressed: 5,
+    });
+    expect(mockDb.email.groupBy).toHaveBeenCalledWith({
+      by: ["latestStatus"],
+      where: {
+        campaignId: "camp_1",
+        latestStatus: { in: ["SCHEDULED", "QUEUED", "FAILED"] },
+      },
+      _count: { _all: true },
     });
   });
 

--- a/apps/web/src/server/api/routers/campaign-delivery.trpc.test.ts
+++ b/apps/web/src/server/api/routers/campaign-delivery.trpc.test.ts
@@ -1,0 +1,131 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockDb, mockScheduleCampaign } = vi.hoisted(() => ({
+  mockDb: {
+    teamUser: { findFirst: vi.fn() },
+    campaign: { findUnique: vi.fn() },
+    contact: { count: vi.fn() },
+    campaignEmail: { groupBy: vi.fn() },
+    email: { groupBy: vi.fn() },
+  },
+  mockScheduleCampaign: vi.fn(),
+}));
+
+vi.mock("~/server/db", () => ({ db: mockDb }));
+vi.mock("~/server/auth", () => ({ getServerAuthSession: vi.fn() }));
+vi.mock("~/server/service/campaign-service", () => ({
+  scheduleCampaign: mockScheduleCampaign,
+}));
+vi.mock("~/server/service/webhook-service", () => ({}));
+vi.mock("~/server/service/domain-service", () => ({
+  validateDomainFromEmail: vi.fn(),
+}));
+vi.mock("~/server/service/storage-service", () => ({
+  getDocumentUploadUrl: vi.fn(),
+  isStorageConfigured: vi.fn(() => false),
+}));
+
+import { campaignRouter } from "~/server/api/routers/campaign";
+import { createCallerFactory } from "~/server/api/trpc";
+
+const createCaller = createCallerFactory(campaignRouter);
+
+function getContext() {
+  return {
+    db: mockDb,
+    headers: new Headers(),
+    session: {
+      user: {
+        id: 1,
+        email: "owner@example.com",
+        isWaitlisted: false,
+        isAdmin: false,
+        isBetaUser: true,
+      },
+    },
+  } as any;
+}
+
+describe("campaign delivery procedures", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDb.teamUser.findFirst.mockResolvedValue({
+      teamId: 10,
+      userId: 1,
+      role: "ADMIN",
+      team: { id: 10, name: "Acme" },
+    });
+    mockDb.campaign.findUnique.mockResolvedValue({
+      id: "camp_1",
+      teamId: 10,
+      contactBookId: "book_1",
+      sent: 15,
+    });
+  });
+
+  it("counts the current subscribed audience for the schedule preview", async () => {
+    mockDb.contact.count.mockResolvedValue(50_000);
+
+    const result = await createCaller(getContext()).getAudienceCount({
+      campaignId: "camp_1",
+    });
+
+    expect(result).toEqual({ total: 50_000 });
+    expect(mockDb.contact.count).toHaveBeenCalledWith({
+      where: { contactBookId: "book_1", subscribed: true },
+    });
+  });
+
+  it("returns delivery progress across recipient and email states", async () => {
+    mockDb.campaignEmail.groupBy.mockResolvedValue([
+      { status: "PENDING", _count: { _all: 40 } },
+      { status: "QUEUED", _count: { _all: 30 } },
+      { status: "SUPPRESSED", _count: { _all: 2 } },
+      { status: "SKIPPED", _count: { _all: 3 } },
+      { status: "FAILED", _count: { _all: 1 } },
+    ]);
+    mockDb.email.groupBy.mockResolvedValue([
+      { latestStatus: "SCHEDULED", _count: { _all: 10 } },
+      { latestStatus: "QUEUED", _count: { _all: 20 } },
+      { latestStatus: "FAILED", _count: { _all: 1 } },
+    ]);
+
+    const result = await createCaller(getContext()).getDeliveryProgress({
+      campaignId: "camp_1",
+    });
+
+    expect(result).toEqual({
+      pending: 40,
+      processed: 36,
+      queued: 30,
+      sent: 15,
+      failed: 1,
+      suppressed: 5,
+    });
+  });
+
+  it("validates and forwards gradual scheduling settings", async () => {
+    mockScheduleCampaign.mockResolvedValue({ ok: true });
+
+    await createCaller(getContext()).scheduleCampaign({
+      campaignId: "camp_1",
+      delivery: {
+        strategy: "GRADUAL",
+        batchPercentage: 10,
+        interval: "hour",
+      },
+    });
+
+    expect(mockScheduleCampaign).toHaveBeenCalledWith({
+      campaignId: "camp_1",
+      teamId: 10,
+      scheduledAt: undefined,
+      batchSize: undefined,
+      delivery: {
+        strategy: "GRADUAL",
+        batchPercentage: 10,
+        interval: "hour",
+      },
+    });
+  });
+});

--- a/apps/web/src/server/api/routers/campaign.ts
+++ b/apps/web/src/server/api/routers/campaign.ts
@@ -9,7 +9,6 @@ import {
   campaignProcedure,
   publicProcedure,
 } from "~/server/api/trpc";
-import { logger } from "~/server/logger/log";
 import { nanoid } from "~/server/nanoid";
 import * as campaignService from "~/server/service/campaign-service";
 import { validateDomainFromEmail } from "~/server/service/domain-service";
@@ -239,7 +238,10 @@ export const campaignRouter = createTRPCRouter({
         }),
         db.email.groupBy({
           by: ["latestStatus"],
-          where: { campaignId: campaign.id },
+          where: {
+            campaignId: campaign.id,
+            latestStatus: { in: ["SCHEDULED", "QUEUED", "FAILED"] },
+          },
           _count: { _all: true },
         }),
       ]);
@@ -250,12 +252,16 @@ export const campaignRouter = createTRPCRouter({
       const emailCount = new Map(
         emailStatuses.map((row) => [row.latestStatus, row._count._all]),
       );
+      const processingRecipients = recipientCount.get("PROCESSING") ?? 0;
+      const awaitingRecipients =
+        (recipientCount.get("PENDING") ?? 0) + processingRecipients;
 
       return {
-        pending: recipientCount.get("PENDING") ?? 0,
+        pending: awaitingRecipients,
+        processing: processingRecipients,
         processed:
           recipientStatuses.reduce((total, row) => total + row._count._all, 0) -
-          (recipientCount.get("PENDING") ?? 0),
+          awaitingRecipients,
         queued:
           (emailCount.get("QUEUED") ?? 0) + (emailCount.get("SCHEDULED") ?? 0),
         sent: campaign.sent,

--- a/apps/web/src/server/api/routers/campaign.ts
+++ b/apps/web/src/server/api/routers/campaign.ts
@@ -19,6 +19,14 @@ import {
 } from "~/server/service/storage-service";
 
 const statuses = Object.values(CampaignStatus) as [CampaignStatus];
+const campaignDeliverySchema = z.discriminatedUnion("strategy", [
+  z.object({ strategy: z.literal("ALL_AT_ONCE") }),
+  z.object({
+    strategy: z.literal("GRADUAL"),
+    batchPercentage: z.number().int().min(1).max(50),
+    interval: z.enum(["minute", "hour"]),
+  }),
+]);
 
 export const campaignRouter = createTRPCRouter({
   getCampaigns: teamProcedure
@@ -171,9 +179,11 @@ export const campaignRouter = createTRPCRouter({
       return campaign;
     }),
 
-  deleteCampaign: campaignProcedure.mutation(async ({ ctx: { team }, input }) => {
-    return await campaignService.deleteCampaign(input.campaignId, team.id);
-  }),
+  deleteCampaign: campaignProcedure.mutation(
+    async ({ ctx: { team }, input }) => {
+      return await campaignService.deleteCampaign(input.campaignId, team.id);
+    },
+  ),
 
   getCampaign: campaignProcedure.query(async ({ ctx: { db, team }, input }) => {
     const campaign = await db.campaign.findUnique({
@@ -201,6 +211,61 @@ export const campaignRouter = createTRPCRouter({
       imageUploadSupported,
     };
   }),
+
+  getAudienceCount: campaignProcedure.query(
+    async ({ ctx: { db, campaign } }) => {
+      if (!campaign.contactBookId) {
+        return { total: 0 };
+      }
+
+      const total = await db.contact.count({
+        where: {
+          contactBookId: campaign.contactBookId,
+          subscribed: true,
+        },
+      });
+
+      return { total };
+    },
+  ),
+
+  getDeliveryProgress: campaignProcedure.query(
+    async ({ ctx: { db, campaign } }) => {
+      const [recipientStatuses, emailStatuses] = await Promise.all([
+        db.campaignEmail.groupBy({
+          by: ["status"],
+          where: { campaignId: campaign.id },
+          _count: { _all: true },
+        }),
+        db.email.groupBy({
+          by: ["latestStatus"],
+          where: { campaignId: campaign.id },
+          _count: { _all: true },
+        }),
+      ]);
+
+      const recipientCount = new Map(
+        recipientStatuses.map((row) => [row.status, row._count._all]),
+      );
+      const emailCount = new Map(
+        emailStatuses.map((row) => [row.latestStatus, row._count._all]),
+      );
+
+      return {
+        pending: recipientCount.get("PENDING") ?? 0,
+        processed:
+          recipientStatuses.reduce((total, row) => total + row._count._all, 0) -
+          (recipientCount.get("PENDING") ?? 0),
+        queued:
+          (emailCount.get("QUEUED") ?? 0) + (emailCount.get("SCHEDULED") ?? 0),
+        sent: campaign.sent,
+        failed: emailCount.get("FAILED") ?? 0,
+        suppressed:
+          (recipientCount.get("SUPPRESSED") ?? 0) +
+          (recipientCount.get("SKIPPED") ?? 0),
+      };
+    },
+  ),
 
   latestEmails: campaignProcedure.query(
     async ({ ctx: { db, team, campaign } }) => {
@@ -266,6 +331,7 @@ export const campaignRouter = createTRPCRouter({
         campaignId: z.string(),
         scheduledAt: z.union([z.string().datetime(), z.date()]).optional(),
         batchSize: z.number().min(1).max(100_000).optional(),
+        delivery: campaignDeliverySchema.optional(),
       }),
     )
     .mutation(async ({ ctx: { team }, input }) => {
@@ -274,6 +340,7 @@ export const campaignRouter = createTRPCRouter({
         teamId: team.id,
         scheduledAt: input.scheduledAt,
         batchSize: input.batchSize,
+        delivery: input.delivery,
       });
       return { ok: true };
     }),

--- a/apps/web/src/server/jobs/campaign-scheduler-job.ts
+++ b/apps/web/src/server/jobs/campaign-scheduler-job.ts
@@ -13,6 +13,78 @@ const SCHEDULER_TICK_MS = 1500;
 
 type SchedulerJob = TeamJob<{}>;
 
+export async function runCampaignSchedulerTick() {
+  try {
+    const now = new Date();
+    const campaigns = await db.campaign.findMany({
+      where: {
+        status: { in: ["SCHEDULED", "RUNNING"] },
+        AND: [
+          {
+            OR: [{ scheduledAt: null }, { scheduledAt: { lte: now } }],
+          },
+          {
+            OR: [
+              { deliveryMode: "ALL_AT_ONCE" },
+              { nextDeliveryAt: null },
+              { nextDeliveryAt: { lte: now } },
+            ],
+          },
+        ],
+      },
+      select: {
+        id: true,
+        teamId: true,
+        lastSentAt: true,
+        batchWindowMinutes: true,
+      },
+    });
+
+    const enqueuePromises: Promise<any>[] = [];
+    for (const campaign of campaigns) {
+      const windowMin = campaign.batchWindowMinutes ?? 0;
+      if (windowMin > 0 && campaign.lastSentAt) {
+        const elapsedMs =
+          now.getTime() - new Date(campaign.lastSentAt).getTime();
+        const windowMs = windowMin * 60 * 1000;
+        if (elapsedMs < windowMs) {
+          const remainingMs = windowMs - elapsedMs;
+          logger.debug(
+            { campaignId: campaign.id, remainingMs, windowMs },
+            "Skip queueing batch; window not elapsed",
+          );
+          continue;
+        }
+      }
+      enqueuePromises.push(
+        CampaignBatchService.queueBatch({
+          campaignId: campaign.id,
+          teamId: campaign.teamId,
+        }).catch((err) => {
+          logger.error(
+            { err, campaignId: campaign.id },
+            "Failed to enqueue campaign batch",
+          );
+        }),
+      );
+    }
+
+    if (enqueuePromises.length > 0) {
+      const results = await Promise.allSettled(enqueuePromises);
+      const rejected = results.filter(
+        (result) => result.status === "rejected",
+      ).length;
+      const fulfilled = results.length - rejected;
+      logger.debug(
+        { total: results.length, fulfilled, rejected },
+        "Scheduler enqueue summary",
+      );
+    }
+  } catch (err) {
+    logger.error({ err }, "Campaign scheduler tick failed");
+  }
+}
+
 export class CampaignSchedulerService {
   private static schedulerQueue = new Queue<SchedulerJob>(
     CAMPAIGN_SCHEDULER_QUEUE,
@@ -20,71 +92,18 @@ export class CampaignSchedulerService {
       connection: getRedis(),
       prefix: BULL_PREFIX,
       skipVersionCheck: true,
-    }
+    },
   );
 
   static worker = new Worker(
     CAMPAIGN_SCHEDULER_QUEUE,
-    createWorkerHandler(async (_job: SchedulerJob) => {
-      try {
-        const now = new Date();
-        const campaigns = await db.campaign.findMany({
-          where: {
-            status: { in: ["SCHEDULED", "RUNNING"] },
-            OR: [{ scheduledAt: null }, { scheduledAt: { lte: now } }],
-          },
-          select: {
-            id: true,
-            teamId: true,
-            lastSentAt: true,
-            batchWindowMinutes: true,
-          },
-        });
-
-        const enqueuePromises: Promise<any>[] = [];
-        for (const c of campaigns) {
-          const windowMin = c.batchWindowMinutes ?? 0;
-          if (windowMin > 0 && c.lastSentAt) {
-            const elapsedMs = now.getTime() - new Date(c.lastSentAt).getTime();
-            const windowMs = windowMin * 60 * 1000;
-            if (elapsedMs < windowMs) {
-              const remainingMs = windowMs - elapsedMs;
-              logger.debug(
-                { campaignId: c.id, remainingMs, windowMs },
-                "Skip queueing batch; window not elapsed"
-              );
-              continue;
-            }
-          }
-          enqueuePromises.push(
-            CampaignBatchService.queueBatch({
-              campaignId: c.id,
-              teamId: c.teamId,
-            }).catch((err) => {
-              logger.error(
-                { err, campaignId: c.id },
-                "Failed to enqueue campaign batch"
-              );
-            })
-          );
-        }
-
-        if (enqueuePromises.length > 0) {
-          const results = await Promise.allSettled(enqueuePromises);
-          const rejected = results.filter(
-            (r) => r.status === "rejected"
-          ).length;
-          const fulfilled = results.length - rejected;
-          logger.debug(
-            { total: results.length, fulfilled, rejected },
-            "Scheduler enqueue summary"
-          );
-        }
-      } catch (err) {
-        logger.error({ err }, "Campaign scheduler tick failed");
-      }
-    }),
-    { connection: getRedis(), concurrency: 1, prefix: BULL_PREFIX, skipVersionCheck: true }
+    createWorkerHandler(runCampaignSchedulerTick),
+    {
+      connection: getRedis(),
+      concurrency: 1,
+      prefix: BULL_PREFIX,
+      skipVersionCheck: true,
+    },
   );
 
   static async start() {
@@ -96,7 +115,7 @@ export class CampaignSchedulerService {
           jobId: "campaign-scheduler",
           repeat: { every: SCHEDULER_TICK_MS },
           ...DEFAULT_QUEUE_OPTIONS,
-        }
+        },
       );
     } catch (err) {
       // Adding the same repeatable job is idempotent; ignore job-exists errors

--- a/apps/web/src/server/jobs/campaign-scheduler-job.ts
+++ b/apps/web/src/server/jobs/campaign-scheduler-job.ts
@@ -40,7 +40,7 @@ export async function runCampaignSchedulerTick() {
       },
     });
 
-    const enqueuePromises: Promise<any>[] = [];
+    const enqueuePromises: Promise<void>[] = [];
     for (const campaign of campaigns) {
       const windowMin = campaign.batchWindowMinutes ?? 0;
       if (windowMin > 0 && campaign.lastSentAt) {
@@ -65,6 +65,7 @@ export async function runCampaignSchedulerTick() {
             { err, campaignId: campaign.id },
             "Failed to enqueue campaign batch",
           );
+          throw err;
         }),
       );
     }

--- a/apps/web/src/server/jobs/campaign-scheduler-job.unit.test.ts
+++ b/apps/web/src/server/jobs/campaign-scheduler-job.unit.test.ts
@@ -2,6 +2,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   findMany: vi.fn(),
+  loggerDebug: vi.fn(),
+  loggerError: vi.fn(),
+  loggerInfo: vi.fn(),
   queueBatch: vi.fn(),
   queueAdd: vi.fn(),
 }));
@@ -32,9 +35,9 @@ vi.mock("~/server/redis", () => ({
 
 vi.mock("~/server/logger/log", () => ({
   logger: {
-    debug: vi.fn(),
-    error: vi.fn(),
-    info: vi.fn(),
+    debug: mocks.loggerDebug,
+    error: mocks.loggerError,
+    info: mocks.loggerInfo,
   },
 }));
 
@@ -49,6 +52,9 @@ import { runCampaignSchedulerTick } from "~/server/jobs/campaign-scheduler-job";
 describe("campaign scheduler", () => {
   beforeEach(() => {
     mocks.findMany.mockReset();
+    mocks.loggerDebug.mockReset();
+    mocks.loggerError.mockReset();
+    mocks.loggerInfo.mockReset();
     mocks.queueBatch.mockReset();
     mocks.queueAdd.mockReset();
     vi.useFakeTimers();
@@ -102,5 +108,37 @@ describe("campaign scheduler", () => {
       campaignId: "campaign_1",
       teamId: 7,
     });
+  });
+
+  it("reports rejected campaign enqueues in the scheduler summary", async () => {
+    const enqueueError = new Error("Redis unavailable");
+    mocks.findMany.mockResolvedValue([
+      {
+        id: "campaign_1",
+        teamId: 7,
+        lastSentAt: null,
+        batchWindowMinutes: 0,
+      },
+      {
+        id: "campaign_2",
+        teamId: 8,
+        lastSentAt: null,
+        batchWindowMinutes: 0,
+      },
+    ]);
+    mocks.queueBatch
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(enqueueError);
+
+    await runCampaignSchedulerTick();
+
+    expect(mocks.loggerError).toHaveBeenCalledWith(
+      { err: enqueueError, campaignId: "campaign_2" },
+      "Failed to enqueue campaign batch",
+    );
+    expect(mocks.loggerDebug).toHaveBeenCalledWith(
+      { total: 2, fulfilled: 1, rejected: 1 },
+      "Scheduler enqueue summary",
+    );
   });
 });

--- a/apps/web/src/server/jobs/campaign-scheduler-job.unit.test.ts
+++ b/apps/web/src/server/jobs/campaign-scheduler-job.unit.test.ts
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  findMany: vi.fn(),
+  queueBatch: vi.fn(),
+  queueAdd: vi.fn(),
+}));
+
+vi.mock("bullmq", () => ({
+  Queue: class {
+    add = mocks.queueAdd;
+  },
+  Worker: class {},
+}));
+
+vi.mock("~/server/queue/bullmq-context", () => ({
+  createWorkerHandler: vi.fn((handler) => handler),
+}));
+
+vi.mock("~/server/db", () => ({
+  db: {
+    campaign: {
+      findMany: mocks.findMany,
+    },
+  },
+}));
+
+vi.mock("~/server/redis", () => ({
+  BULL_PREFIX: "bull",
+  getRedis: vi.fn(() => ({})),
+}));
+
+vi.mock("~/server/logger/log", () => ({
+  logger: {
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
+vi.mock("~/server/service/campaign-service", () => ({
+  CampaignBatchService: {
+    queueBatch: mocks.queueBatch,
+  },
+}));
+
+import { runCampaignSchedulerTick } from "~/server/jobs/campaign-scheduler-job";
+
+describe("campaign scheduler", () => {
+  beforeEach(() => {
+    mocks.findMany.mockReset();
+    mocks.queueBatch.mockReset();
+    mocks.queueAdd.mockReset();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-21T09:00:00.000Z"));
+    mocks.findMany.mockResolvedValue([]);
+  });
+
+  it("selects only campaigns whose schedule or gradual wave is due", async () => {
+    await runCampaignSchedulerTick();
+
+    const now = new Date("2026-07-21T09:00:00.000Z");
+    expect(mocks.findMany).toHaveBeenCalledWith({
+      where: {
+        status: { in: ["SCHEDULED", "RUNNING"] },
+        AND: [
+          {
+            OR: [{ scheduledAt: null }, { scheduledAt: { lte: now } }],
+          },
+          {
+            OR: [
+              { deliveryMode: "ALL_AT_ONCE" },
+              { nextDeliveryAt: null },
+              { nextDeliveryAt: { lte: now } },
+            ],
+          },
+        ],
+      },
+      select: {
+        id: true,
+        teamId: true,
+        lastSentAt: true,
+        batchWindowMinutes: true,
+      },
+    });
+  });
+
+  it("queues campaigns returned by the due-work query", async () => {
+    mocks.findMany.mockResolvedValue([
+      {
+        id: "campaign_1",
+        teamId: 7,
+        lastSentAt: null,
+        batchWindowMinutes: 0,
+      },
+    ]);
+    mocks.queueBatch.mockResolvedValue(undefined);
+
+    await runCampaignSchedulerTick();
+
+    expect(mocks.queueBatch).toHaveBeenCalledWith({
+      campaignId: "campaign_1",
+      teamId: 7,
+    });
+  });
+});

--- a/apps/web/src/server/public-api/api/campaigns/campaign-delivery.ts
+++ b/apps/web/src/server/public-api/api/campaigns/campaign-delivery.ts
@@ -1,0 +1,20 @@
+import type { CampaignScheduleInput } from "~/server/public-api/schemas/campaign-schema";
+import type { CampaignDeliveryInput as ServiceCampaignDeliveryInput } from "~/server/service/campaign-service";
+
+export function toServiceDelivery(
+  delivery: CampaignScheduleInput["delivery"],
+): ServiceCampaignDeliveryInput | undefined {
+  if (!delivery) {
+    return undefined;
+  }
+
+  if (delivery.strategy === "all_at_once") {
+    return { strategy: "ALL_AT_ONCE" };
+  }
+
+  return {
+    strategy: "GRADUAL",
+    batchPercentage: delivery.batchPercentage,
+    interval: delivery.interval,
+  };
+}

--- a/apps/web/src/server/public-api/api/campaigns/campaign-delivery.unit.test.ts
+++ b/apps/web/src/server/public-api/api/campaigns/campaign-delivery.unit.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { toServiceDelivery } from "~/server/public-api/api/campaigns/campaign-delivery";
+
+describe("toServiceDelivery", () => {
+  it("maps public delivery strategies to service inputs", () => {
+    expect(toServiceDelivery(undefined)).toBeUndefined();
+    expect(toServiceDelivery({ strategy: "all_at_once" })).toEqual({
+      strategy: "ALL_AT_ONCE",
+    });
+    expect(
+      toServiceDelivery({
+        strategy: "gradual",
+        batchPercentage: 10,
+        interval: "hour",
+      }),
+    ).toEqual({
+      strategy: "GRADUAL",
+      batchPercentage: 10,
+      interval: "hour",
+    });
+  });
+});

--- a/apps/web/src/server/public-api/api/campaigns/create-campaign.ts
+++ b/apps/web/src/server/public-api/api/campaigns/create-campaign.ts
@@ -11,6 +11,7 @@ import {
   getCampaignForTeam,
   scheduleCampaign,
 } from "~/server/service/campaign-service";
+import { toServiceDelivery } from "./campaign-delivery";
 const route = createRoute({
   method: "post",
   path: "/v1/campaigns",
@@ -55,15 +56,7 @@ function createCampaign(app: PublicAPIApp) {
       cc: body.cc,
       bcc: body.bcc,
       batchSize: body.batchSize,
-      delivery: body.delivery
-        ? body.delivery.strategy === "gradual"
-          ? {
-              strategy: "GRADUAL",
-              batchPercentage: body.delivery.batchPercentage,
-              interval: body.delivery.interval,
-            }
-          : { strategy: "ALL_AT_ONCE" }
-        : undefined,
+      delivery: toServiceDelivery(body.delivery),
     });
 
     if (body.sendNow || body.scheduledAt) {
@@ -76,15 +69,7 @@ function createCampaign(app: PublicAPIApp) {
         teamId: team.id,
         scheduledAt: scheduledAtInput,
         batchSize: body.batchSize,
-        delivery: body.delivery
-          ? body.delivery.strategy === "gradual"
-            ? {
-                strategy: "GRADUAL",
-                batchPercentage: body.delivery.batchPercentage,
-                interval: body.delivery.interval,
-              }
-            : { strategy: "ALL_AT_ONCE" }
-          : undefined,
+        delivery: toServiceDelivery(body.delivery),
       });
     }
 

--- a/apps/web/src/server/public-api/api/campaigns/create-campaign.ts
+++ b/apps/web/src/server/public-api/api/campaigns/create-campaign.ts
@@ -55,6 +55,15 @@ function createCampaign(app: PublicAPIApp) {
       cc: body.cc,
       bcc: body.bcc,
       batchSize: body.batchSize,
+      delivery: body.delivery
+        ? body.delivery.strategy === "gradual"
+          ? {
+              strategy: "GRADUAL",
+              batchPercentage: body.delivery.batchPercentage,
+              interval: body.delivery.interval,
+            }
+          : { strategy: "ALL_AT_ONCE" }
+        : undefined,
     });
 
     if (body.sendNow || body.scheduledAt) {
@@ -67,6 +76,15 @@ function createCampaign(app: PublicAPIApp) {
         teamId: team.id,
         scheduledAt: scheduledAtInput,
         batchSize: body.batchSize,
+        delivery: body.delivery
+          ? body.delivery.strategy === "gradual"
+            ? {
+                strategy: "GRADUAL",
+                batchPercentage: body.delivery.batchPercentage,
+                interval: body.delivery.interval,
+              }
+            : { strategy: "ALL_AT_ONCE" }
+          : undefined,
       });
     }
 

--- a/apps/web/src/server/public-api/api/campaigns/create-campaign.ts
+++ b/apps/web/src/server/public-api/api/campaigns/create-campaign.ts
@@ -1,4 +1,4 @@
-import { createRoute, z } from "@hono/zod-openapi";
+import { createRoute } from "@hono/zod-openapi";
 import { PublicAPIApp } from "~/server/public-api/hono";
 import {
   campaignCreateSchema,

--- a/apps/web/src/server/public-api/api/campaigns/schedule-campaign.ts
+++ b/apps/web/src/server/public-api/api/campaigns/schedule-campaign.ts
@@ -6,6 +6,7 @@ import {
   parseScheduledAt,
 } from "~/server/public-api/schemas/campaign-schema";
 import { scheduleCampaign as scheduleCampaignService } from "~/server/service/campaign-service";
+import { toServiceDelivery } from "./campaign-delivery";
 const route = createRoute({
   method: "post",
   path: "/v1/campaigns/{campaignId}/schedule",
@@ -56,15 +57,7 @@ function scheduleCampaign(app: PublicAPIApp) {
       teamId: team.id,
       scheduledAt: parseScheduledAt(body.scheduledAt),
       batchSize: body.batchSize,
-      delivery: body.delivery
-        ? body.delivery.strategy === "gradual"
-          ? {
-              strategy: "GRADUAL",
-              batchPercentage: body.delivery.batchPercentage,
-              interval: body.delivery.interval,
-            }
-          : { strategy: "ALL_AT_ONCE" }
-        : undefined,
+      delivery: toServiceDelivery(body.delivery),
     });
 
     return c.json({ success: true });

--- a/apps/web/src/server/public-api/api/campaigns/schedule-campaign.ts
+++ b/apps/web/src/server/public-api/api/campaigns/schedule-campaign.ts
@@ -5,9 +5,7 @@ import {
   CampaignScheduleInput,
   parseScheduledAt,
 } from "~/server/public-api/schemas/campaign-schema";
-import {
-  scheduleCampaign as scheduleCampaignService,
-} from "~/server/service/campaign-service";
+import { scheduleCampaign as scheduleCampaignService } from "~/server/service/campaign-service";
 const route = createRoute({
   method: "post",
   path: "/v1/campaigns/{campaignId}/schedule",
@@ -58,6 +56,15 @@ function scheduleCampaign(app: PublicAPIApp) {
       teamId: team.id,
       scheduledAt: parseScheduledAt(body.scheduledAt),
       batchSize: body.batchSize,
+      delivery: body.delivery
+        ? body.delivery.strategy === "gradual"
+          ? {
+              strategy: "GRADUAL",
+              batchPercentage: body.delivery.batchPercentage,
+              interval: body.delivery.interval,
+            }
+          : { strategy: "ALL_AT_ONCE" }
+        : undefined,
     });
 
     return c.json({ success: true });

--- a/apps/web/src/server/public-api/schemas/campaign-schema.ts
+++ b/apps/web/src/server/public-api/schemas/campaign-schema.ts
@@ -7,6 +7,15 @@ const stringOrStringArray = z.union([
   z.array(z.string().min(1)),
 ]);
 
+export const campaignDeliverySchema = z.discriminatedUnion("strategy", [
+  z.object({ strategy: z.literal("all_at_once") }),
+  z.object({
+    strategy: z.literal("gradual"),
+    batchPercentage: z.number().int().min(1).max(50),
+    interval: z.enum(["minute", "hour"]),
+  }),
+]);
+
 export const parseScheduledAt = (scheduledAt?: string): Date | undefined => {
   if (!scheduledAt) return undefined;
 
@@ -45,13 +54,14 @@ export const campaignCreateSchema = z
       .string()
       .optional()
       .describe(
-        "Timestamp in ISO 8601 format or natural language (e.g., 'tomorrow 9am', 'next monday 10:30')"
+        "Timestamp in ISO 8601 format or natural language (e.g., 'tomorrow 9am', 'next monday 10:30')",
       ),
     batchSize: z.number().int().min(1).max(100_000).optional(),
+    delivery: campaignDeliverySchema.optional(),
   })
   .refine(
     (data) => !!data.content || !!data.html,
-    "Either content or html must be provided."
+    "Either content or html must be provided.",
   );
 
 export const campaignScheduleSchema = z.object({
@@ -59,9 +69,10 @@ export const campaignScheduleSchema = z.object({
     .string()
     .optional()
     .describe(
-      "Timestamp in ISO 8601 format or natural language (e.g., 'tomorrow 9am', 'next monday 10:30')"
+      "Timestamp in ISO 8601 format or natural language (e.g., 'tomorrow 9am', 'next monday 10:30')",
     ),
   batchSize: z.number().int().min(1).max(100_000).optional(),
+  delivery: campaignDeliverySchema.optional(),
 });
 
 export type CampaignCreateInput = z.infer<typeof campaignCreateSchema>;
@@ -80,6 +91,13 @@ export const campaignResponseSchema = z.object({
   scheduledAt: z.string().datetime().nullable(),
   batchSize: z.number().int(),
   batchWindowMinutes: z.number().int(),
+  deliveryMode: z.enum(["ALL_AT_ONCE", "GRADUAL"]),
+  deliveryBatchPercentage: z.number().int().nullable(),
+  deliveryIntervalMinutes: z.number().int().nullable(),
+  deliveryBatchSize: z.number().int().nullable(),
+  currentDeliveryBatch: z.number().int(),
+  deliveryBatchProcessed: z.number().int(),
+  nextDeliveryAt: z.string().datetime().nullable(),
   total: z.number().int(),
   sent: z.number().int(),
   delivered: z.number().int(),

--- a/apps/web/src/server/public-api/schemas/campaign-schema.ts
+++ b/apps/web/src/server/public-api/schemas/campaign-schema.ts
@@ -8,7 +8,7 @@ const stringOrStringArray = z.union([
 ]);
 
 export const campaignDeliverySchema = z.discriminatedUnion("strategy", [
-  z.object({ strategy: z.literal("all_at_once") }),
+  z.object({ strategy: z.literal("all_at_once") }).strict(),
   z.object({
     strategy: z.literal("gradual"),
     batchPercentage: z.number().int().min(1).max(50),

--- a/apps/web/src/server/public-api/schemas/campaign-schema.unit.test.ts
+++ b/apps/web/src/server/public-api/schemas/campaign-schema.unit.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import {
+  campaignCreateSchema,
+  campaignScheduleSchema,
+} from "~/server/public-api/schemas/campaign-schema";
+
+describe("campaign delivery API schemas", () => {
+  it("accepts gradual delivery when creating a campaign", () => {
+    const result = campaignCreateSchema.safeParse({
+      name: "Product launch",
+      from: "hello@example.com",
+      subject: "We are live",
+      contactBookId: "book_1",
+      html: "<p>Hello</p>",
+      delivery: {
+        strategy: "gradual",
+        batchPercentage: 10,
+        interval: "hour",
+      },
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it.each([0, 51, 10.5])(
+    "rejects an invalid gradual percentage of %s",
+    (batchPercentage) => {
+      const result = campaignScheduleSchema.safeParse({
+        delivery: {
+          strategy: "gradual",
+          batchPercentage,
+          interval: "minute",
+        },
+      });
+
+      expect(result.success).toBe(false);
+    },
+  );
+
+  it("accepts the all-at-once delivery strategy", () => {
+    const result = campaignScheduleSchema.safeParse({
+      delivery: { strategy: "all_at_once" },
+    });
+
+    expect(result.success).toBe(true);
+  });
+});

--- a/apps/web/src/server/public-api/schemas/campaign-schema.unit.test.ts
+++ b/apps/web/src/server/public-api/schemas/campaign-schema.unit.test.ts
@@ -44,4 +44,16 @@ describe("campaign delivery API schemas", () => {
 
     expect(result.success).toBe(true);
   });
+
+  it("rejects gradual-only fields for all-at-once delivery", () => {
+    const result = campaignScheduleSchema.safeParse({
+      delivery: {
+        strategy: "all_at_once",
+        batchPercentage: 10,
+        interval: "hour",
+      },
+    });
+
+    expect(result.success).toBe(false);
+  });
 });

--- a/apps/web/src/server/service/campaign-service.ts
+++ b/apps/web/src/server/service/campaign-service.ts
@@ -31,6 +31,22 @@ import {
 } from "../utils/contact-variable-replacement";
 import { updateContactSubscription } from "./contact-service";
 import { getCampaignUnsubscribeVariableValues } from "~/lib/constants/campaign";
+import {
+  calculateGradualDelivery,
+  GRADUAL_DELIVERY_INTERVAL_MINUTES,
+} from "~/lib/campaign-delivery";
+import type { GradualDeliveryInterval } from "~/lib/campaign-delivery";
+
+const CAMPAIGN_AUDIENCE_SNAPSHOT_CHUNK_SIZE = 5_000;
+const GRADUAL_DELIVERY_INTERNAL_BATCH_SIZE = 500;
+
+export type CampaignDeliveryInput =
+  | { strategy: "ALL_AT_ONCE" }
+  | {
+      strategy: "GRADUAL";
+      batchPercentage: number;
+      interval: GradualDeliveryInterval;
+    };
 
 const CAMPAIGN_UNSUB_PLACEHOLDER_TOKENS = [
   "{{unsend_unsubscribe_url}}",
@@ -67,6 +83,40 @@ function sanitizeAddressList(addresses?: string | string[]) {
   return list
     .map((address) => address.trim())
     .filter((address) => address.length > 0);
+}
+
+function getCampaignDeliveryData({
+  delivery,
+  audienceSize,
+  startsAt,
+}: {
+  delivery?: CampaignDeliveryInput;
+  audienceSize: number;
+  startsAt: Date;
+}) {
+  if (!delivery || delivery.strategy === "ALL_AT_ONCE") {
+    return {
+      deliveryMode: "ALL_AT_ONCE" as const,
+      deliveryBatchPercentage: null,
+      deliveryIntervalMinutes: null,
+      deliveryBatchSize: null,
+    };
+  }
+
+  const intervalMinutes = GRADUAL_DELIVERY_INTERVAL_MINUTES[delivery.interval];
+  const estimate = calculateGradualDelivery({
+    audienceSize,
+    batchPercentage: delivery.batchPercentage,
+    intervalMinutes,
+    startsAt,
+  });
+
+  return {
+    deliveryMode: "GRADUAL" as const,
+    deliveryBatchPercentage: delivery.batchPercentage,
+    deliveryIntervalMinutes: intervalMinutes,
+    deliveryBatchSize: estimate.batchSize,
+  };
 }
 
 async function prepareCampaignHtml(
@@ -305,6 +355,13 @@ export async function getCampaignForTeam({
       scheduledAt: true,
       batchSize: true,
       batchWindowMinutes: true,
+      deliveryMode: true,
+      deliveryBatchPercentage: true,
+      deliveryIntervalMinutes: true,
+      deliveryBatchSize: true,
+      currentDeliveryBatch: true,
+      deliveryBatchProcessed: true,
+      nextDeliveryAt: true,
       total: true,
       sent: true,
       delivered: true,
@@ -390,11 +447,13 @@ export async function scheduleCampaign({
   teamId,
   scheduledAt: scheduledAtInput,
   batchSize,
+  delivery,
 }: {
   campaignId: string;
   teamId: number;
   scheduledAt?: Date | string;
   batchSize?: number;
+  delivery?: CampaignDeliveryInput;
 }) {
   let campaign = await db.campaign.findUnique({
     where: { id: campaignId, teamId },
@@ -403,6 +462,14 @@ export async function scheduleCampaign({
     throw new UnsendApiError({
       code: "NOT_FOUND",
       message: "Campaign not found",
+    });
+  }
+
+  if (campaign.status !== "DRAFT" && campaign.status !== "SCHEDULED") {
+    throw new UnsendApiError({
+      code: "BAD_REQUEST",
+      message:
+        "Delivery settings cannot be changed after a campaign has started",
     });
   }
 
@@ -461,18 +528,36 @@ export async function scheduleCampaign({
       : new Date(scheduledAtInput)
     : new Date();
 
-  const shouldResetCursor =
-    campaign.status === "DRAFT" || campaign.status === "SENT";
+  const shouldResetCursor = campaign.status === "DRAFT";
 
-  await db.campaign.update({
-    where: { id: campaign.id },
-    data: {
-      status: "SCHEDULED",
-      scheduledAt,
-      total,
-      ...(batchSize ? { batchSize } : {}),
-      ...(shouldResetCursor ? { lastCursor: null } : {}),
-    },
+  const deliveryData = getCampaignDeliveryData({
+    delivery,
+    audienceSize: total,
+    startsAt: scheduledAt,
+  });
+
+  await db.$transaction(async (tx) => {
+    await tx.campaignEmail.deleteMany({
+      where: { campaignId: campaign.id },
+    });
+
+    await tx.campaign.update({
+      where: { id: campaign.id },
+      data: {
+        status: "SCHEDULED",
+        scheduledAt,
+        total,
+        ...deliveryData,
+        currentDeliveryBatch: 0,
+        deliveryBatchProcessed: 0,
+        nextDeliveryAt: null,
+        audienceCapturedAt: null,
+        audiencePreparedAt: null,
+        pausedAt: null,
+        ...(batchSize ? { batchSize } : {}),
+        ...(shouldResetCursor ? { lastCursor: null } : {}),
+      },
+    });
   });
 
   return { ok: true };
@@ -498,7 +583,7 @@ export async function pauseCampaign({
 
   await db.campaign.update({
     where: { id: campaignId },
-    data: { status: "PAUSED" },
+    data: { status: "PAUSED", pausedAt: new Date() },
   });
 
   return { ok: true };
@@ -522,15 +607,31 @@ export async function resumeCampaign({
     });
   }
 
-  if (campaign.scheduledAt && campaign.scheduledAt.getTime() > Date.now()) {
+  const now = new Date();
+  const pausedDurationMs = campaign.pausedAt
+    ? Math.max(0, now.getTime() - campaign.pausedAt.getTime())
+    : 0;
+  const shiftedNextDeliveryAt = campaign.nextDeliveryAt
+    ? new Date(campaign.nextDeliveryAt.getTime() + pausedDurationMs)
+    : null;
+
+  if (campaign.scheduledAt && campaign.scheduledAt.getTime() > now.getTime()) {
     await db.campaign.update({
       where: { id: campaignId },
-      data: { status: "SCHEDULED" },
+      data: {
+        status: "SCHEDULED",
+        pausedAt: null,
+        nextDeliveryAt: shiftedNextDeliveryAt,
+      },
     });
   } else {
     await db.campaign.update({
       where: { id: campaignId },
-      data: { status: "RUNNING" },
+      data: {
+        status: "RUNNING",
+        pausedAt: null,
+        nextDeliveryAt: shiftedNextDeliveryAt,
+      },
     });
   }
 
@@ -818,12 +919,37 @@ export async function recordCampaignContactFailure({
         emailId = failedEmail.id;
       }
 
-      await tx.campaignEmail.create({
-        data: {
+      await tx.campaignEmail.upsert({
+        where: {
+          campaignId_contactId: {
+            campaignId: campaign.id,
+            contactId: contact.id,
+          },
+        },
+        create: {
           campaignId: campaign.id,
           contactId: contact.id,
           emailId,
+          status: "FAILED",
+          processedAt: new Date(),
         },
+        update: {
+          emailId,
+          status: "FAILED",
+          processedAt: new Date(),
+        },
+      });
+    }
+
+    if (existingCampaignEmail?.emailId) {
+      await tx.campaignEmail.update({
+        where: {
+          campaignId_contactId: {
+            campaignId: campaign.id,
+            contactId: contact.id,
+          },
+        },
+        data: { status: "FAILED", processedAt: new Date() },
       });
     }
 
@@ -933,11 +1059,24 @@ async function processContactEmail(jobData: CampaignEmailJob) {
       },
     });
 
-    await db.campaignEmail.create({
-      data: {
+    await db.campaignEmail.upsert({
+      where: {
+        campaignId_contactId: {
+          campaignId: emailConfig.campaignId,
+          contactId: contact.id,
+        },
+      },
+      create: {
         campaignId: emailConfig.campaignId,
         contactId: contact.id,
         emailId: email.id,
+        status: "SUPPRESSED",
+        processedAt: new Date(),
+      },
+      update: {
+        emailId: email.id,
+        status: "SUPPRESSED",
+        processedAt: new Date(),
       },
     });
 
@@ -987,11 +1126,24 @@ async function processContactEmail(jobData: CampaignEmailJob) {
     },
   });
 
-  await db.campaignEmail.create({
-    data: {
+  await db.campaignEmail.upsert({
+    where: {
+      campaignId_contactId: {
+        campaignId: emailConfig.campaignId,
+        contactId: contact.id,
+      },
+    },
+    create: {
       campaignId: emailConfig.campaignId,
       contactId: contact.id,
       emailId: email.id,
+      status: "QUEUED",
+      processedAt: new Date(),
+    },
+    update: {
+      emailId: email.id,
+      status: "QUEUED",
+      processedAt: new Date(),
     },
   });
 
@@ -1056,6 +1208,169 @@ export async function updateCampaignAnalytics(
 // Simple campaign batch queue
 // ---------------------------
 
+async function prepareCampaignAudience(campaign: Campaign) {
+  if (campaign.audiencePreparedAt) {
+    return campaign;
+  }
+
+  if (!campaign.contactBookId) {
+    throw new Error("No contact book found for campaign");
+  }
+
+  const capturedAt = campaign.audienceCapturedAt ?? new Date();
+
+  if (!campaign.audienceCapturedAt) {
+    await db.campaign.update({
+      where: { id: campaign.id },
+      data: { audienceCapturedAt: capturedAt },
+    });
+  }
+
+  let cursor: string | undefined;
+
+  while (true) {
+    const contacts = await db.contact.findMany({
+      where: {
+        contactBookId: campaign.contactBookId,
+        subscribed: true,
+        createdAt: { lte: capturedAt },
+      },
+      select: { id: true },
+      orderBy: { id: "asc" },
+      take: CAMPAIGN_AUDIENCE_SNAPSHOT_CHUNK_SIZE,
+      ...(cursor ? { cursor: { id: cursor }, skip: 1 } : {}),
+    });
+
+    if (contacts.length === 0) {
+      break;
+    }
+
+    await db.campaignEmail.createMany({
+      data: contacts.map((contact) => ({
+        campaignId: campaign.id,
+        contactId: contact.id,
+        status: "PENDING" as const,
+      })),
+      skipDuplicates: true,
+    });
+
+    cursor = contacts[contacts.length - 1]?.id;
+
+    if (contacts.length < CAMPAIGN_AUDIENCE_SNAPSHOT_CHUNK_SIZE) {
+      break;
+    }
+  }
+
+  const total = await db.campaignEmail.count({
+    where: { campaignId: campaign.id },
+  });
+
+  const deliveryBatchSize =
+    campaign.deliveryMode === "GRADUAL"
+      ? calculateGradualDelivery({
+          audienceSize: total,
+          batchPercentage: campaign.deliveryBatchPercentage ?? 0,
+          intervalMinutes: campaign.deliveryIntervalMinutes ?? 0,
+          startsAt: campaign.scheduledAt ?? new Date(),
+        }).batchSize
+      : null;
+
+  return db.campaign.update({
+    where: { id: campaign.id },
+    data: {
+      total,
+      audienceCapturedAt: capturedAt,
+      audiencePreparedAt: new Date(),
+      deliveryBatchSize,
+    },
+  });
+}
+
+function getGradualDeliveryWaveSize(campaign: Campaign) {
+  if (
+    campaign.deliveryMode !== "GRADUAL" ||
+    !campaign.deliveryBatchSize ||
+    campaign.currentDeliveryBatch <= 0
+  ) {
+    return 0;
+  }
+
+  const previouslyReleased =
+    (campaign.currentDeliveryBatch - 1) * campaign.deliveryBatchSize;
+
+  return Math.max(
+    0,
+    Math.min(campaign.deliveryBatchSize, campaign.total - previouslyReleased),
+  );
+}
+
+async function getCampaignProcessingLimit(campaign: Campaign) {
+  if (campaign.deliveryMode !== "GRADUAL") {
+    return { campaign, take: campaign.batchSize ?? 500 };
+  }
+
+  if (!campaign.deliveryBatchSize || !campaign.deliveryIntervalMinutes) {
+    throw new Error("Gradual delivery configuration is incomplete");
+  }
+
+  const deliveryBatchSize = campaign.deliveryBatchSize;
+  const deliveryIntervalMinutes = campaign.deliveryIntervalMinutes;
+
+  let currentCampaign = campaign;
+  let currentWaveSize = getGradualDeliveryWaveSize(currentCampaign);
+
+  if (currentCampaign.currentDeliveryBatch === 0) {
+    currentCampaign = await db.campaign.update({
+      where: { id: currentCampaign.id },
+      data: {
+        currentDeliveryBatch: 1,
+        deliveryBatchProcessed: 0,
+        nextDeliveryAt: new Date(
+          Date.now() + deliveryIntervalMinutes * 60 * 1000,
+        ),
+      },
+    });
+    currentWaveSize = getGradualDeliveryWaveSize(currentCampaign);
+  } else if (currentCampaign.deliveryBatchProcessed >= currentWaveSize) {
+    const allWavesReleased =
+      currentCampaign.currentDeliveryBatch * deliveryBatchSize >=
+      currentCampaign.total;
+
+    if (allWavesReleased) {
+      return { campaign: currentCampaign, take: 0 };
+    }
+
+    if (
+      currentCampaign.nextDeliveryAt &&
+      currentCampaign.nextDeliveryAt.getTime() > Date.now()
+    ) {
+      return { campaign: currentCampaign, take: 0 };
+    }
+
+    currentCampaign = await db.campaign.update({
+      where: { id: currentCampaign.id },
+      data: {
+        currentDeliveryBatch: { increment: 1 },
+        deliveryBatchProcessed: 0,
+        nextDeliveryAt: new Date(
+          Date.now() + deliveryIntervalMinutes * 60 * 1000,
+        ),
+      },
+    });
+    currentWaveSize = getGradualDeliveryWaveSize(currentCampaign);
+  }
+
+  const remainingInWave = Math.max(
+    0,
+    currentWaveSize - currentCampaign.deliveryBatchProcessed,
+  );
+
+  return {
+    campaign: currentCampaign,
+    take: Math.min(GRADUAL_DELIVERY_INTERNAL_BATCH_SIZE, remainingInWave),
+  };
+}
+
 type CampaignBatchJob = TeamJob<{ campaignId: string }>;
 
 export class CampaignBatchService {
@@ -1073,11 +1388,12 @@ export class CampaignBatchService {
     createWorkerHandler(async (job: CampaignBatchJob) => {
       const { campaignId } = job.data;
 
-      const campaign = await db.campaign.findUnique({
+      let campaign = await db.campaign.findUnique({
         where: { id: campaignId },
       });
       if (!campaign) return;
       if (!campaign.contactBookId) return;
+      const contactBookId = campaign.contactBookId;
 
       // Skip paused campaigns
       if (campaign.status === "PAUSED") return;
@@ -1088,31 +1404,65 @@ export class CampaignBatchService {
 
       // First touch moves SCHEDULED -> RUNNING
       if (campaign.status === "SCHEDULED") {
-        await db.campaign.update({
+        campaign = await db.campaign.update({
           where: { id: campaignId },
           data: { status: "RUNNING" },
         });
       }
 
-      const batchSize = campaign.batchSize ?? 500;
+      campaign = await prepareCampaignAudience(campaign);
 
-      const where = {
-        contactBookId: campaign.contactBookId,
-        subscribed: true,
-      } as const;
-      const pagination: any = {
-        take: batchSize,
-        orderBy: { id: "asc" as const },
-      };
-      if (campaign.lastCursor) {
-        pagination.cursor = { id: campaign.lastCursor };
-        pagination.skip = 1; // do not include the cursor row
+      if (campaign.total === 0) {
+        await db.campaign.update({
+          where: { id: campaignId },
+          data: { status: "SENT" },
+        });
+        return;
       }
 
-      const contacts = await db.contact.findMany({ where, ...pagination });
+      const processingLimit = await getCampaignProcessingLimit(campaign);
+      campaign = processingLimit.campaign;
+
+      if (processingLimit.take === 0) {
+        const pendingRecipients = await db.campaignEmail.count({
+          where: { campaignId, status: "PENDING" },
+        });
+
+        if (pendingRecipients === 0) {
+          await db.campaign.update({
+            where: { id: campaignId },
+            data: { status: "SENT", nextDeliveryAt: null },
+          });
+        }
+        return;
+      }
+
+      const recipients = await db.campaignEmail.findMany({
+        where: { campaignId, status: "PENDING" },
+        select: { contactId: true },
+        orderBy: { contactId: "asc" },
+        take: processingLimit.take,
+      });
+
+      if (recipients.length === 0) {
+        await db.campaign.update({
+          where: { id: campaignId },
+          data: { status: "SENT", nextDeliveryAt: null },
+        });
+        return;
+      }
+
+      const contacts = await db.contact.findMany({
+        where: {
+          id: { in: recipients.map((recipient) => recipient.contactId) },
+        },
+      });
+      const contactsById = new Map(
+        contacts.map((contact) => [contact.id, contact]),
+      );
 
       const contactBook = await db.contactBook.findUnique({
-        where: { id: campaign.contactBookId },
+        where: { id: contactBookId },
         select: { variables: true },
       });
 
@@ -1121,34 +1471,31 @@ export class CampaignBatchService {
         ...(contactBook?.variables ?? []),
       ];
 
-      if (contacts.length === 0) {
-        // No more contacts -> mark SENT
-        await db.campaign.update({
-          where: { id: campaignId },
-          data: { status: "SENT" },
-        });
-        return;
-      }
-
       // Fetch domain for region and id
       const domain = await db.domain.findUnique({
         where: { id: campaign.domainId },
       });
       if (!domain) return;
 
-      // Bulk existence check to avoid duplicates while unique is not enforced
-      const existing = await db.campaignEmail.findMany({
-        where: {
-          campaignId: campaign.id,
-          contactId: { in: contacts.map((c) => c.id) },
-        },
-        select: { contactId: true },
-      });
-      const existingSet = new Set(existing.map((e) => e.contactId));
-
       // Process each contact in this batch
-      for (const contact of contacts) {
-        if (existingSet.has(contact.id)) continue;
+      let processedRecipientCount = 0;
+
+      for (const recipient of recipients) {
+        const contact = contactsById.get(recipient.contactId);
+
+        if (!contact || !contact.subscribed) {
+          await db.campaignEmail.update({
+            where: {
+              campaignId_contactId: {
+                campaignId,
+                contactId: recipient.contactId,
+              },
+            },
+            data: { status: "SKIPPED", processedAt: new Date() },
+          });
+          processedRecipientCount += 1;
+          continue;
+        }
 
         try {
           await processContactEmail({
@@ -1188,21 +1535,43 @@ export class CampaignBatchService {
               },
               error: err,
             });
+            processedRecipientCount += 1;
           } catch (recordErr) {
             logger.error(
               { err: recordErr, contactId: contact.id, campaignId },
               "Failed to record campaign contact failure; skipping to next",
             );
           }
+          continue;
         }
+
+        processedRecipientCount += 1;
       }
 
-      // Advance cursor and timestamp
-      const newCursor = contacts[contacts.length - 1]?.id;
       await db.campaign.update({
         where: { id: campaignId },
-        data: { lastCursor: newCursor, lastSentAt: new Date() },
+        data: {
+          lastSentAt: new Date(),
+          ...(campaign.deliveryMode === "GRADUAL"
+            ? {
+                deliveryBatchProcessed: {
+                  increment: processedRecipientCount,
+                },
+              }
+            : {}),
+        },
       });
+
+      const pendingRecipients = await db.campaignEmail.count({
+        where: { campaignId, status: "PENDING" },
+      });
+
+      if (pendingRecipients === 0) {
+        await db.campaign.update({
+          where: { id: campaignId },
+          data: { status: "SENT", nextDeliveryAt: null },
+        });
+      }
     }),
     {
       connection: getRedis(),
@@ -1223,10 +1592,47 @@ export class CampaignBatchService {
     try {
       const campaign = await db.campaign.findUnique({
         where: { id: campaignId },
-        select: { lastSentAt: true, batchWindowMinutes: true, status: true },
+        select: {
+          lastSentAt: true,
+          batchWindowMinutes: true,
+          status: true,
+          total: true,
+          deliveryMode: true,
+          deliveryBatchSize: true,
+          currentDeliveryBatch: true,
+          deliveryBatchProcessed: true,
+          nextDeliveryAt: true,
+        },
       });
       if (!campaign) return;
       if (campaign.status === "PAUSED" || campaign.status === "SENT") return;
+
+      if (
+        campaign.deliveryMode === "GRADUAL" &&
+        campaign.deliveryBatchSize &&
+        campaign.currentDeliveryBatch > 0
+      ) {
+        const previouslyReleased =
+          (campaign.currentDeliveryBatch - 1) * campaign.deliveryBatchSize;
+        const currentWaveSize = Math.max(
+          0,
+          Math.min(
+            campaign.deliveryBatchSize,
+            campaign.total - previouslyReleased,
+          ),
+        );
+        const currentWaveComplete =
+          campaign.deliveryBatchProcessed >= currentWaveSize;
+
+        if (
+          currentWaveComplete &&
+          campaign.nextDeliveryAt &&
+          campaign.nextDeliveryAt.getTime() > Date.now()
+        ) {
+          return;
+        }
+      }
+
       const windowMin = campaign.batchWindowMinutes ?? 0;
       if (windowMin > 0 && campaign.lastSentAt) {
         const elapsedMs = Date.now() - new Date(campaign.lastSentAt).getTime();

--- a/apps/web/src/server/service/campaign-service.ts
+++ b/apps/web/src/server/service/campaign-service.ts
@@ -3,9 +3,11 @@ import { db } from "../db";
 import { createHash } from "crypto";
 import { env } from "~/env";
 import {
-  Campaign,
-  Contact,
+  type Campaign,
+  type Contact,
+  type Email,
   EmailStatus,
+  Prisma,
   UnsubscribeReason,
 } from "@prisma/client";
 import { EmailQueueService } from "./email-queue-service";
@@ -37,8 +39,14 @@ import {
 } from "~/lib/campaign-delivery";
 import type { GradualDeliveryInterval } from "~/lib/campaign-delivery";
 
-const CAMPAIGN_AUDIENCE_SNAPSHOT_CHUNK_SIZE = 5_000;
 const GRADUAL_DELIVERY_INTERNAL_BATCH_SIZE = 500;
+const CAMPAIGN_RECIPIENT_CLAIM_TIMEOUT_MS = 60 * 60 * 1000;
+const CAMPAIGN_AUDIENCE_PREPARATION_TIMEOUT_MS = 30 * 60 * 1000;
+
+type ClaimedCampaignRecipient = {
+  contactId: string;
+  claimProcessedAt: Date;
+};
 
 export type CampaignDeliveryInput =
   | { strategy: "ALL_AT_ONCE" }
@@ -47,6 +55,24 @@ export type CampaignDeliveryInput =
       batchPercentage: number;
       interval: GradualDeliveryInterval;
     };
+
+function assertCampaignCanBeScheduled(status: Campaign["status"]) {
+  if (status === "SENT") {
+    throw new UnsendApiError({
+      code: "BAD_REQUEST",
+      message:
+        "Completed campaigns cannot be scheduled again. Duplicate the campaign to send it again",
+    });
+  }
+
+  if (status !== "DRAFT" && status !== "SCHEDULED") {
+    throw new UnsendApiError({
+      code: "BAD_REQUEST",
+      message:
+        "Delivery settings cannot be changed after a campaign has started",
+    });
+  }
+}
 
 const CAMPAIGN_UNSUB_PLACEHOLDER_TOKENS = [
   "{{unsend_unsubscribe_url}}",
@@ -510,13 +536,7 @@ export async function scheduleCampaign({
     });
   }
 
-  if (campaign.status !== "DRAFT" && campaign.status !== "SCHEDULED") {
-    throw new UnsendApiError({
-      code: "BAD_REQUEST",
-      message:
-        "Delivery settings cannot be changed after a campaign has started",
-    });
-  }
+  assertCampaignCanBeScheduled(campaign.status);
 
   let html: string;
   try {
@@ -582,6 +602,25 @@ export async function scheduleCampaign({
   });
 
   await db.$transaction(async (tx) => {
+    const lockedCampaign = await tx.$queryRaw<
+      Array<{ status: Campaign["status"] }>
+    >`
+      SELECT "status"
+      FROM "Campaign"
+      WHERE "id" = ${campaign.id}
+        AND "teamId" = ${teamId}
+      FOR UPDATE
+    `;
+
+    if (lockedCampaign.length === 0) {
+      throw new UnsendApiError({
+        code: "NOT_FOUND",
+        message: "Campaign not found",
+      });
+    }
+
+    assertCampaignCanBeScheduled(lockedCampaign[0]!.status);
+
     await tx.campaignEmail.deleteMany({
       where: { campaignId: campaign.id },
     });
@@ -626,8 +665,16 @@ export async function pauseCampaign({
     });
   }
 
-  await db.campaign.update({
-    where: { id: campaignId },
+  if (campaign.status === "PAUSED") {
+    return { ok: true };
+  }
+
+  await db.campaign.updateMany({
+    where: {
+      id: campaignId,
+      teamId,
+      status: campaign.status,
+    },
     data: { status: "PAUSED", pausedAt: new Date() },
   });
 
@@ -873,6 +920,7 @@ export async function deleteCampaign(id: string, teamId: number) {
 type CampaignEmailJob = {
   contact: Contact;
   campaign: Campaign;
+  claimProcessedAt: Date;
   allowedVariables: string[];
   emailConfig: {
     from: string;
@@ -891,6 +939,7 @@ type CampaignEmailJob = {
 type CampaignContactFailureInput = {
   contact: Pick<Contact, "id" | "email">;
   campaign: Pick<Campaign, "id" | "from" | "subject" | "html" | "previewText">;
+  claimProcessedAt?: Date;
   emailConfig: {
     replyTo?: string[];
     cc?: string[];
@@ -912,6 +961,7 @@ function getFailureMessage(error: unknown) {
 export async function recordCampaignContactFailure({
   contact,
   campaign,
+  claimProcessedAt,
   emailConfig,
   error,
 }: CampaignContactFailureInput) {
@@ -925,20 +975,31 @@ export async function recordCampaignContactFailure({
           contactId: contact.id,
         },
       },
-      select: { emailId: true },
+      select: { emailId: true, status: true, processedAt: true },
     });
+
+    if (
+      claimProcessedAt &&
+      (existingCampaignEmail?.status !== "PROCESSING" ||
+        existingCampaignEmail.processedAt?.getTime() !==
+          claimProcessedAt.getTime())
+    ) {
+      return;
+    }
 
     let emailId = existingCampaignEmail?.emailId;
 
     if (!emailId) {
-      const existingEmail = await tx.email.findFirst({
-        where: {
-          campaignId: campaign.id,
-          contactId: contact.id,
-        },
-        orderBy: { createdAt: "desc" },
-        select: { id: true },
-      });
+      const existingEmail = claimProcessedAt
+        ? null
+        : await tx.email.findFirst({
+            where: {
+              campaignId: campaign.id,
+              contactId: contact.id,
+            },
+            orderBy: { createdAt: "desc" },
+            select: { id: true },
+          });
 
       if (existingEmail) {
         emailId = existingEmail.id;
@@ -964,38 +1025,70 @@ export async function recordCampaignContactFailure({
         emailId = failedEmail.id;
       }
 
-      await tx.campaignEmail.upsert({
-        where: {
-          campaignId_contactId: {
+      if (claimProcessedAt) {
+        const updatedRecipient = await tx.campaignEmail.updateMany({
+          where: {
             campaignId: campaign.id,
             contactId: contact.id,
+            status: "PROCESSING",
+            processedAt: claimProcessedAt,
           },
-        },
-        create: {
-          campaignId: campaign.id,
-          contactId: contact.id,
-          emailId,
-          status: "FAILED",
-          processedAt: new Date(),
-        },
-        update: {
-          emailId,
-          status: "FAILED",
-          processedAt: new Date(),
-        },
-      });
+          data: { emailId, status: "FAILED", processedAt: new Date() },
+        });
+
+        if (updatedRecipient.count !== 1) {
+          throw new Error("Campaign recipient claim was lost");
+        }
+      } else {
+        await tx.campaignEmail.upsert({
+          where: {
+            campaignId_contactId: {
+              campaignId: campaign.id,
+              contactId: contact.id,
+            },
+          },
+          create: {
+            campaignId: campaign.id,
+            contactId: contact.id,
+            emailId,
+            status: "FAILED",
+            processedAt: new Date(),
+          },
+          update: {
+            emailId,
+            status: "FAILED",
+            processedAt: new Date(),
+          },
+        });
+      }
     }
 
     if (existingCampaignEmail?.emailId) {
-      await tx.campaignEmail.update({
-        where: {
-          campaignId_contactId: {
+      if (claimProcessedAt) {
+        const updatedRecipient = await tx.campaignEmail.updateMany({
+          where: {
             campaignId: campaign.id,
             contactId: contact.id,
+            status: "PROCESSING",
+            processedAt: claimProcessedAt,
           },
-        },
-        data: { status: "FAILED", processedAt: new Date() },
-      });
+          data: { status: "FAILED", processedAt: new Date() },
+        });
+
+        if (updatedRecipient.count !== 1) {
+          return;
+        }
+      } else {
+        await tx.campaignEmail.update({
+          where: {
+            campaignId_contactId: {
+              campaignId: campaign.id,
+              contactId: contact.id,
+            },
+          },
+          data: { status: "FAILED", processedAt: new Date() },
+        });
+      }
     }
 
     await tx.email.update({
@@ -1014,8 +1107,76 @@ export async function recordCampaignContactFailure({
   });
 }
 
+export async function queueClaimedCampaignEmail({
+  email,
+  campaignId,
+  contactId,
+  claimProcessedAt,
+  teamId,
+  region,
+  oneClickUnsubUrl,
+}: {
+  email: Pick<Email, "id" | "latestStatus" | "sesEmailId">;
+  campaignId: string;
+  contactId: string;
+  claimProcessedAt: Date;
+  teamId: number;
+  region: string;
+  oneClickUnsubUrl: string;
+}) {
+  if (
+    !email.sesEmailId &&
+    (email.latestStatus === "QUEUED" || email.latestStatus === "SCHEDULED")
+  ) {
+    await EmailQueueService.queueEmail(
+      email.id,
+      teamId,
+      region,
+      false,
+      oneClickUnsubUrl,
+    );
+  }
+
+  try {
+    const updatedRecipient = await db.campaignEmail.updateMany({
+      where: {
+        campaignId,
+        contactId,
+        status: "PROCESSING",
+        processedAt: claimProcessedAt,
+        emailId: email.id,
+      },
+      data: {
+        status: email.latestStatus === "FAILED" ? "FAILED" : "QUEUED",
+        processedAt: new Date(),
+      },
+    });
+
+    if (updatedRecipient.count !== 1) {
+      logger.warn(
+        { campaignId, contactId, emailId: email.id },
+        "Campaign email was queued but recipient bookkeeping was deferred",
+      );
+      return { recoveryPending: true };
+    }
+  } catch (error) {
+    // Redis may already contain (or may already have completed) this email job.
+    // Leave the recipient claim recoverable instead of recording a false send
+    // failure. Recovery reuses the same BullMQ job ID and skips emails that
+    // already have an SES message ID.
+    logger.warn(
+      { err: error, campaignId, contactId, emailId: email.id },
+      "Campaign email was queued but recipient bookkeeping failed",
+    );
+    return { recoveryPending: true };
+  }
+
+  return { recoveryPending: false };
+}
+
 async function processContactEmail(jobData: CampaignEmailJob) {
-  const { contact, campaign, emailConfig, allowedVariables } = jobData;
+  const { contact, campaign, claimProcessedAt, emailConfig, allowedVariables } =
+    jobData;
 
   const unsubscribeUrl = createUnsubUrl(contact.id, emailConfig.campaignId);
   const oneClickUnsubUrl = createOneClickUnsubUrl(
@@ -1075,54 +1236,92 @@ async function processContactEmail(jobData: CampaignEmailJob) {
       "Contact email is suppressed. Creating suppressed email record.",
     );
 
-    const email = await db.email.create({
-      data: {
-        to: toEmails,
-        replyTo: emailConfig.replyTo,
-        cc: ccEmails.length > 0 ? ccEmails : undefined,
-        bcc: bccEmails.length > 0 ? bccEmails : undefined,
-        from: emailConfig.from,
-        subject,
-        html,
-        text: emailConfig.previewText,
-        teamId: emailConfig.teamId,
-        campaignId: emailConfig.campaignId,
-        contactId: contact.id,
-        domainId: emailConfig.domainId,
-        latestStatus: "SUPPRESSED",
-      },
-    });
-
-    await db.emailEvent.create({
-      data: {
-        emailId: email.id,
-        status: "SUPPRESSED",
-        data: {
-          error: "Contact email is suppressed. No email sent.",
+    await db.$transaction(async (tx) => {
+      const recipient = await tx.campaignEmail.findUnique({
+        where: {
+          campaignId_contactId: {
+            campaignId: emailConfig.campaignId,
+            contactId: contact.id,
+          },
         },
-        teamId: emailConfig.teamId,
-      },
-    });
+        select: { emailId: true, status: true, processedAt: true },
+      });
 
-    await db.campaignEmail.upsert({
-      where: {
-        campaignId_contactId: {
+      if (
+        recipient?.status !== "PROCESSING" ||
+        recipient.processedAt?.getTime() !== claimProcessedAt.getTime()
+      ) {
+        throw new Error("Campaign recipient claim was lost");
+      }
+
+      let email = recipient.emailId
+        ? await tx.email.findUnique({ where: { id: recipient.emailId } })
+        : null;
+
+      if (!email) {
+        email = await tx.email.create({
+          data: {
+            to: toEmails,
+            replyTo: emailConfig.replyTo,
+            cc: ccEmails.length > 0 ? ccEmails : undefined,
+            bcc: bccEmails.length > 0 ? bccEmails : undefined,
+            from: emailConfig.from,
+            subject,
+            html,
+            text: emailConfig.previewText,
+            teamId: emailConfig.teamId,
+            campaignId: emailConfig.campaignId,
+            contactId: contact.id,
+            domainId: emailConfig.domainId,
+            latestStatus: "SUPPRESSED",
+          },
+        });
+
+        await tx.emailEvent.create({
+          data: {
+            emailId: email.id,
+            status: "SUPPRESSED",
+            data: {
+              error: "Contact email is suppressed. No email sent.",
+            },
+            teamId: emailConfig.teamId,
+          },
+        });
+      } else if (email.latestStatus !== "SUPPRESSED") {
+        email = await tx.email.update({
+          where: { id: email.id },
+          data: { latestStatus: "SUPPRESSED" },
+        });
+
+        await tx.emailEvent.create({
+          data: {
+            emailId: email.id,
+            status: "SUPPRESSED",
+            data: {
+              error: "Contact email is suppressed. No email sent.",
+            },
+            teamId: emailConfig.teamId,
+          },
+        });
+      }
+
+      const updatedRecipient = await tx.campaignEmail.updateMany({
+        where: {
           campaignId: emailConfig.campaignId,
           contactId: contact.id,
+          status: "PROCESSING",
+          processedAt: claimProcessedAt,
         },
-      },
-      create: {
-        campaignId: emailConfig.campaignId,
-        contactId: contact.id,
-        emailId: email.id,
-        status: "SUPPRESSED",
-        processedAt: new Date(),
-      },
-      update: {
-        emailId: email.id,
-        status: "SUPPRESSED",
-        processedAt: new Date(),
-      },
+        data: {
+          emailId: email.id,
+          status: "SUPPRESSED",
+          processedAt: new Date(),
+        },
+      });
+
+      if (updatedRecipient.count !== 1) {
+        throw new Error("Campaign recipient claim was lost");
+      }
     });
 
     return;
@@ -1153,53 +1352,80 @@ async function processContactEmail(jobData: CampaignEmailJob) {
     );
   }
 
-  // Create email with filtered recipients
-  const email = await db.email.create({
-    data: {
-      to: filteredToEmails,
-      replyTo: emailConfig.replyTo,
-      cc: filteredCcEmails.length > 0 ? filteredCcEmails : undefined,
-      bcc: filteredBccEmails.length > 0 ? filteredBccEmails : undefined,
-      from: emailConfig.from,
-      subject,
-      html,
-      text: emailConfig.previewText,
-      teamId: emailConfig.teamId,
-      campaignId: emailConfig.campaignId,
-      contactId: contact.id,
-      domainId: emailConfig.domainId,
-    },
-  });
+  const email = await db.$transaction(async (tx) => {
+    const recipient = await tx.campaignEmail.findUnique({
+      where: {
+        campaignId_contactId: {
+          campaignId: emailConfig.campaignId,
+          contactId: contact.id,
+        },
+      },
+      select: { emailId: true, status: true, processedAt: true },
+    });
 
-  await db.campaignEmail.upsert({
-    where: {
-      campaignId_contactId: {
+    if (
+      recipient?.status !== "PROCESSING" ||
+      recipient.processedAt?.getTime() !== claimProcessedAt.getTime()
+    ) {
+      throw new Error("Campaign recipient claim was lost");
+    }
+
+    if (recipient.emailId) {
+      const existingEmail = await tx.email.findUnique({
+        where: { id: recipient.emailId },
+      });
+
+      if (!existingEmail) {
+        throw new Error("Claimed campaign email was not found");
+      }
+
+      return existingEmail;
+    }
+
+    const createdEmail = await tx.email.create({
+      data: {
+        to: filteredToEmails,
+        replyTo: emailConfig.replyTo,
+        cc: filteredCcEmails.length > 0 ? filteredCcEmails : undefined,
+        bcc: filteredBccEmails.length > 0 ? filteredBccEmails : undefined,
+        from: emailConfig.from,
+        subject,
+        html,
+        text: emailConfig.previewText,
+        teamId: emailConfig.teamId,
         campaignId: emailConfig.campaignId,
         contactId: contact.id,
+        domainId: emailConfig.domainId,
       },
-    },
-    create: {
-      campaignId: emailConfig.campaignId,
-      contactId: contact.id,
-      emailId: email.id,
-      status: "QUEUED",
-      processedAt: new Date(),
-    },
-    update: {
-      emailId: email.id,
-      status: "QUEUED",
-      processedAt: new Date(),
-    },
+    });
+
+    const linkedRecipient = await tx.campaignEmail.updateMany({
+      where: {
+        campaignId: emailConfig.campaignId,
+        contactId: contact.id,
+        status: "PROCESSING",
+        processedAt: claimProcessedAt,
+        emailId: null,
+      },
+      data: { emailId: createdEmail.id },
+    });
+
+    if (linkedRecipient.count !== 1) {
+      throw new Error("Campaign recipient claim was lost");
+    }
+
+    return createdEmail;
   });
 
-  // Queue email for sending
-  await EmailQueueService.queueEmail(
-    email.id,
-    emailConfig.teamId,
-    emailConfig.region,
-    false,
+  await queueClaimedCampaignEmail({
+    email,
+    campaignId: emailConfig.campaignId,
+    contactId: contact.id,
+    claimProcessedAt,
+    teamId: emailConfig.teamId,
+    region: emailConfig.region,
     oneClickUnsubUrl,
-  );
+  });
 }
 
 export async function updateCampaignAnalytics(
@@ -1253,7 +1479,7 @@ export async function updateCampaignAnalytics(
 // Simple campaign batch queue
 // ---------------------------
 
-async function prepareCampaignAudience(campaign: Campaign) {
+export async function prepareCampaignAudience(campaign: Campaign) {
   if (campaign.audiencePreparedAt) {
     return campaign;
   }
@@ -1262,73 +1488,72 @@ async function prepareCampaignAudience(campaign: Campaign) {
     throw new Error("No contact book found for campaign");
   }
 
-  const capturedAt = campaign.audienceCapturedAt ?? new Date();
+  return db.$transaction(
+    async (tx) => {
+      const storedCampaign = await tx.campaign.findUnique({
+        where: { id: campaign.id },
+      });
 
-  if (!campaign.audienceCapturedAt) {
-    await db.campaign.update({
-      where: { id: campaign.id },
-      data: { audienceCapturedAt: capturedAt },
-    });
-  }
+      if (!storedCampaign) {
+        throw new Error("Campaign not found");
+      }
 
-  let cursor: string | undefined;
+      if (storedCampaign.audiencePreparedAt) {
+        return storedCampaign;
+      }
 
-  while (true) {
-    const contacts = await db.contact.findMany({
-      where: {
-        contactBookId: campaign.contactBookId,
-        subscribed: true,
-        createdAt: { lte: capturedAt },
-      },
-      select: { id: true },
-      orderBy: { id: "asc" },
-      take: CAMPAIGN_AUDIENCE_SNAPSHOT_CHUNK_SIZE,
-      ...(cursor ? { cursor: { id: cursor }, skip: 1 } : {}),
-    });
+      if (!storedCampaign.contactBookId) {
+        throw new Error("No contact book found for campaign");
+      }
 
-    if (contacts.length === 0) {
-      break;
-    }
+      const capturedAt = storedCampaign.audienceCapturedAt ?? new Date();
 
-    await db.campaignEmail.createMany({
-      data: contacts.map((contact) => ({
-        campaignId: campaign.id,
-        contactId: contact.id,
-        status: "PENDING" as const,
-      })),
-      skipDuplicates: true,
-    });
+      if (!storedCampaign.audienceCapturedAt) {
+        await tx.campaign.update({
+          where: { id: storedCampaign.id },
+          data: { audienceCapturedAt: capturedAt },
+        });
+      }
 
-    cursor = contacts[contacts.length - 1]?.id;
+      await tx.$executeRaw`
+        INSERT INTO "CampaignEmail" ("campaignId", "contactId", "status")
+        SELECT ${storedCampaign.id}, "id", 'PENDING'::"CampaignRecipientStatus"
+        FROM "Contact"
+        WHERE "contactBookId" = ${storedCampaign.contactBookId}
+          AND "subscribed" = true
+          AND "createdAt" <= ${capturedAt}
+        ON CONFLICT ("campaignId", "contactId") DO NOTHING
+      `;
 
-    if (contacts.length < CAMPAIGN_AUDIENCE_SNAPSHOT_CHUNK_SIZE) {
-      break;
-    }
-  }
+      const total = await tx.campaignEmail.count({
+        where: { campaignId: storedCampaign.id },
+      });
 
-  const total = await db.campaignEmail.count({
-    where: { campaignId: campaign.id },
-  });
+      const deliveryBatchSize =
+        storedCampaign.deliveryMode === "GRADUAL"
+          ? calculateGradualDelivery({
+              audienceSize: total,
+              batchPercentage: storedCampaign.deliveryBatchPercentage ?? 0,
+              intervalMinutes: storedCampaign.deliveryIntervalMinutes ?? 0,
+              startsAt: storedCampaign.scheduledAt ?? new Date(),
+            }).batchSize
+          : null;
 
-  const deliveryBatchSize =
-    campaign.deliveryMode === "GRADUAL"
-      ? calculateGradualDelivery({
-          audienceSize: total,
-          batchPercentage: campaign.deliveryBatchPercentage ?? 0,
-          intervalMinutes: campaign.deliveryIntervalMinutes ?? 0,
-          startsAt: campaign.scheduledAt ?? new Date(),
-        }).batchSize
-      : null;
-
-  return db.campaign.update({
-    where: { id: campaign.id },
-    data: {
-      total,
-      audienceCapturedAt: capturedAt,
-      audiencePreparedAt: new Date(),
-      deliveryBatchSize,
+      return tx.campaign.update({
+        where: { id: storedCampaign.id },
+        data: {
+          total,
+          audienceCapturedAt: capturedAt,
+          audiencePreparedAt: new Date(),
+          deliveryBatchSize,
+        },
+      });
     },
-  });
+    {
+      isolationLevel: Prisma.TransactionIsolationLevel.RepeatableRead,
+      timeout: CAMPAIGN_AUDIENCE_PREPARATION_TIMEOUT_MS,
+    },
+  );
 }
 
 function getGradualDeliveryWaveSize(campaign: Campaign) {
@@ -1349,71 +1574,230 @@ function getGradualDeliveryWaveSize(campaign: Campaign) {
   );
 }
 
-async function getCampaignProcessingLimit(campaign: Campaign) {
-  if (campaign.deliveryMode !== "GRADUAL") {
-    return { campaign, take: campaign.batchSize ?? 500 };
-  }
+export async function claimCampaignRecipients(campaignId: string): Promise<{
+  campaign: Campaign | null;
+  recipients: ClaimedCampaignRecipient[];
+}> {
+  return db.$transaction(async (tx) => {
+    const lockedCampaign = await tx.$queryRaw<Array<{ id: string }>>`
+      SELECT "id"
+      FROM "Campaign"
+      WHERE "id" = ${campaignId}
+      FOR UPDATE
+    `;
 
-  if (!campaign.deliveryBatchSize || !campaign.deliveryIntervalMinutes) {
-    throw new Error("Gradual delivery configuration is incomplete");
-  }
-
-  const deliveryBatchSize = campaign.deliveryBatchSize;
-  const deliveryIntervalMinutes = campaign.deliveryIntervalMinutes;
-
-  let currentCampaign = campaign;
-  let currentWaveSize = getGradualDeliveryWaveSize(currentCampaign);
-
-  if (currentCampaign.currentDeliveryBatch === 0) {
-    currentCampaign = await db.campaign.update({
-      where: { id: currentCampaign.id },
-      data: {
-        currentDeliveryBatch: 1,
-        deliveryBatchProcessed: 0,
-        nextDeliveryAt: new Date(
-          Date.now() + deliveryIntervalMinutes * 60 * 1000,
-        ),
-      },
-    });
-    currentWaveSize = getGradualDeliveryWaveSize(currentCampaign);
-  } else if (currentCampaign.deliveryBatchProcessed >= currentWaveSize) {
-    const allWavesReleased =
-      currentCampaign.currentDeliveryBatch * deliveryBatchSize >=
-      currentCampaign.total;
-
-    if (allWavesReleased) {
-      return { campaign: currentCampaign, take: 0 };
+    if (lockedCampaign.length === 0) {
+      return { campaign: null, recipients: [] };
     }
 
-    if (
-      currentCampaign.nextDeliveryAt &&
-      currentCampaign.nextDeliveryAt.getTime() > Date.now()
-    ) {
-      return { campaign: currentCampaign, take: 0 };
+    let campaign = await tx.campaign.findUnique({
+      where: { id: campaignId },
+    });
+
+    if (!campaign || campaign.status !== "RUNNING") {
+      return { campaign, recipients: [] };
     }
 
-    currentCampaign = await db.campaign.update({
-      where: { id: currentCampaign.id },
-      data: {
-        currentDeliveryBatch: { increment: 1 },
-        deliveryBatchProcessed: 0,
-        nextDeliveryAt: new Date(
-          Date.now() + deliveryIntervalMinutes * 60 * 1000,
-        ),
+    const claimedAt = new Date();
+    const staleBefore = new Date(
+      claimedAt.getTime() - CAMPAIGN_RECIPIENT_CLAIM_TIMEOUT_MS,
+    );
+    const staleRecipients = await tx.campaignEmail.findMany({
+      where: {
+        campaignId,
+        status: "PROCESSING",
+        processedAt: { lte: staleBefore },
       },
+      select: { contactId: true },
+      orderBy: { contactId: "asc" },
+      take: GRADUAL_DELIVERY_INTERNAL_BATCH_SIZE,
     });
-    currentWaveSize = getGradualDeliveryWaveSize(currentCampaign);
+
+    if (staleRecipients.length > 0) {
+      const staleContactIds = staleRecipients.map(
+        (recipient) => recipient.contactId,
+      );
+
+      await tx.campaignEmail.updateMany({
+        where: {
+          campaignId,
+          contactId: { in: staleContactIds },
+          status: "PROCESSING",
+          processedAt: { lte: staleBefore },
+        },
+        data: { processedAt: claimedAt },
+      });
+
+      const reclaimedRecipients = await tx.campaignEmail.findMany({
+        where: {
+          campaignId,
+          contactId: { in: staleContactIds },
+          status: "PROCESSING",
+          processedAt: claimedAt,
+        },
+        select: { contactId: true },
+        orderBy: { contactId: "asc" },
+      });
+
+      return {
+        campaign,
+        recipients: reclaimedRecipients.map((recipient) => ({
+          contactId: recipient.contactId,
+          claimProcessedAt: claimedAt,
+        })),
+      };
+    }
+
+    const activeClaims = await tx.campaignEmail.count({
+      where: { campaignId, status: "PROCESSING" },
+    });
+
+    if (activeClaims > 0) {
+      return { campaign, recipients: [] };
+    }
+
+    let take = campaign.batchSize ?? 500;
+    let currentWaveSize = 0;
+    let deliveryIntervalMinutes = 0;
+
+    if (campaign.deliveryMode === "GRADUAL") {
+      if (!campaign.deliveryBatchSize || !campaign.deliveryIntervalMinutes) {
+        throw new Error("Gradual delivery configuration is incomplete");
+      }
+
+      const deliveryBatchSize = campaign.deliveryBatchSize;
+      deliveryIntervalMinutes = campaign.deliveryIntervalMinutes;
+      currentWaveSize = getGradualDeliveryWaveSize(campaign);
+
+      if (campaign.currentDeliveryBatch === 0) {
+        campaign = await tx.campaign.update({
+          where: { id: campaign.id },
+          data: {
+            currentDeliveryBatch: 1,
+            deliveryBatchProcessed: 0,
+            nextDeliveryAt: null,
+          },
+        });
+        currentWaveSize = getGradualDeliveryWaveSize(campaign);
+      } else if (campaign.deliveryBatchProcessed >= currentWaveSize) {
+        const allWavesReleased =
+          campaign.currentDeliveryBatch * deliveryBatchSize >= campaign.total;
+
+        if (allWavesReleased) {
+          return { campaign, recipients: [] };
+        }
+
+        if (
+          campaign.nextDeliveryAt &&
+          campaign.nextDeliveryAt.getTime() > claimedAt.getTime()
+        ) {
+          return { campaign, recipients: [] };
+        }
+
+        campaign = await tx.campaign.update({
+          where: { id: campaign.id },
+          data: {
+            currentDeliveryBatch: { increment: 1 },
+            deliveryBatchProcessed: 0,
+            nextDeliveryAt: null,
+          },
+        });
+        currentWaveSize = getGradualDeliveryWaveSize(campaign);
+      }
+
+      const remainingInWave = Math.max(
+        0,
+        currentWaveSize - campaign.deliveryBatchProcessed,
+      );
+      take = Math.min(GRADUAL_DELIVERY_INTERNAL_BATCH_SIZE, remainingInWave);
+    }
+
+    if (take === 0) {
+      return { campaign, recipients: [] };
+    }
+
+    const pendingRecipients = await tx.campaignEmail.findMany({
+      where: { campaignId, status: "PENDING" },
+      select: { contactId: true },
+      orderBy: { contactId: "asc" },
+      take,
+    });
+
+    if (pendingRecipients.length === 0) {
+      return { campaign, recipients: [] };
+    }
+
+    const pendingContactIds = pendingRecipients.map(
+      (recipient) => recipient.contactId,
+    );
+
+    await tx.campaignEmail.updateMany({
+      where: {
+        campaignId,
+        contactId: { in: pendingContactIds },
+        status: "PENDING",
+      },
+      data: { status: "PROCESSING", processedAt: claimedAt },
+    });
+
+    const claimedRecipients = await tx.campaignEmail.findMany({
+      where: {
+        campaignId,
+        contactId: { in: pendingContactIds },
+        status: "PROCESSING",
+        processedAt: claimedAt,
+      },
+      select: { contactId: true },
+      orderBy: { contactId: "asc" },
+    });
+
+    if (campaign.deliveryMode === "GRADUAL" && claimedRecipients.length > 0) {
+      const updatedDeliveryBatchProcessed =
+        campaign.deliveryBatchProcessed + claimedRecipients.length;
+
+      campaign = await tx.campaign.update({
+        where: { id: campaign.id },
+        data: {
+          deliveryBatchProcessed: { increment: claimedRecipients.length },
+          ...(updatedDeliveryBatchProcessed >= currentWaveSize
+            ? {
+                nextDeliveryAt: new Date(
+                  claimedAt.getTime() + deliveryIntervalMinutes * 60 * 1000,
+                ),
+              }
+            : {}),
+        },
+      });
+    }
+
+    return {
+      campaign,
+      recipients: claimedRecipients.map((recipient) => ({
+        contactId: recipient.contactId,
+        claimProcessedAt: claimedAt,
+      })),
+    };
+  });
+}
+
+export async function startCampaignIfDue(
+  campaignId: string,
+  now: Date = new Date(),
+) {
+  const started = await db.campaign.updateMany({
+    where: {
+      id: campaignId,
+      status: "SCHEDULED",
+      OR: [{ scheduledAt: null }, { scheduledAt: { lte: now } }],
+    },
+    data: { status: "RUNNING" },
+  });
+
+  if (started.count !== 1) {
+    return null;
   }
 
-  const remainingInWave = Math.max(
-    0,
-    currentWaveSize - currentCampaign.deliveryBatchProcessed,
-  );
-
-  return {
-    campaign: currentCampaign,
-    take: Math.min(GRADUAL_DELIVERY_INTERNAL_BATCH_SIZE, remainingInWave),
-  };
+  return db.campaign.findUnique({ where: { id: campaignId } });
 }
 
 type CampaignBatchJob = TeamJob<{ campaignId: string }>;
@@ -1443,17 +1827,15 @@ export class CampaignBatchService {
       // Skip paused campaigns
       if (campaign.status === "PAUSED") return;
 
-      // Respect scheduledAt if set
-      if (campaign.scheduledAt && campaign.scheduledAt.getTime() > Date.now())
-        return;
-
-      // First touch moves SCHEDULED -> RUNNING
+      // Atomically start only if the campaign is still scheduled and due. This
+      // prevents a stale worker from overriding a concurrent reschedule.
       if (campaign.status === "SCHEDULED") {
-        campaign = await db.campaign.update({
-          where: { id: campaignId },
-          data: { status: "RUNNING" },
-        });
+        const startedCampaign = await startCampaignIfDue(campaignId);
+        if (!startedCampaign) return;
+        campaign = startedCampaign;
       }
+
+      if (campaign.status !== "RUNNING") return;
 
       campaign = await prepareCampaignAudience(campaign);
 
@@ -1465,35 +1847,29 @@ export class CampaignBatchService {
         return;
       }
 
-      const processingLimit = await getCampaignProcessingLimit(campaign);
-      campaign = processingLimit.campaign;
+      const domain = await db.domain.findUnique({
+        where: { id: campaign.domainId },
+      });
+      if (!domain) return;
 
-      if (processingLimit.take === 0) {
-        const pendingRecipients = await db.campaignEmail.count({
-          where: { campaignId, status: "PENDING" },
+      const claim = await claimCampaignRecipients(campaignId);
+      campaign = claim.campaign ?? campaign;
+      const recipients = claim.recipients;
+
+      if (recipients.length === 0) {
+        const outstandingRecipients = await db.campaignEmail.count({
+          where: {
+            campaignId,
+            status: { in: ["PENDING", "PROCESSING"] },
+          },
         });
 
-        if (pendingRecipients === 0) {
+        if (outstandingRecipients === 0) {
           await db.campaign.update({
             where: { id: campaignId },
             data: { status: "SENT", nextDeliveryAt: null },
           });
         }
-        return;
-      }
-
-      const recipients = await db.campaignEmail.findMany({
-        where: { campaignId, status: "PENDING" },
-        select: { contactId: true },
-        orderBy: { contactId: "asc" },
-        take: processingLimit.take,
-      });
-
-      if (recipients.length === 0) {
-        await db.campaign.update({
-          where: { id: campaignId },
-          data: { status: "SENT", nextDeliveryAt: null },
-        });
         return;
       }
 
@@ -1516,29 +1892,20 @@ export class CampaignBatchService {
         ...(contactBook?.variables ?? []),
       ];
 
-      // Fetch domain for region and id
-      const domain = await db.domain.findUnique({
-        where: { id: campaign.domainId },
-      });
-      if (!domain) return;
-
       // Process each contact in this batch
-      let processedRecipientCount = 0;
-
       for (const recipient of recipients) {
         const contact = contactsById.get(recipient.contactId);
 
         if (!contact || !contact.subscribed) {
-          await db.campaignEmail.update({
+          await db.campaignEmail.updateMany({
             where: {
-              campaignId_contactId: {
-                campaignId,
-                contactId: recipient.contactId,
-              },
+              campaignId,
+              contactId: recipient.contactId,
+              status: "PROCESSING",
+              processedAt: recipient.claimProcessedAt,
             },
             data: { status: "SKIPPED", processedAt: new Date() },
           });
-          processedRecipientCount += 1;
           continue;
         }
 
@@ -1546,6 +1913,7 @@ export class CampaignBatchService {
           await processContactEmail({
             contact,
             campaign,
+            claimProcessedAt: recipient.claimProcessedAt,
             allowedVariables,
             emailConfig: {
               from: campaign.from,
@@ -1569,6 +1937,7 @@ export class CampaignBatchService {
             await recordCampaignContactFailure({
               contact,
               campaign,
+              claimProcessedAt: recipient.claimProcessedAt,
               emailConfig: {
                 replyTo: Array.isArray(campaign.replyTo)
                   ? campaign.replyTo
@@ -1580,7 +1949,6 @@ export class CampaignBatchService {
               },
               error: err,
             });
-            processedRecipientCount += 1;
           } catch (recordErr) {
             logger.error(
               { err: recordErr, contactId: contact.id, campaignId },
@@ -1589,29 +1957,21 @@ export class CampaignBatchService {
           }
           continue;
         }
-
-        processedRecipientCount += 1;
       }
 
       await db.campaign.update({
         where: { id: campaignId },
-        data: {
-          lastSentAt: new Date(),
-          ...(campaign.deliveryMode === "GRADUAL"
-            ? {
-                deliveryBatchProcessed: {
-                  increment: processedRecipientCount,
-                },
-              }
-            : {}),
+        data: { lastSentAt: new Date() },
+      });
+
+      const outstandingRecipients = await db.campaignEmail.count({
+        where: {
+          campaignId,
+          status: { in: ["PENDING", "PROCESSING"] },
         },
       });
 
-      const pendingRecipients = await db.campaignEmail.count({
-        where: { campaignId, status: "PENDING" },
-      });
-
-      if (pendingRecipients === 0) {
+      if (outstandingRecipients === 0) {
         await db.campaign.update({
           where: { id: campaignId },
           data: { status: "SENT", nextDeliveryAt: null },
@@ -1700,7 +2060,11 @@ export class CampaignBatchService {
     await this.batchQueue.add(
       `campaign-${campaignId}`,
       { campaignId, teamId },
-      { jobId: `campaign-batch:${campaignId}`, ...DEFAULT_QUEUE_OPTIONS },
+      {
+        jobId: `campaign-batch-${campaignId}`,
+        ...DEFAULT_QUEUE_OPTIONS,
+        removeOnFail: true,
+      },
     );
   }
 }

--- a/apps/web/src/server/service/campaign-service.ts
+++ b/apps/web/src/server/service/campaign-service.ts
@@ -119,6 +119,48 @@ function getCampaignDeliveryData({
   };
 }
 
+function getCampaignDraftDeliveryData(delivery?: CampaignDeliveryInput) {
+  if (!delivery || delivery.strategy === "ALL_AT_ONCE") {
+    return {
+      deliveryMode: "ALL_AT_ONCE" as const,
+      deliveryBatchPercentage: null,
+      deliveryIntervalMinutes: null,
+      deliveryBatchSize: null,
+    };
+  }
+
+  return {
+    deliveryMode: "GRADUAL" as const,
+    deliveryBatchPercentage: delivery.batchPercentage,
+    deliveryIntervalMinutes:
+      GRADUAL_DELIVERY_INTERVAL_MINUTES[delivery.interval],
+    deliveryBatchSize: null,
+  };
+}
+
+function getStoredCampaignDelivery(campaign: Campaign): CampaignDeliveryInput {
+  if (campaign.deliveryMode !== "GRADUAL") {
+    return { strategy: "ALL_AT_ONCE" };
+  }
+
+  const interval = Object.entries(GRADUAL_DELIVERY_INTERVAL_MINUTES).find(
+    ([, minutes]) => minutes === campaign.deliveryIntervalMinutes,
+  )?.[0] as GradualDeliveryInterval | undefined;
+
+  if (!campaign.deliveryBatchPercentage || !interval) {
+    throw new UnsendApiError({
+      code: "BAD_REQUEST",
+      message: "Gradual delivery configuration is incomplete",
+    });
+  }
+
+  return {
+    strategy: "GRADUAL",
+    batchPercentage: campaign.deliveryBatchPercentage,
+    interval,
+  };
+}
+
 async function prepareCampaignHtml(
   campaign: Campaign,
 ): Promise<{ campaign: Campaign; html: string }> {
@@ -228,6 +270,7 @@ export async function createCampaignFromApi({
   cc,
   bcc,
   batchSize,
+  delivery,
 }: {
   teamId: number;
   apiKeyId?: number;
@@ -242,6 +285,7 @@ export async function createCampaignFromApi({
   cc?: string | string[];
   bcc?: string | string[];
   batchSize?: number;
+  delivery?: CampaignDeliveryInput;
 }) {
   if (!content && !html) {
     throw new UnsendApiError({
@@ -326,6 +370,7 @@ export async function createCampaignFromApi({
       bcc: sanitizeAddressList(bcc),
       teamId,
       domainId: domain.id,
+      ...getCampaignDraftDeliveryData(delivery),
       ...(typeof batchSize === "number" ? { batchSize } : {}),
     },
   });
@@ -531,7 +576,7 @@ export async function scheduleCampaign({
   const shouldResetCursor = campaign.status === "DRAFT";
 
   const deliveryData = getCampaignDeliveryData({
-    delivery,
+    delivery: delivery ?? getStoredCampaignDelivery(campaign),
     audienceSize: total,
     startsAt: scheduledAt,
   });

--- a/apps/web/src/server/service/campaign-service.ts
+++ b/apps/web/src/server/service/campaign-service.ts
@@ -1556,7 +1556,12 @@ export async function prepareCampaignAudience(campaign: Campaign) {
   );
 }
 
-function getGradualDeliveryWaveSize(campaign: Campaign) {
+type GradualDeliveryWaveCampaign = Pick<
+  Campaign,
+  "deliveryMode" | "deliveryBatchSize" | "currentDeliveryBatch" | "total"
+>;
+
+function getGradualDeliveryWaveSize(campaign: GradualDeliveryWaveCampaign) {
   if (
     campaign.deliveryMode !== "GRADUAL" ||
     !campaign.deliveryBatchSize ||
@@ -2017,15 +2022,7 @@ export class CampaignBatchService {
         campaign.deliveryBatchSize &&
         campaign.currentDeliveryBatch > 0
       ) {
-        const previouslyReleased =
-          (campaign.currentDeliveryBatch - 1) * campaign.deliveryBatchSize;
-        const currentWaveSize = Math.max(
-          0,
-          Math.min(
-            campaign.deliveryBatchSize,
-            campaign.total - previouslyReleased,
-          ),
-        );
+        const currentWaveSize = getGradualDeliveryWaveSize(campaign);
         const currentWaveComplete =
           campaign.deliveryBatchProcessed >= currentWaveSize;
 

--- a/apps/web/src/server/service/campaign-service.unit.test.ts
+++ b/apps/web/src/server/service/campaign-service.unit.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createHash } from "crypto";
 import { UnsubscribeReason } from "@prisma/client";
 
@@ -6,7 +6,8 @@ const { mockDb, mockTx, mockUpdateContactSubscription } = vi.hoisted(() => {
   const mockTx = {
     campaignEmail: {
       findUnique: vi.fn(),
-      create: vi.fn(),
+      update: vi.fn(),
+      upsert: vi.fn(),
     },
     email: {
       findFirst: vi.fn(),
@@ -28,6 +29,7 @@ const { mockDb, mockTx, mockUpdateContactSubscription } = vi.hoisted(() => {
         findUnique: vi.fn(),
       },
       campaign: {
+        findUnique: vi.fn(),
         update: vi.fn(),
       },
     },
@@ -93,6 +95,8 @@ vi.mock("~/server/logger/log", () => ({
 
 import {
   recordCampaignContactFailure,
+  resumeCampaign,
+  scheduleCampaign,
   subscribeContact,
   unsubscribeContact,
 } from "~/server/service/campaign-service";
@@ -142,6 +146,15 @@ describe("recordCampaignContactFailure", () => {
         teamId: 7,
       },
     });
+    expect(mockTx.campaignEmail.update).toHaveBeenCalledWith({
+      where: {
+        campaignId_contactId: {
+          campaignId: "campaign_1",
+          contactId: "contact_1",
+        },
+      },
+      data: { status: "FAILED", processedAt: expect.any(Date) },
+    });
   });
 
   it("creates a failed email and campaign link when processing failed before persistence", async () => {
@@ -160,11 +173,24 @@ describe("recordCampaignContactFailure", () => {
       }),
       select: { id: true },
     });
-    expect(mockTx.campaignEmail.create).toHaveBeenCalledWith({
-      data: {
+    expect(mockTx.campaignEmail.upsert).toHaveBeenCalledWith({
+      where: {
+        campaignId_contactId: {
+          campaignId: "campaign_1",
+          contactId: "contact_1",
+        },
+      },
+      create: {
         campaignId: "campaign_1",
         contactId: "contact_1",
         emailId: "email_2",
+        status: "FAILED",
+        processedAt: expect.any(Date),
+      },
+      update: {
+        emailId: "email_2",
+        status: "FAILED",
+        processedAt: expect.any(Date),
       },
     });
     expect(mockTx.emailEvent.create).toHaveBeenCalledWith({
@@ -182,16 +208,88 @@ describe("recordCampaignContactFailure", () => {
     await recordCampaignContactFailure(input);
 
     expect(mockTx.email.create).not.toHaveBeenCalled();
-    expect(mockTx.campaignEmail.create).toHaveBeenCalledWith({
-      data: {
+    expect(mockTx.campaignEmail.upsert).toHaveBeenCalledWith({
+      where: {
+        campaignId_contactId: {
+          campaignId: "campaign_1",
+          contactId: "contact_1",
+        },
+      },
+      create: {
         campaignId: "campaign_1",
         contactId: "contact_1",
         emailId: "email_3",
+        status: "FAILED",
+        processedAt: expect.any(Date),
+      },
+      update: {
+        emailId: "email_3",
+        status: "FAILED",
+        processedAt: expect.any(Date),
       },
     });
     expect(mockTx.email.update).toHaveBeenCalledWith({
       where: { id: "email_3" },
       data: { latestStatus: "FAILED" },
+    });
+  });
+});
+
+describe("campaign delivery lifecycle", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("does not allow delivery settings to change after sending starts", async () => {
+    mockDb.campaign.findUnique.mockResolvedValue({
+      id: "campaign_1",
+      status: "RUNNING",
+    });
+
+    await expect(
+      scheduleCampaign({
+        campaignId: "campaign_1",
+        teamId: 7,
+        delivery: {
+          strategy: "GRADUAL",
+          batchPercentage: 10,
+          interval: "hour",
+        },
+      }),
+    ).rejects.toMatchObject({
+      code: "BAD_REQUEST",
+      message:
+        "Delivery settings cannot be changed after a campaign has started",
+    });
+    expect(mockDb.$transaction).not.toHaveBeenCalled();
+  });
+
+  it("moves the next wave by the paused duration when resuming", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-21T12:00:00.000Z"));
+    mockDb.campaign.findUnique.mockResolvedValue({
+      id: "campaign_1",
+      teamId: 7,
+      status: "PAUSED",
+      scheduledAt: new Date("2026-07-21T09:00:00.000Z"),
+      pausedAt: new Date("2026-07-21T10:00:00.000Z"),
+      nextDeliveryAt: new Date("2026-07-21T10:30:00.000Z"),
+    });
+
+    await resumeCampaign({ campaignId: "campaign_1", teamId: 7 });
+
+    expect(mockDb.campaign.update).toHaveBeenCalledWith({
+      where: { id: "campaign_1" },
+      data: {
+        status: "RUNNING",
+        pausedAt: null,
+        nextDeliveryAt: new Date("2026-07-21T12:30:00.000Z"),
+      },
     });
   });
 });

--- a/apps/web/src/server/service/campaign-service.unit.test.ts
+++ b/apps/web/src/server/service/campaign-service.unit.test.ts
@@ -5,17 +5,30 @@ import { UnsubscribeReason } from "@prisma/client";
 const {
   mockDb,
   mockTx,
+  mockQueueAdd,
+  mockQueueEmail,
   mockUpdateContactSubscription,
   mockValidateDomainFromEmail,
 } = vi.hoisted(() => {
   const mockTx = {
+    $executeRaw: vi.fn(),
+    $queryRaw: vi.fn(),
     campaignEmail: {
+      count: vi.fn(),
+      deleteMany: vi.fn(),
+      findMany: vi.fn(),
       findUnique: vi.fn(),
       update: vi.fn(),
+      updateMany: vi.fn(),
       upsert: vi.fn(),
+    },
+    campaign: {
+      findUnique: vi.fn(),
+      update: vi.fn(),
     },
     email: {
       findFirst: vi.fn(),
+      findUnique: vi.fn(),
       create: vi.fn(),
       update: vi.fn(),
     },
@@ -31,6 +44,7 @@ const {
         callback(mockTx),
       ),
       contact: {
+        count: vi.fn(),
         findUnique: vi.fn(),
       },
       contactBook: {
@@ -40,8 +54,14 @@ const {
         create: vi.fn(),
         findUnique: vi.fn(),
         update: vi.fn(),
+        updateMany: vi.fn(),
+      },
+      campaignEmail: {
+        updateMany: vi.fn(),
       },
     },
+    mockQueueAdd: vi.fn(),
+    mockQueueEmail: vi.fn(),
     mockUpdateContactSubscription: vi.fn(),
     mockValidateDomainFromEmail: vi.fn(),
   };
@@ -67,7 +87,7 @@ vi.mock("~/server/service/contact-service", () => ({
 
 vi.mock("bullmq", () => ({
   Queue: class {
-    add = vi.fn();
+    add = mockQueueAdd;
   },
   Worker: class {},
 }));
@@ -78,7 +98,9 @@ vi.mock("~/server/redis", () => ({
 }));
 
 vi.mock("~/server/service/email-queue-service", () => ({
-  EmailQueueService: {},
+  EmailQueueService: {
+    queueEmail: mockQueueEmail,
+  },
 }));
 
 vi.mock("~/server/queue/bullmq-context", () => ({
@@ -104,10 +126,16 @@ vi.mock("~/server/logger/log", () => ({
 }));
 
 import {
+  CampaignBatchService,
+  claimCampaignRecipients,
   createCampaignFromApi,
+  pauseCampaign,
+  prepareCampaignAudience,
+  queueClaimedCampaignEmail,
   recordCampaignContactFailure,
   resumeCampaign,
   scheduleCampaign,
+  startCampaignIfDue,
   subscribeContact,
   unsubscribeContact,
 } from "~/server/service/campaign-service";
@@ -244,6 +272,111 @@ describe("recordCampaignContactFailure", () => {
       data: { latestStatus: "FAILED" },
     });
   });
+
+  it("does not overwrite a recipient after its processing claim is replaced", async () => {
+    const originalClaim = new Date("2026-07-21T09:00:00.000Z");
+    mockTx.campaignEmail.findUnique.mockResolvedValue({
+      emailId: "email_1",
+      status: "PROCESSING",
+      processedAt: new Date("2026-07-21T10:30:00.000Z"),
+    });
+
+    await recordCampaignContactFailure({
+      ...input,
+      claimProcessedAt: originalClaim,
+    });
+
+    expect(mockTx.campaignEmail.updateMany).not.toHaveBeenCalled();
+    expect(mockTx.email.update).not.toHaveBeenCalled();
+    expect(mockTx.emailEvent.create).not.toHaveBeenCalled();
+  });
+});
+
+describe("queueClaimedCampaignEmail", () => {
+  const claimProcessedAt = new Date("2026-07-21T09:00:00.000Z");
+  const queueInput = {
+    campaignId: "campaign_1",
+    contactId: "contact_1",
+    claimProcessedAt,
+    teamId: 7,
+    region: "us-east-1",
+    oneClickUnsubUrl: "https://example.com/unsubscribe",
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("leaves an accepted queue job recoverable when bookkeeping fails", async () => {
+    mockQueueEmail.mockResolvedValue(undefined);
+    mockDb.campaignEmail.updateMany.mockRejectedValue(
+      new Error("database unavailable"),
+    );
+
+    const result = await queueClaimedCampaignEmail({
+      ...queueInput,
+      email: {
+        id: "email_1",
+        latestStatus: "QUEUED",
+        sesEmailId: null,
+      },
+    });
+
+    expect(mockQueueEmail).toHaveBeenCalledWith(
+      "email_1",
+      7,
+      "us-east-1",
+      false,
+      "https://example.com/unsubscribe",
+    );
+    expect(result).toEqual({ recoveryPending: true });
+  });
+
+  it("does not requeue an email that already has an SES message ID", async () => {
+    mockDb.campaignEmail.updateMany.mockResolvedValue({ count: 1 });
+
+    const result = await queueClaimedCampaignEmail({
+      ...queueInput,
+      email: {
+        id: "email_1",
+        latestStatus: "QUEUED",
+        sesEmailId: "ses-message-1",
+      },
+    });
+
+    expect(mockQueueEmail).not.toHaveBeenCalled();
+    expect(mockDb.campaignEmail.updateMany).toHaveBeenCalledWith({
+      where: {
+        campaignId: "campaign_1",
+        contactId: "contact_1",
+        status: "PROCESSING",
+        processedAt: claimProcessedAt,
+        emailId: "email_1",
+      },
+      data: {
+        status: "QUEUED",
+        processedAt: expect.any(Date),
+      },
+    });
+    expect(result).toEqual({ recoveryPending: false });
+  });
+
+  it("propagates a real queue rejection so the caller can record failure", async () => {
+    mockQueueEmail.mockRejectedValue(new Error("redis unavailable"));
+
+    await expect(
+      queueClaimedCampaignEmail({
+        ...queueInput,
+        email: {
+          id: "email_1",
+          latestStatus: "QUEUED",
+          sesEmailId: null,
+        },
+      }),
+    ).rejects.toThrow("redis unavailable");
+
+    expect(mockDb.campaignEmail.updateMany).not.toHaveBeenCalled();
+  });
 });
 
 describe("campaign delivery lifecycle", () => {
@@ -309,6 +442,93 @@ describe("campaign delivery lifecycle", () => {
     expect(mockDb.$transaction).not.toHaveBeenCalled();
   });
 
+  it("requires a completed campaign to be duplicated before sending again", async () => {
+    mockDb.campaign.findUnique.mockResolvedValue({
+      id: "campaign_1",
+      teamId: 7,
+      status: "SENT",
+    });
+
+    await expect(
+      scheduleCampaign({
+        campaignId: "campaign_1",
+        teamId: 7,
+        scheduledAt: new Date("2026-07-22T09:00:00.000Z"),
+      }),
+    ).rejects.toMatchObject({
+      code: "BAD_REQUEST",
+      message:
+        "Completed campaigns cannot be scheduled again. Duplicate the campaign to send it again",
+    });
+    expect(mockDb.$transaction).not.toHaveBeenCalled();
+  });
+
+  it("does not clear recipient claims if the campaign starts concurrently", async () => {
+    mockDb.campaign.findUnique.mockResolvedValue({
+      id: "campaign_1",
+      teamId: 7,
+      status: "SCHEDULED",
+      content: null,
+      html: '<a href="{{usesend_unsubscribe_url}}">Unsubscribe</a>',
+      contactBookId: "book_1",
+      scheduledAt: new Date("2026-07-22T09:00:00.000Z"),
+      deliveryMode: "ALL_AT_ONCE",
+      deliveryBatchPercentage: null,
+      deliveryIntervalMinutes: null,
+    });
+    mockDb.contact.count.mockResolvedValue(100);
+    mockTx.$queryRaw.mockResolvedValue([{ status: "RUNNING" }]);
+
+    await expect(
+      scheduleCampaign({
+        campaignId: "campaign_1",
+        teamId: 7,
+        scheduledAt: new Date("2026-07-23T09:00:00.000Z"),
+      }),
+    ).rejects.toMatchObject({
+      code: "BAD_REQUEST",
+      message:
+        "Delivery settings cannot be changed after a campaign has started",
+    });
+
+    expect(mockTx.campaignEmail.deleteMany).not.toHaveBeenCalled();
+    expect(mockTx.campaign.update).not.toHaveBeenCalled();
+  });
+
+  it("starts a campaign only while it is still scheduled and due", async () => {
+    const now = new Date("2026-07-21T09:00:00.000Z");
+    const runningCampaign = {
+      id: "campaign_1",
+      status: "RUNNING",
+    };
+    mockDb.campaign.updateMany.mockResolvedValue({ count: 1 });
+    mockDb.campaign.findUnique.mockResolvedValue(runningCampaign);
+
+    const result = await startCampaignIfDue("campaign_1", now);
+
+    expect(mockDb.campaign.updateMany).toHaveBeenCalledWith({
+      where: {
+        id: "campaign_1",
+        status: "SCHEDULED",
+        OR: [{ scheduledAt: null }, { scheduledAt: { lte: now } }],
+      },
+      data: { status: "RUNNING" },
+    });
+    expect(result).toBe(runningCampaign);
+  });
+
+  it("leaves a concurrently rescheduled campaign untouched", async () => {
+    mockDb.campaign.updateMany.mockResolvedValue({ count: 0 });
+
+    const result = await startCampaignIfDue(
+      "campaign_1",
+      new Date("2026-07-21T09:00:00.000Z"),
+    );
+
+    expect(result).toBeNull();
+    expect(mockDb.campaign.findUnique).not.toHaveBeenCalled();
+  });
+
   it("moves the next wave by the paused duration when resuming", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-07-21T12:00:00.000Z"));
@@ -331,6 +551,267 @@ describe("campaign delivery lifecycle", () => {
         nextDeliveryAt: new Date("2026-07-21T12:30:00.000Z"),
       },
     });
+  });
+
+  it("keeps the original pause timestamp when pause is retried", async () => {
+    mockDb.campaign.findUnique.mockResolvedValue({
+      id: "campaign_1",
+      teamId: 7,
+      status: "PAUSED",
+      pausedAt: new Date("2026-07-21T10:00:00.000Z"),
+    });
+
+    await pauseCampaign({ campaignId: "campaign_1", teamId: 7 });
+
+    expect(mockDb.campaign.updateMany).not.toHaveBeenCalled();
+  });
+
+  it("atomically transitions an active campaign to paused", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-21T10:00:00.000Z"));
+    mockDb.campaign.findUnique.mockResolvedValue({
+      id: "campaign_1",
+      teamId: 7,
+      status: "RUNNING",
+    });
+    mockDb.campaign.updateMany.mockResolvedValue({ count: 1 });
+
+    await pauseCampaign({ campaignId: "campaign_1", teamId: 7 });
+
+    expect(mockDb.campaign.updateMany).toHaveBeenCalledWith({
+      where: {
+        id: "campaign_1",
+        teamId: 7,
+        status: "RUNNING",
+      },
+      data: {
+        status: "PAUSED",
+        pausedAt: new Date("2026-07-21T10:00:00.000Z"),
+      },
+    });
+  });
+
+  it("captures the audience with one database snapshot", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-21T09:00:00.000Z"));
+    const campaign = {
+      id: "campaign_1",
+      contactBookId: "book_1",
+      audienceCapturedAt: null,
+      audiencePreparedAt: null,
+      deliveryMode: "GRADUAL",
+      deliveryBatchPercentage: 10,
+      deliveryIntervalMinutes: 60,
+      scheduledAt: new Date("2026-07-21T09:00:00.000Z"),
+    } as any;
+    mockTx.campaign.findUnique.mockResolvedValue(campaign);
+    mockTx.$executeRaw.mockResolvedValue(2);
+    mockTx.campaignEmail.count.mockResolvedValue(2);
+    mockTx.campaign.update.mockResolvedValue(campaign);
+
+    await prepareCampaignAudience(campaign);
+
+    expect(mockTx.$executeRaw).toHaveBeenCalledTimes(1);
+    expect(mockTx.$executeRaw.mock.calls[0]?.slice(1)).toEqual([
+      "campaign_1",
+      "book_1",
+      new Date("2026-07-21T09:00:00.000Z"),
+    ]);
+    expect(mockTx.campaignEmail.count).toHaveBeenCalledWith({
+      where: { campaignId: "campaign_1" },
+    });
+    expect(mockTx.campaign.update).toHaveBeenLastCalledWith({
+      where: { id: "campaign_1" },
+      data: {
+        total: 2,
+        audienceCapturedAt: new Date("2026-07-21T09:00:00.000Z"),
+        audiencePreparedAt: expect.any(Date),
+        deliveryBatchSize: 1,
+      },
+    });
+    expect(mockDb.$transaction).toHaveBeenCalledWith(expect.any(Function), {
+      isolationLevel: "RepeatableRead",
+      timeout: 30 * 60 * 1000,
+    });
+  });
+
+  it("queues campaign batches with a BullMQ-compatible job ID", async () => {
+    mockDb.campaign.findUnique.mockResolvedValue({
+      status: "SCHEDULED",
+      lastSentAt: null,
+      batchWindowMinutes: 0,
+      total: 23,
+      deliveryMode: "GRADUAL",
+      deliveryBatchSize: 12,
+      currentDeliveryBatch: 0,
+      deliveryBatchProcessed: 0,
+      nextDeliveryAt: null,
+    });
+
+    await CampaignBatchService.queueBatch({
+      campaignId: "campaign_1",
+      teamId: 7,
+    });
+
+    expect(mockQueueAdd).toHaveBeenCalledWith(
+      "campaign-campaign_1",
+      { campaignId: "campaign_1", teamId: 7 },
+      expect.objectContaining({
+        jobId: "campaign-batch-campaign_1",
+        removeOnFail: true,
+      }),
+    );
+  });
+
+  it("claims gradual wave capacity in the recipient transaction", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-21T09:00:00.000Z"));
+
+    const campaign = {
+      id: "campaign_1",
+      status: "RUNNING",
+      deliveryMode: "GRADUAL",
+      deliveryBatchSize: 2,
+      deliveryIntervalMinutes: 60,
+      currentDeliveryBatch: 0,
+      deliveryBatchProcessed: 0,
+      total: 5,
+      batchSize: 500,
+    };
+    const firstWaveCampaign = {
+      ...campaign,
+      currentDeliveryBatch: 1,
+      nextDeliveryAt: null,
+    };
+    const claimedCampaign = {
+      ...firstWaveCampaign,
+      deliveryBatchProcessed: 2,
+      nextDeliveryAt: new Date("2026-07-21T10:00:00.000Z"),
+    };
+
+    mockTx.$queryRaw.mockResolvedValue([{ id: "campaign_1" }]);
+    mockTx.campaign.findUnique.mockResolvedValue(campaign);
+    mockTx.campaign.update
+      .mockResolvedValueOnce(firstWaveCampaign)
+      .mockResolvedValueOnce(claimedCampaign);
+    mockTx.campaignEmail.findMany
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        { contactId: "contact_1" },
+        { contactId: "contact_2" },
+      ])
+      .mockResolvedValueOnce([
+        { contactId: "contact_1" },
+        { contactId: "contact_2" },
+      ]);
+    mockTx.campaignEmail.count.mockResolvedValue(0);
+    mockTx.campaignEmail.updateMany.mockResolvedValue({ count: 2 });
+
+    const result = await claimCampaignRecipients("campaign_1");
+
+    expect(result.recipients).toEqual([
+      {
+        contactId: "contact_1",
+        claimProcessedAt: new Date("2026-07-21T09:00:00.000Z"),
+      },
+      {
+        contactId: "contact_2",
+        claimProcessedAt: new Date("2026-07-21T09:00:00.000Z"),
+      },
+    ]);
+    expect(mockTx.campaignEmail.updateMany).toHaveBeenCalledWith({
+      where: {
+        campaignId: "campaign_1",
+        contactId: { in: ["contact_1", "contact_2"] },
+        status: "PENDING",
+      },
+      data: {
+        status: "PROCESSING",
+        processedAt: new Date("2026-07-21T09:00:00.000Z"),
+      },
+    });
+    expect(mockTx.campaign.update).toHaveBeenLastCalledWith({
+      where: { id: "campaign_1" },
+      data: {
+        deliveryBatchProcessed: { increment: 2 },
+        nextDeliveryAt: new Date("2026-07-21T10:00:00.000Z"),
+      },
+    });
+  });
+
+  it("keeps the next delivery unset until the whole wave is claimed", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-21T09:00:00.000Z"));
+
+    const campaign = {
+      id: "campaign_1",
+      status: "RUNNING",
+      deliveryMode: "GRADUAL",
+      deliveryBatchSize: 1_000,
+      deliveryIntervalMinutes: 60,
+      currentDeliveryBatch: 1,
+      deliveryBatchProcessed: 0,
+      nextDeliveryAt: null,
+      total: 2_000,
+      batchSize: 500,
+    };
+    const recipients = Array.from({ length: 500 }, (_, index) => ({
+      contactId: `contact_${index}`,
+    }));
+
+    mockTx.$queryRaw.mockResolvedValue([{ id: "campaign_1" }]);
+    mockTx.campaign.findUnique.mockResolvedValue(campaign);
+    mockTx.campaign.update.mockResolvedValue({
+      ...campaign,
+      deliveryBatchProcessed: 500,
+    });
+    mockTx.campaignEmail.findMany
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce(recipients)
+      .mockResolvedValueOnce(recipients);
+    mockTx.campaignEmail.count.mockResolvedValue(0);
+    mockTx.campaignEmail.updateMany.mockResolvedValue({ count: 500 });
+
+    await claimCampaignRecipients("campaign_1");
+
+    expect(mockTx.campaign.update).toHaveBeenCalledWith({
+      where: { id: "campaign_1" },
+      data: {
+        deliveryBatchProcessed: { increment: 500 },
+      },
+    });
+  });
+
+  it("reclaims stale recipients without consuming wave capacity twice", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-21T12:00:00.000Z"));
+
+    mockTx.$queryRaw.mockResolvedValue([{ id: "campaign_1" }]);
+    mockTx.campaign.findUnique.mockResolvedValue({
+      id: "campaign_1",
+      status: "RUNNING",
+      deliveryMode: "GRADUAL",
+      deliveryBatchSize: 10,
+      deliveryIntervalMinutes: 60,
+      currentDeliveryBatch: 1,
+      deliveryBatchProcessed: 5,
+      total: 100,
+      batchSize: 500,
+    });
+    mockTx.campaignEmail.findMany
+      .mockResolvedValueOnce([{ contactId: "contact_1" }])
+      .mockResolvedValueOnce([{ contactId: "contact_1" }]);
+    mockTx.campaignEmail.updateMany.mockResolvedValue({ count: 1 });
+
+    const result = await claimCampaignRecipients("campaign_1");
+
+    expect(result.recipients).toEqual([
+      {
+        contactId: "contact_1",
+        claimProcessedAt: new Date("2026-07-21T12:00:00.000Z"),
+      },
+    ]);
+    expect(mockTx.campaign.update).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/web/src/server/service/campaign-service.unit.test.ts
+++ b/apps/web/src/server/service/campaign-service.unit.test.ts
@@ -2,7 +2,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createHash } from "crypto";
 import { UnsubscribeReason } from "@prisma/client";
 
-const { mockDb, mockTx, mockUpdateContactSubscription } = vi.hoisted(() => {
+const {
+  mockDb,
+  mockTx,
+  mockUpdateContactSubscription,
+  mockValidateDomainFromEmail,
+} = vi.hoisted(() => {
   const mockTx = {
     campaignEmail: {
       findUnique: vi.fn(),
@@ -28,12 +33,17 @@ const { mockDb, mockTx, mockUpdateContactSubscription } = vi.hoisted(() => {
       contact: {
         findUnique: vi.fn(),
       },
+      contactBook: {
+        findUnique: vi.fn(),
+      },
       campaign: {
+        create: vi.fn(),
         findUnique: vi.fn(),
         update: vi.fn(),
       },
     },
     mockUpdateContactSubscription: vi.fn(),
+    mockValidateDomainFromEmail: vi.fn(),
   };
 });
 
@@ -81,7 +91,7 @@ vi.mock("~/server/service/suppression-service", () => ({
 
 vi.mock("~/server/service/domain-service", () => ({
   validateApiKeyDomainAccess: vi.fn(),
-  validateDomainFromEmail: vi.fn(),
+  validateDomainFromEmail: mockValidateDomainFromEmail,
 }));
 
 vi.mock("~/server/logger/log", () => ({
@@ -94,6 +104,7 @@ vi.mock("~/server/logger/log", () => ({
 }));
 
 import {
+  createCampaignFromApi,
   recordCampaignContactFailure,
   resumeCampaign,
   scheduleCampaign,
@@ -243,6 +254,35 @@ describe("campaign delivery lifecycle", () => {
 
   afterEach(() => {
     vi.useRealTimers();
+  });
+
+  it("stores gradual settings on API-created drafts", async () => {
+    mockDb.contactBook.findUnique.mockResolvedValue({ id: "book_1" });
+    mockValidateDomainFromEmail.mockResolvedValue({ id: 11 });
+    mockDb.campaign.create.mockResolvedValue({ id: "campaign_1" });
+
+    await createCampaignFromApi({
+      teamId: 7,
+      name: "Launch",
+      from: "sender@example.com",
+      subject: "Hello",
+      html: '<a href="{{usesend_unsubscribe_url}}">Unsubscribe</a>',
+      contactBookId: "book_1",
+      delivery: {
+        strategy: "GRADUAL",
+        batchPercentage: 10,
+        interval: "hour",
+      },
+    });
+
+    expect(mockDb.campaign.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        deliveryMode: "GRADUAL",
+        deliveryBatchPercentage: 10,
+        deliveryIntervalMinutes: 60,
+        deliveryBatchSize: null,
+      }),
+    });
   });
 
   it("does not allow delivery settings to change after sending starts", async () => {

--- a/packages/python-sdk/README.md
+++ b/packages/python-sdk/README.md
@@ -63,6 +63,11 @@ campaign_resp, _ = client.campaigns.create(payload=campaign_payload)
 # Schedule a campaign
 schedule_payload: types.CampaignSchedule = {
     "scheduledAt": "2024-12-01T10:00:00Z",
+    "delivery": {
+        "strategy": "gradual",
+        "batchPercentage": 10,
+        "interval": "hour",
+    },
 }
 schedule_resp, _ = client.campaigns.schedule(
     campaign_id=campaign_resp["id"],

--- a/packages/python-sdk/tests/test_resources.py
+++ b/packages/python-sdk/tests/test_resources.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, List, Optional
 
-from usesend import UseSend
+from usesend import UseSend, types
 
 
 class MockResponse:
@@ -136,3 +136,39 @@ def test_contacts_bulk_methods_use_expected_payloads() -> None:
     ]
     assert session.calls[1]["method"] == "DELETE"
     assert session.calls[1]["json"] == {"contactIds": ["ct_1", "ct_2"]}
+
+
+def test_campaigns_forward_gradual_delivery_payloads() -> None:
+    session = MockSession(
+        [
+            MockResponse({"id": "campaign_123"}),
+            MockResponse({"success": True}),
+        ]
+    )
+    client = UseSend("us_test", session=session)
+    delivery: types.CampaignDeliveryGradual = {
+        "strategy": "gradual",
+        "batchPercentage": 10,
+        "interval": "hour",
+    }
+
+    client.campaigns.create(
+        {
+            "name": "Launch",
+            "from": "hello@example.com",
+            "subject": "Hello",
+            "contactBookId": "book_123",
+            "html": "<p>Hello</p>",
+            "delivery": delivery,
+        }
+    )
+    client.campaigns.schedule(
+        "campaign_123",
+        {"delivery": delivery},
+    )
+
+    assert session.calls[0]["json"]["delivery"] == delivery
+    assert session.calls[1]["json"]["delivery"] == delivery
+    assert "deliveryMode" in types.Campaign.__annotations__
+    assert "delivery" in types.CampaignCreate.__annotations__
+    assert "delivery" in types.CampaignSchedule.__annotations__

--- a/packages/python-sdk/usesend/types.py
+++ b/packages/python-sdk/usesend/types.py
@@ -417,6 +417,23 @@ class ContactDeleteResponse(TypedDict):
 # Campaigns
 # ---------------------------------------------------------------------------
 
+CampaignDeliveryMode = Literal["ALL_AT_ONCE", "GRADUAL"]
+CampaignDeliveryInterval = Literal["minute", "hour"]
+
+
+class CampaignDeliveryAllAtOnce(TypedDict):
+    strategy: Literal["all_at_once"]
+
+
+class CampaignDeliveryGradual(TypedDict):
+    strategy: Literal["gradual"]
+    batchPercentage: int
+    interval: CampaignDeliveryInterval
+
+
+CampaignDelivery = Union[CampaignDeliveryAllAtOnce, CampaignDeliveryGradual]
+
+
 Campaign = TypedDict(
     "Campaign",
     {
@@ -432,6 +449,13 @@ Campaign = TypedDict(
         "scheduledAt": Optional[str],
         "batchSize": int,
         "batchWindowMinutes": int,
+        "deliveryMode": CampaignDeliveryMode,
+        "deliveryBatchPercentage": Optional[int],
+        "deliveryIntervalMinutes": Optional[int],
+        "deliveryBatchSize": Optional[int],
+        "currentDeliveryBatch": int,
+        "deliveryBatchProcessed": int,
+        "nextDeliveryAt": Optional[str],
         "total": int,
         "sent": int,
         "delivered": int,
@@ -466,6 +490,7 @@ CampaignCreate = TypedDict(
         "sendNow": NotRequired[bool],
         "scheduledAt": NotRequired[str],
         "batchSize": NotRequired[int],
+        "delivery": NotRequired[CampaignDelivery],
     },
 )
 
@@ -485,6 +510,13 @@ CampaignCreateResponse = TypedDict(
         "scheduledAt": Optional[str],
         "batchSize": int,
         "batchWindowMinutes": int,
+        "deliveryMode": CampaignDeliveryMode,
+        "deliveryBatchPercentage": Optional[int],
+        "deliveryIntervalMinutes": Optional[int],
+        "deliveryBatchSize": Optional[int],
+        "currentDeliveryBatch": int,
+        "deliveryBatchProcessed": int,
+        "nextDeliveryAt": Optional[str],
         "total": int,
         "sent": int,
         "delivered": int,
@@ -507,6 +539,7 @@ class CampaignSchedule(TypedDict, total=False):
     scheduledAt: Optional[str]
     batchSize: Optional[int]
     sendNow: Optional[bool]
+    delivery: CampaignDelivery
 
 
 class CampaignScheduleResponse(TypedDict, total=False):

--- a/packages/sdk/types/schema.d.ts
+++ b/packages/sdk/types/schema.d.ts
@@ -1605,6 +1605,16 @@ export interface paths {
                         /** @description Timestamp in ISO 8601 format or natural language (e.g., 'tomorrow 9am', 'next monday 10:30') */
                         scheduledAt?: string;
                         batchSize?: number;
+                        delivery?: {
+                            /** @enum {string} */
+                            strategy: "all_at_once";
+                        } | {
+                            /** @enum {string} */
+                            strategy: "gradual";
+                            batchPercentage: number;
+                            /** @enum {string} */
+                            interval: "minute" | "hour";
+                        };
                     };
                 };
             };
@@ -1629,6 +1639,15 @@ export interface paths {
                             scheduledAt: string | null;
                             batchSize: number;
                             batchWindowMinutes: number;
+                            /** @enum {string} */
+                            deliveryMode: "ALL_AT_ONCE" | "GRADUAL";
+                            deliveryBatchPercentage: number | null;
+                            deliveryIntervalMinutes: number | null;
+                            deliveryBatchSize: number | null;
+                            currentDeliveryBatch: number;
+                            deliveryBatchProcessed: number;
+                            /** Format: date-time */
+                            nextDeliveryAt: string | null;
                             total: number;
                             sent: number;
                             delivered: number;
@@ -1694,6 +1713,15 @@ export interface paths {
                             scheduledAt: string | null;
                             batchSize: number;
                             batchWindowMinutes: number;
+                            /** @enum {string} */
+                            deliveryMode: "ALL_AT_ONCE" | "GRADUAL";
+                            deliveryBatchPercentage: number | null;
+                            deliveryIntervalMinutes: number | null;
+                            deliveryBatchSize: number | null;
+                            currentDeliveryBatch: number;
+                            deliveryBatchProcessed: number;
+                            /** Format: date-time */
+                            nextDeliveryAt: string | null;
                             total: number;
                             sent: number;
                             delivered: number;
@@ -1748,6 +1776,15 @@ export interface paths {
                             scheduledAt: string | null;
                             batchSize: number;
                             batchWindowMinutes: number;
+                            /** @enum {string} */
+                            deliveryMode: "ALL_AT_ONCE" | "GRADUAL";
+                            deliveryBatchPercentage: number | null;
+                            deliveryIntervalMinutes: number | null;
+                            deliveryBatchSize: number | null;
+                            currentDeliveryBatch: number;
+                            deliveryBatchProcessed: number;
+                            /** Format: date-time */
+                            nextDeliveryAt: string | null;
                             total: number;
                             sent: number;
                             delivered: number;
@@ -1798,6 +1835,16 @@ export interface paths {
                         /** @description Timestamp in ISO 8601 format or natural language (e.g., 'tomorrow 9am', 'next monday 10:30') */
                         scheduledAt?: string;
                         batchSize?: number;
+                        delivery?: {
+                            /** @enum {string} */
+                            strategy: "all_at_once";
+                        } | {
+                            /** @enum {string} */
+                            strategy: "gradual";
+                            batchPercentage: number;
+                            /** @enum {string} */
+                            interval: "minute" | "hour";
+                        };
                     };
                 };
             };


### PR DESCRIPTION
Closes #389

## Summary

- add gradual campaign delivery alongside the existing all-at-once mode
- let users configure a batch percentage and delivery interval from the dashboard and public API
- snapshot campaign recipients and process them in deterministic, retry-safe delivery waves
- support pausing and resuming gradual campaigns without releasing a due batch while paused
- show live processed, pending, suppressed, skipped, and failed recipient progress
- expose the new scheduling fields through the OpenAPI schema, JavaScript types, and Python SDK

## Impact

Campaign senders can throttle large sends into predictable waves instead of queueing the entire audience at once. Existing campaigns retain all-at-once behavior by default.

This implements fixed-percentage interval throttling and the underlying resumable delivery path. Adaptive ramp-up strategies and daily-volume caps are outside this initial scope.

## Screenshots
<img width="1580" height="1111" alt="Scheduling Dialog" src="https://github.com/user-attachments/assets/bf3df732-ee30-4fd5-9c9a-9855c7afc40f" />
<img width="711" height="400" alt="Completed Sumary" src="https://github.com/user-attachments/assets/b832ee55-3868-4a95-a052-809bb0761fe8" />



## Migrations

- add delivery mode, scheduling, progress, pause, and audience-preparation fields
- add per-recipient campaign delivery state and timestamps
- preserve existing campaign behavior with `ALL_AT_ONCE` and treat existing campaign recipients as already queued
- add the high-traffic `Email(campaignId, latestStatus)` index in a separate one-statement migration using `CREATE INDEX CONCURRENTLY`

Both feature migrations were deployed successfully from an empty PostgreSQL database as part of the integration test run.

## Verification

- `pnpm test:web` — 181 tests passed
- `pnpm test:web:integration:full` — all 43 migrations applied from an empty database and 11 integration tests passed
- `pnpm --filter=web typecheck`
- focused ESLint with zero warnings on all changed web TypeScript files
- Prettier check on changed source files
- Python SDK tests — 9 passed
- `pnpm build` — all workspace builds passed
- `git diff --check`

## Manual QA

- scheduled a four-recipient campaign at 50% per minute
- verified the first two recipients were processed as one wave
- paused the campaign and confirmed the due second wave remained held
- resumed the campaign and confirmed the remaining two recipients were processed
- verified the completed campaign reported two batches and four processed recipients



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds gradual campaign delivery with fixed-percentage batches on minute/hour intervals, plus pause/resume, scheduling previews, and live progress. Keeps existing campaigns all at once by default and exposes settings in the dashboard and Public API.

- **New Features**
  - Choose All at once or Gradual (x% per minute/hour) when scheduling; available in the dashboard and Public API, with OpenAPI, TypeScript SDK types, and Python SDK updated.
  - Deterministic, retry-safe waves with per-recipient statuses (pending, processing, queued, suppressed, skipped, failed); pausing holds due batches until resume.
  - Scheduler enqueues waves on schedule, updates next-delivery, and honors batch windows; campaign page shows progress, and the scheduling dialog previews batch timing and completion.

- **Migration**
  - Adds delivery mode and scheduling fields to Campaign; adds status and processedAt to CampaignEmail and makes emailId nullable; existing rows default to `ALL_AT_ONCE`.
  - Adds concurrent indexes: CampaignEmail(campaignId, status, contactId), Campaign(status, nextDeliveryAt), Email(campaignId, latestStatus). Run Prisma migrations as usual.

<sup>Written for commit db0a28b6481d38650e788e23a0326cd88de76f4d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usesend/useSend/pull/436?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added campaign delivery modes: **All at once** or **Gradual** batching.
  * Gradual delivery supports **batch percentage (1–50)** and **interval** (minutes or hours), including estimated completion and next scheduled delivery time.
  * Added campaign delivery progress/batch status visibility in the campaign details view.
  * API, web UI, and Python SDK now support creating and scheduling campaigns with delivery configuration.
  * Added campaign delivery analytics endpoints for audience size and live delivery progress.
* **Improvements**
  * Improved scheduler handling for gradual waves and added delivery-aware pause/resume behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->