### PR TITLE
Feat/mailer smtp provider

### DIFF
--- a/apps/web/src/env.js
+++ b/apps/web/src/env.js
@@ -75,6 +75,12 @@ export const env = createEnv({
         .string()
         .optional()
         .transform((str) => (str ? parseInt(str, 10) : undefined)),
+    MAILER_PROVIDER: z.enum(["ses", "smtp", "usesend"]).optional(),
+    MAILER_SMTP_HOST: z.string().optional(),
+    MAILER_SMTP_PORT: z.string().optional(),
+    MAILER_SMTP_USER: z.string().optional(),
+    MAILER_SMTP_PASS: z.string().optional(),
+    MAILER_SMTP_SECURE: z.string().optional(),
   },
 
   /**
@@ -137,6 +143,12 @@ export const env = createEnv({
     SMTP_USER: process.env.SMTP_USER,
     CONTACT_BOOK_ID: process.env.CONTACT_BOOK_ID,
     EMAIL_CLEANUP_DAYS: process.env.EMAIL_CLEANUP_DAYS,
+    MAILER_PROVIDER: process.env.MAILER_PROVIDER,
+    MAILER_SMTP_HOST: process.env.MAILER_SMTP_HOST,
+    MAILER_SMTP_PORT: process.env.MAILER_SMTP_PORT,
+    MAILER_SMTP_USER: process.env.MAILER_SMTP_USER,
+    MAILER_SMTP_PASS: process.env.MAILER_SMTP_PASS,
+    MAILER_SMTP_SECURE: process.env.MAILER_SMTP_SECURE,
   },
   /**
    * Run `build` or `dev` with `SKIP_ENV_VALIDATION` to skip env validation. This is especially

--- a/apps/web/src/server/aws/ses.ts
+++ b/apps/web/src/server/aws/ses.ts
@@ -44,7 +44,7 @@ async function getIdentityArn(domain: string, region: string) {
   return `arn:aws:ses:${region}:${accountId}:identity/${domain}`;
 }
 
-function getSesClient(region: string) {
+export function getSesClient(region: string) {
   return new SESv2Client({
     region: region,
     endpoint: env.AWS_SES_ENDPOINT,

--- a/apps/web/src/server/mailer.ts
+++ b/apps/web/src/server/mailer.ts
@@ -1,20 +1,7 @@
 import { env } from "~/env";
-import { UseSend } from "usesend-js";
-import { isSelfHosted } from "~/utils/common";
-import { db } from "./db";
-import { getDomains } from "./service/domain-service";
-import { sendEmail } from "./service/email-service";
 import { logger } from "./logger/log";
 import { renderOtpEmail, renderTeamInviteEmail } from "./email-templates";
-
-let usesend: UseSend | undefined;
-
-const getClient = () => {
-  if (!usesend) {
-    usesend = new UseSend(env.USESEND_API_KEY ?? env.UNSEND_API_KEY);
-  }
-  return usesend;
-};
+import { getMailerTransport } from "./mailer/providers/resolve";
 
 export async function sendSignUpEmail(
   email: string,
@@ -90,69 +77,12 @@ export async function sendMail(
   replyTo?: string,
   fromOverride?: string
 ) {
-  if (isSelfHosted()) {
-    logger.info("Sending email using self hosted");
-    /* 
-      Self hosted so checking if we can send using one of the available domain
-      Assuming self hosted will have only one team
-      TODO: fix this
-     */
-    const team = await db.team.findFirst({});
-    if (!team) {
-      logger.error("No team found");
-      return;
-    }
-
-    const domains = await getDomains(team.id);
-
-    if (domains.length === 0 || !domains[0]) {
-      logger.error("No domains found");
-      return;
-    }
-
-    const availableDomains = domains.map((d) => d.name);
-    const domain = domains[0];
-
-    const candidateFroms = [fromOverride, env.FROM_EMAIL, `hello@${domain.name}`].filter(
-      (value): value is string => Boolean(value)
-    );
-
-    const selectedFrom =
-      candidateFroms.find((address) => {
-        const domainPart = address.split("@")[1];
-        return domainPart ? availableDomains.includes(domainPart) : false;
-      }) ?? `hello@${domain.name}`;
-
-    await sendEmail({
-      teamId: team.id,
-      to: email,
-      from: selectedFrom,
-      subject,
-      text,
-      html,
-      replyTo,
-    });
-  } else if (env.UNSEND_API_KEY && (env.FROM_EMAIL || fromOverride)) {
-    const fromAddress = fromOverride ?? env.FROM_EMAIL!;
-    const resp = await getClient().emails.send({
-      to: email,
-      from: fromAddress,
-      subject,
-      text,
-      html,
-      replyTo,
-    });
-
-    if (resp.data) {
-      logger.info("Email sent using usesend");
-      return;
-    } else {
-      logger.error(
-        { code: resp.error?.code, message: resp.error?.message },
-        "Error sending email using usesend"
-      );
-    }
-  } else {
-    throw new Error("USESEND_API_KEY/UNSEND_API_KEY not found");
-  }
+  await getMailerTransport().send({
+    to: email,
+    subject,
+    text,
+    html,
+    replyTo,
+    fromOverride,
+  });
 }

--- a/apps/web/src/server/mailer.unit.test.ts
+++ b/apps/web/src/server/mailer.unit.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockTransport,
+  mockGetMailerTransport,
+  mockRenderOtp,
+  mockRenderInvite,
+  mockEnv,
+  mockLogger,
+} = vi.hoisted(() => ({
+  mockTransport: { send: vi.fn() },
+  mockGetMailerTransport: vi.fn(() => mockTransport),
+  mockRenderOtp: vi.fn(),
+  mockRenderInvite: vi.fn(),
+  mockEnv: {
+    NODE_ENV: "test",
+    FOUNDER_EMAIL: "founder@example.com",
+    FROM_EMAIL: "hello@example.com",
+  } as Record<string, string | undefined>,
+  mockLogger: { info: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("~/server/mailer/providers/resolve", () => ({
+  getMailerTransport: mockGetMailerTransport,
+}));
+vi.mock("~/server/email-templates", () => ({
+  renderOtpEmail: mockRenderOtp,
+  renderTeamInviteEmail: mockRenderInvite,
+}));
+vi.mock("~/env", () => ({
+  env: new Proxy({}, { get: (_t, k) => mockEnv[k as string] }),
+}));
+vi.mock("~/server/logger/log", () => ({ logger: mockLogger }));
+
+import {
+  sendMail,
+  sendSignUpEmail,
+  sendSubscriptionConfirmationEmail,
+} from "~/server/mailer";
+
+describe("mailer", () => {
+  beforeEach(() => {
+    mockTransport.send.mockReset();
+    mockGetMailerTransport.mockClear();
+    mockRenderOtp.mockReset();
+    mockRenderInvite.mockReset();
+  });
+
+  it("sendMail delegates to the resolved transport", async () => {
+    await sendMail("to@x.com", "s", "t", "h", "r@x.com", "from@x.com");
+
+    expect(mockTransport.send).toHaveBeenCalledWith({
+      to: "to@x.com",
+      subject: "s",
+      text: "t",
+      html: "h",
+      replyTo: "r@x.com",
+      fromOverride: "from@x.com",
+    });
+  });
+
+  it("sendSignUpEmail renders OTP and sends via transport", async () => {
+    mockRenderOtp.mockResolvedValue("<p>otp</p>");
+
+    await sendSignUpEmail("to@x.com", "ABCDE", "https://app.example.com/verify");
+
+    expect(mockRenderOtp).toHaveBeenCalled();
+    expect(mockTransport.send).toHaveBeenCalledTimes(1);
+    expect(mockTransport.send.mock.calls[0]?.[0].to).toBe("to@x.com");
+  });
+
+  it("sendSubscriptionConfirmationEmail sends with founder fromOverride", async () => {
+    await sendSubscriptionConfirmationEmail("sub@x.com");
+
+    expect(mockTransport.send).toHaveBeenCalledTimes(1);
+    expect(mockTransport.send.mock.calls[0]?.[0].fromOverride).toBe(
+      "founder@example.com",
+    );
+  });
+});

--- a/apps/web/src/server/mailer/providers/legacy-ses.ts
+++ b/apps/web/src/server/mailer/providers/legacy-ses.ts
@@ -1,0 +1,60 @@
+import { env } from "~/env";
+import { db } from "~/server/db";
+import { getDomains } from "~/server/service/domain-service";
+import { sendEmail } from "~/server/service/email-service";
+import { logger } from "~/server/logger/log";
+import type { MailerSendOptions, MailerTransport } from "./types";
+
+export class LegacySesTransport implements MailerTransport {
+  async send({
+    to,
+    subject,
+    text,
+    html,
+    replyTo,
+    fromOverride,
+  }: MailerSendOptions): Promise<void> {
+    logger.info("Sending email using self hosted");
+    /*
+      Self hosted so checking if we can send using one of the available domain
+      Assuming self hosted will have only one team
+    */
+    const team = await db.team.findFirst({});
+    if (!team) {
+      logger.error("No team found");
+      return;
+    }
+
+    const domains = await getDomains(team.id);
+
+    if (domains.length === 0 || !domains[0]) {
+      logger.error("No domains found");
+      return;
+    }
+
+    const availableDomains = domains.map((d) => d.name);
+    const domain = domains[0];
+
+    const candidateFroms = [
+      fromOverride,
+      env.FROM_EMAIL,
+      `hello@${domain.name}`,
+    ].filter((value): value is string => Boolean(value));
+
+    const selectedFrom =
+      candidateFroms.find((address) => {
+        const domainPart = address.split("@")[1];
+        return domainPart ? availableDomains.includes(domainPart) : false;
+      }) ?? `hello@${domain.name}`;
+
+    await sendEmail({
+      teamId: team.id,
+      to,
+      from: selectedFrom,
+      subject,
+      text,
+      html,
+      replyTo,
+    });
+  }
+}

--- a/apps/web/src/server/mailer/providers/legacy-ses.unit.test.ts
+++ b/apps/web/src/server/mailer/providers/legacy-ses.unit.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockDb, mockGetDomains, mockSendEmail, mockLogger, mockEnv } =
+  vi.hoisted(() => ({
+    mockDb: { team: { findFirst: vi.fn() } },
+    mockGetDomains: vi.fn(),
+    mockSendEmail: vi.fn(),
+    mockLogger: { info: vi.fn(), error: vi.fn() },
+    mockEnv: { FROM_EMAIL: "hello@example.com" } as Record<
+      string,
+      string | undefined
+    >,
+  }));
+
+vi.mock("~/server/db", () => ({ db: mockDb }));
+vi.mock("~/server/service/domain-service", () => ({
+  getDomains: mockGetDomains,
+}));
+vi.mock("~/server/service/email-service", () => ({ sendEmail: mockSendEmail }));
+vi.mock("~/server/logger/log", () => ({ logger: mockLogger }));
+vi.mock("~/env", () => ({
+  env: new Proxy(
+    {},
+    { get: (_t, k) => mockEnv[k as string] },
+  ),
+}));
+
+import { LegacySesTransport } from "~/server/mailer/providers/legacy-ses";
+
+describe("LegacySesTransport", () => {
+  beforeEach(() => {
+    mockDb.team.findFirst.mockReset();
+    mockGetDomains.mockReset();
+    mockSendEmail.mockReset();
+    mockLogger.info.mockReset();
+    mockLogger.error.mockReset();
+    mockEnv.FROM_EMAIL = "hello@example.com";
+  });
+
+  it("returns without sending when no team exists", async () => {
+    mockDb.team.findFirst.mockResolvedValue(null);
+
+    await new LegacySesTransport().send({
+      to: "to@x.com",
+      subject: "s",
+      text: "t",
+      html: "h",
+    });
+
+    expect(mockSendEmail).not.toHaveBeenCalled();
+    expect(mockLogger.error).toHaveBeenCalledWith("No team found");
+  });
+
+  it("returns without sending when no domains exist", async () => {
+    mockDb.team.findFirst.mockResolvedValue({ id: 7 });
+    mockGetDomains.mockResolvedValue([]);
+
+    await new LegacySesTransport().send({
+      to: "to@x.com",
+      subject: "s",
+      text: "t",
+      html: "h",
+    });
+
+    expect(mockSendEmail).not.toHaveBeenCalled();
+    expect(mockLogger.error).toHaveBeenCalledWith("No domains found");
+  });
+
+  it("sends via sendEmail with domain-matched from", async () => {
+    mockDb.team.findFirst.mockResolvedValue({ id: 7 });
+    mockGetDomains.mockResolvedValue([{ name: "example.com" }]);
+    mockSendEmail.mockResolvedValue({});
+
+    await new LegacySesTransport().send({
+      to: "to@x.com",
+      subject: "s",
+      text: "t",
+      html: "h",
+    });
+
+    expect(mockSendEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        teamId: 7,
+        to: "to@x.com",
+        from: "hello@example.com",
+      }),
+    );
+  });
+});

--- a/apps/web/src/server/mailer/providers/resolve.ts
+++ b/apps/web/src/server/mailer/providers/resolve.ts
@@ -1,0 +1,84 @@
+import nodemailer from "nodemailer";
+import { UseSend } from "usesend-js";
+import { env } from "~/env";
+import { getSesClient } from "~/server/aws/ses";
+import { SesMailerTransport } from "./ses";
+import { SmtpMailerTransport } from "./smtp";
+import { UseSendMailerTransport } from "./usesend";
+import { LegacySesTransport } from "./legacy-ses";
+import type { MailerTransport } from "./types";
+
+export function resolveMailerTransport(
+  provider: string | undefined,
+  isCloud: boolean,
+): MailerTransport {
+  if (provider === "ses") {
+    return new SesMailerTransport({
+      getSesClient,
+      createTransport: nodemailer.createTransport,
+      region: env.AWS_DEFAULT_REGION,
+      fromDefault: env.FROM_EMAIL,
+    });
+  }
+
+  if (provider === "smtp") {
+    if (!env.MAILER_SMTP_HOST || !env.MAILER_SMTP_USER || !env.MAILER_SMTP_PASS) {
+      throw new Error(
+        "MAILER_PROVIDER=smtp requires MAILER_SMTP_HOST, MAILER_SMTP_USER, MAILER_SMTP_PASS",
+      );
+    }
+    const port = env.MAILER_SMTP_PORT ? Number(env.MAILER_SMTP_PORT) : 587;
+    const secure = env.MAILER_SMTP_SECURE === "true" || port === 465;
+    return new SmtpMailerTransport({
+      createTransport: nodemailer.createTransport,
+      host: env.MAILER_SMTP_HOST,
+      port,
+      secure,
+      user: env.MAILER_SMTP_USER,
+      pass: env.MAILER_SMTP_PASS,
+      fromDefault: env.FROM_EMAIL,
+    });
+  }
+
+  if (provider === "usesend") {
+    const apiKey = env.USESEND_API_KEY ?? env.UNSEND_API_KEY;
+    if (!apiKey) {
+      throw new Error(
+        "MAILER_PROVIDER=usesend requires USESEND_API_KEY or UNSEND_API_KEY",
+      );
+    }
+    return new UseSendMailerTransport({
+      client: new UseSend(apiKey),
+      fromDefault: env.FROM_EMAIL,
+    });
+  }
+
+  // MAILER_PROVIDER unset -> backward-compatible default
+  if (!isCloud) {
+    return new LegacySesTransport();
+  }
+
+  const apiKey = env.USESEND_API_KEY ?? env.UNSEND_API_KEY;
+  if (!apiKey) {
+    throw new Error(
+      "MAILER_PROVIDER=usesend requires USESEND_API_KEY or UNSEND_API_KEY",
+    );
+  }
+  return new UseSendMailerTransport({
+    client: new UseSend(apiKey),
+    fromDefault: env.FROM_EMAIL,
+  });
+}
+
+let cached: MailerTransport | undefined;
+
+export function getMailerTransport(): MailerTransport {
+  if (!cached) {
+    cached = resolveMailerTransport(env.MAILER_PROVIDER, env.NEXT_PUBLIC_IS_CLOUD);
+  }
+  return cached;
+}
+
+export function __resetMailerTransportForTests(): void {
+  cached = undefined;
+}

--- a/apps/web/src/server/mailer/providers/resolve.unit.test.ts
+++ b/apps/web/src/server/mailer/providers/resolve.unit.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockEnv,
+  SesMailerTransport,
+  SmtpMailerTransport,
+  UseSendMailerTransport,
+  LegacySesTransport,
+  mockGetSesClient,
+  mockCreateTransport,
+  MockUseSend,
+} = vi.hoisted(() => ({
+  mockEnv: {} as Record<string, string | boolean | undefined>,
+  SesMailerTransport: vi.fn(),
+  SmtpMailerTransport: vi.fn(),
+  UseSendMailerTransport: vi.fn(),
+  LegacySesTransport: vi.fn(),
+  mockGetSesClient: vi.fn(),
+  mockCreateTransport: vi.fn(),
+  MockUseSend: vi.fn(),
+}));
+
+vi.mock("~/env", () => ({
+  env: new Proxy({}, { get: (_t, k) => mockEnv[k as string] }),
+}));
+vi.mock("~/server/aws/ses", () => ({ getSesClient: mockGetSesClient }));
+vi.mock("nodemailer", () => ({ default: { createTransport: mockCreateTransport } }));
+vi.mock("usesend-js", () => ({ UseSend: MockUseSend }));
+vi.mock("~/server/mailer/providers/ses", () => ({ SesMailerTransport }));
+vi.mock("~/server/mailer/providers/smtp", () => ({ SmtpMailerTransport }));
+vi.mock("~/server/mailer/providers/usesend", () => ({
+  UseSendMailerTransport,
+}));
+vi.mock("~/server/mailer/providers/legacy-ses", () => ({ LegacySesTransport }));
+
+import { resolveMailerTransport } from "~/server/mailer/providers/resolve";
+
+beforeEach(() => {
+  SesMailerTransport.mockClear();
+  SmtpMailerTransport.mockClear();
+  UseSendMailerTransport.mockClear();
+  LegacySesTransport.mockClear();
+  MockUseSend.mockClear();
+  for (const k of Object.keys(mockEnv)) delete mockEnv[k];
+  mockEnv.AWS_DEFAULT_REGION = "us-east-1";
+  mockEnv.FROM_EMAIL = "hello@example.com";
+});
+
+describe("resolveMailerTransport", () => {
+  it("returns SesMailerTransport for provider=ses", () => {
+    resolveMailerTransport("ses", true);
+    expect(SesMailerTransport).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns SmtpMailerTransport for provider=smtp with creds and secure port", () => {
+    mockEnv.MAILER_SMTP_HOST = "smtp.example.com";
+    mockEnv.MAILER_SMTP_USER = "u";
+    mockEnv.MAILER_SMTP_PASS = "p";
+    mockEnv.MAILER_SMTP_PORT = "465";
+
+    resolveMailerTransport("smtp", true);
+
+    expect(SmtpMailerTransport).toHaveBeenCalledWith(
+      expect.objectContaining({
+        host: "smtp.example.com",
+        port: 465,
+        secure: true,
+        user: "u",
+        pass: "p",
+      }),
+    );
+  });
+
+  it("defaults smtp port to 587 and secure false when not 465", () => {
+    mockEnv.MAILER_SMTP_HOST = "h";
+    mockEnv.MAILER_SMTP_USER = "u";
+    mockEnv.MAILER_SMTP_PASS = "p";
+
+    resolveMailerTransport("smtp", true);
+
+    expect(SmtpMailerTransport).toHaveBeenCalledWith(
+      expect.objectContaining({ port: 587, secure: false }),
+    );
+  });
+
+  it("throws for provider=smtp missing creds", () => {
+    expect(() => resolveMailerTransport("smtp", true)).toThrow(/MAILER_SMTP_HOST/);
+  });
+
+  it("returns UseSendMailerTransport for provider=usesend with key", () => {
+    mockEnv.UNSEND_API_KEY = "key";
+
+    resolveMailerTransport("usesend", true);
+
+    expect(MockUseSend).toHaveBeenCalledWith("key");
+    expect(UseSendMailerTransport).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws for provider=usesend missing key", () => {
+    expect(() => resolveMailerTransport("usesend", true)).toThrow(/USESEND_API_KEY/);
+  });
+
+  it("returns LegacySesTransport when unset and self-hosted", () => {
+    resolveMailerTransport(undefined, false);
+    expect(LegacySesTransport).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns UseSendMailerTransport when unset and cloud with key", () => {
+    mockEnv.UNSEND_API_KEY = "key";
+    resolveMailerTransport(undefined, true);
+    expect(UseSendMailerTransport).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws when unset, cloud, and no useSend key", () => {
+    expect(() => resolveMailerTransport(undefined, true)).toThrow(/USESEND_API_KEY/);
+  });
+});

--- a/apps/web/src/server/mailer/providers/ses.ts
+++ b/apps/web/src/server/mailer/providers/ses.ts
@@ -1,0 +1,54 @@
+import { SendEmailCommand } from "@aws-sdk/client-sesv2";
+import type { MailerSendOptions, MailerTransport } from "./types";
+
+interface SesSender {
+  send(command: SendEmailCommand): Promise<unknown>;
+}
+
+interface SesMailerConfig {
+  getSesClient: (region: string) => SesSender;
+  createTransport: (opts: { streamTransport: boolean }) => {
+    sendMail: (mail: {
+      from: string;
+      to: string;
+      subject: string;
+      text: string;
+      html: string;
+      replyTo?: string;
+    }) => Promise<{ message: AsyncIterable<Buffer | string> }>;
+  };
+  region: string;
+  fromDefault?: string;
+}
+
+export class SesMailerTransport implements MailerTransport {
+  constructor(private readonly cfg: SesMailerConfig) {}
+
+  async send({
+    to,
+    subject,
+    text,
+    html,
+    replyTo,
+    fromOverride,
+  }: MailerSendOptions): Promise<void> {
+    const from = fromOverride ?? this.cfg.fromDefault;
+    if (!from) {
+      throw new Error("FROM_EMAIL is required for mailer");
+    }
+
+    const { message } = await this.cfg
+      .createTransport({ streamTransport: true })
+      .sendMail({ from, to, subject, text, html, replyTo });
+
+    const chunks: Buffer[] = [];
+    for await (const chunk of message) {
+      chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
+    }
+    const data = Buffer.concat(chunks);
+
+    await this.cfg
+      .getSesClient(this.cfg.region)
+      .send(new SendEmailCommand({ Content: { Raw: { Data: data } } }));
+  }
+}

--- a/apps/web/src/server/mailer/providers/ses.unit.test.ts
+++ b/apps/web/src/server/mailer/providers/ses.unit.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from "vitest";
+import { SendEmailCommand } from "@aws-sdk/client-sesv2";
+import { SesMailerTransport } from "~/server/mailer/providers/ses";
+
+function fakeMessage(...chunks: Buffer[]) {
+  return {
+    async *[Symbol.asyncIterator]() {
+      for (const c of chunks) yield c;
+    },
+  };
+}
+
+describe("SesMailerTransport", () => {
+  it("sends raw email via SES client with resolved from", async () => {
+    const send = vi.fn().mockResolvedValue({});
+    const getSesClient = vi.fn(() => ({ send }));
+    const sendMail = vi
+      .fn()
+      .mockResolvedValue({ message: fakeMessage(Buffer.from("RAW")) });
+    const createTransport = vi.fn(() => ({ sendMail }));
+
+    const transport = new SesMailerTransport({
+      getSesClient,
+      createTransport,
+      region: "us-east-1",
+      fromDefault: "hello@example.com",
+    });
+
+    await transport.send({
+      to: "to@x.com",
+      subject: "s",
+      text: "t",
+      html: "<b>h</b>",
+    });
+
+    expect(createTransport).toHaveBeenCalledWith({ streamTransport: true });
+    expect(sendMail).toHaveBeenCalledWith(
+      expect.objectContaining({ from: "hello@example.com", to: "to@x.com" }),
+    );
+    expect(getSesClient).toHaveBeenCalledWith("us-east-1");
+    expect(send).toHaveBeenCalledTimes(1);
+    const command = send.mock.calls[0]?.[0];
+    expect(command).toBeInstanceOf(SendEmailCommand);
+    expect((command as SendEmailCommand).input.Content?.Raw?.Data).toBeInstanceOf(
+      Buffer,
+    );
+  });
+
+  it("uses fromOverride when provided", async () => {
+    const sendMail = vi
+      .fn()
+      .mockResolvedValue({ message: fakeMessage(Buffer.from("R")) });
+    const transport = new SesMailerTransport({
+      getSesClient: () => ({ send: vi.fn().mockResolvedValue({}) }),
+      createTransport: () => ({ sendMail }),
+      region: "us-east-1",
+      fromDefault: "hello@example.com",
+    });
+
+    await transport.send({
+      to: "to@x.com",
+      subject: "s",
+      text: "t",
+      html: "h",
+      fromOverride: "other@example.com",
+    });
+
+    expect(sendMail).toHaveBeenCalledWith(
+      expect.objectContaining({ from: "other@example.com" }),
+    );
+  });
+
+  it("throws when no from address is available", async () => {
+    const transport = new SesMailerTransport({
+      getSesClient: () => ({ send: vi.fn() }),
+      createTransport: () => ({ sendMail: vi.fn() }),
+      region: "us-east-1",
+    });
+
+    await expect(
+      transport.send({ to: "to@x.com", subject: "s", text: "t", html: "h" }),
+    ).rejects.toThrow("FROM_EMAIL is required for mailer");
+  });
+});

--- a/apps/web/src/server/mailer/providers/smtp.ts
+++ b/apps/web/src/server/mailer/providers/smtp.ts
@@ -1,0 +1,55 @@
+import type { MailerSendOptions, MailerTransport } from "./types";
+
+interface SmtpTransporter {
+  sendMail(mail: {
+    from: string;
+    to: string;
+    subject: string;
+    text: string;
+    html: string;
+    replyTo?: string;
+  }): Promise<unknown>;
+}
+
+interface SmtpMailerConfig {
+  createTransport: (opts: {
+    host: string;
+    port: number;
+    secure: boolean;
+    auth?: { user: string; pass: string };
+  }) => SmtpTransporter;
+  host: string;
+  port: number;
+  secure: boolean;
+  user?: string;
+  pass?: string;
+  fromDefault?: string;
+}
+
+export class SmtpMailerTransport implements MailerTransport {
+  private readonly transporter: SmtpTransporter;
+
+  constructor(private readonly cfg: SmtpMailerConfig) {
+    this.transporter = cfg.createTransport({
+      host: cfg.host,
+      port: cfg.port,
+      secure: cfg.secure,
+      auth: cfg.user ? { user: cfg.user, pass: cfg.pass ?? "" } : undefined,
+    });
+  }
+
+  async send({
+    to,
+    subject,
+    text,
+    html,
+    replyTo,
+    fromOverride,
+  }: MailerSendOptions): Promise<void> {
+    const from = fromOverride ?? this.cfg.fromDefault;
+    if (!from) {
+      throw new Error("FROM_EMAIL is required for mailer");
+    }
+    await this.transporter.sendMail({ from, to, subject, text, html, replyTo });
+  }
+}

--- a/apps/web/src/server/mailer/providers/smtp.unit.test.ts
+++ b/apps/web/src/server/mailer/providers/smtp.unit.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from "vitest";
+import { SmtpMailerTransport } from "~/server/mailer/providers/smtp";
+
+describe("SmtpMailerTransport", () => {
+  it("creates transport with host/port/secure/auth and sends", async () => {
+    const sendMail = vi.fn().mockResolvedValue({});
+    const createTransport = vi.fn(() => ({ sendMail }));
+
+    const transport = new SmtpMailerTransport({
+      createTransport,
+      host: "smtp.example.com",
+      port: 465,
+      secure: true,
+      user: "u",
+      pass: "p",
+      fromDefault: "hello@example.com",
+    });
+
+    await transport.send({ to: "to@x.com", subject: "s", text: "t", html: "h" });
+
+    expect(createTransport).toHaveBeenCalledWith({
+      host: "smtp.example.com",
+      port: 465,
+      secure: true,
+      auth: { user: "u", pass: "p" },
+    });
+    expect(sendMail).toHaveBeenCalledWith(
+      expect.objectContaining({ from: "hello@example.com", to: "to@x.com" }),
+    );
+  });
+
+  it("omits auth when no user provided", async () => {
+    const createTransport = vi.fn(() => ({
+      sendMail: vi.fn().mockResolvedValue({}),
+    }));
+
+    const transport = new SmtpMailerTransport({
+      createTransport,
+      host: "h",
+      port: 587,
+      secure: false,
+      fromDefault: "hello@example.com",
+    });
+
+    await transport.send({ to: "to@x.com", subject: "s", text: "t", html: "h" });
+
+    expect(createTransport).toHaveBeenCalledWith(
+      expect.objectContaining({ auth: undefined }),
+    );
+  });
+
+  it("throws when no from address is available", async () => {
+    const transport = new SmtpMailerTransport({
+      createTransport: () => ({ sendMail: vi.fn() }),
+      host: "h",
+      port: 587,
+      secure: false,
+    });
+
+    await expect(
+      transport.send({ to: "to@x.com", subject: "s", text: "t", html: "h" }),
+    ).rejects.toThrow("FROM_EMAIL is required for mailer");
+  });
+});

--- a/apps/web/src/server/mailer/providers/types.ts
+++ b/apps/web/src/server/mailer/providers/types.ts
@@ -1,0 +1,12 @@
+export interface MailerSendOptions {
+  to: string;
+  subject: string;
+  text: string;
+  html: string;
+  replyTo?: string;
+  fromOverride?: string;
+}
+
+export interface MailerTransport {
+  send(opts: MailerSendOptions): Promise<void>;
+}

--- a/apps/web/src/server/mailer/providers/usesend.ts
+++ b/apps/web/src/server/mailer/providers/usesend.ts
@@ -1,0 +1,55 @@
+import type { MailerSendOptions, MailerTransport } from "./types";
+
+interface UseSendSendResponse {
+  data?: unknown;
+  error?: { code?: string; message?: string };
+}
+
+interface UseSendMailerConfig {
+  client: {
+    emails: {
+      send: (args: {
+        to: string;
+        from: string;
+        subject: string;
+        text: string;
+        html: string;
+        replyTo?: string;
+      }) => Promise<UseSendSendResponse>;
+    };
+  };
+  fromDefault?: string;
+}
+
+export class UseSendMailerTransport implements MailerTransport {
+  constructor(private readonly cfg: UseSendMailerConfig) {}
+
+  async send({
+    to,
+    subject,
+    text,
+    html,
+    replyTo,
+    fromOverride,
+  }: MailerSendOptions): Promise<void> {
+    const from = fromOverride ?? this.cfg.fromDefault;
+    if (!from) {
+      throw new Error("FROM_EMAIL is required for mailer");
+    }
+
+    const resp = await this.cfg.client.emails.send({
+      to,
+      from,
+      subject,
+      text,
+      html,
+      replyTo,
+    });
+
+    if (!resp.data) {
+      throw new Error(
+        `useSend mailer failed: ${resp.error?.code ?? ""} ${resp.error?.message ?? ""}`.trim(),
+      );
+    }
+  }
+}

--- a/apps/web/src/server/mailer/providers/usesend.unit.test.ts
+++ b/apps/web/src/server/mailer/providers/usesend.unit.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from "vitest";
+import { UseSendMailerTransport } from "~/server/mailer/providers/usesend";
+
+describe("UseSendMailerTransport", () => {
+  it("sends via useSend client with resolved from", async () => {
+    const send = vi.fn().mockResolvedValue({ data: { id: "1" } });
+
+    const transport = new UseSendMailerTransport({
+      client: { emails: { send } },
+      fromDefault: "hello@example.com",
+    });
+
+    await transport.send({ to: "to@x.com", subject: "s", text: "t", html: "h" });
+
+    expect(send).toHaveBeenCalledWith(
+      expect.objectContaining({ to: "to@x.com", from: "hello@example.com" }),
+    );
+  });
+
+  it("throws on useSend failure with error details", async () => {
+    const send = vi.fn().mockResolvedValue({
+      error: { code: "ERR", message: "boom" },
+    });
+
+    const transport = new UseSendMailerTransport({
+      client: { emails: { send } },
+      fromDefault: "hello@example.com",
+    });
+
+    await expect(
+      transport.send({ to: "to@x.com", subject: "s", text: "t", html: "h" }),
+    ).rejects.toThrow(/boom/);
+  });
+
+  it("throws when no from address is available", async () => {
+    const transport = new UseSendMailerTransport({
+      client: { emails: { send: vi.fn() } },
+    });
+
+    await expect(
+      transport.send({ to: "to@x.com", subject: "s", text: "t", html: "h" }),
+    ).rejects.toThrow("FROM_EMAIL is required for mailer");
+  });
+});

--- a/docker/prod/.env.example-saas
+++ b/docker/prod/.env.example-saas
@@ -1,0 +1,148 @@
+#################################################
+# Application
+#################################################
+
+PORT=3000
+TZ=Asia/Jakarta
+
+NEXT_PUBLIC_IS_CLOUD=false
+
+#################################################
+# NextAuth
+#################################################
+
+NEXTAUTH_URL=https://mail.example.com
+NEXTAUTH_SECRET=replace-with-random-secret
+
+#################################################
+# Email Login (Magic Link / OTP)
+#################################################
+
+# Enables passwordless email login on the dashboard.
+# Use an address on a verified sending domain configured in-app
+# (self-hosted sends the OTP via the app's own SES pipeline, not SMTP_HOST).
+# Leave empty to disable email login and rely on OAuth providers only.
+FROM_EMAIL=hello@example.com
+
+#################################################
+# Mailer Provider (platform notifications)
+#################################################
+
+# Outbound transport for magic-link / invite / billing emails.
+# ses | smtp | usesend. Unset = backward-compatible default
+# (self-hosted -> SES via app domain; cloud -> useSend API).
+MAILER_PROVIDER=
+
+# Required only when MAILER_PROVIDER=smtp.
+# Uses the MAILER_SMTP_ prefix (NOT SMTP_HOST/SMTP_USER, which are the inbound tenant proxy).
+MAILER_SMTP_HOST=
+MAILER_SMTP_PORT=587
+MAILER_SMTP_USER=
+MAILER_SMTP_PASS=
+# "true" forces TLS; if unset, derived from port (465 = secure).
+MAILER_SMTP_SECURE=
+
+#################################################
+# Database (Neon PostgreSQL)
+#################################################
+
+DATABASE_URL=replace-with-your-postgresql-connection-string
+
+#################################################
+# Redis (Upstash)
+#################################################
+
+REDIS_URL=replace-with-your-redis-connection-string
+REDIS_KEY_PREFIX=usesend:
+
+#################################################
+# Amazon SES
+#################################################
+
+AWS_ACCESS_KEY_ID=AKIAXXXXXXXXXXXXX
+AWS_SECRET_ACCESS_KEY=xxxxxxxxxxxxxxxxxxxxxxxx
+AWS_DEFAULT_REGION=ap-southeast-1
+
+#################################################
+# Cloudflare R2
+#################################################
+
+S3_COMPATIBLE_API_URL=https://<ACCOUNT_ID>.r2.cloudflarestorage.com
+
+S3_COMPATIBLE_ACCESS_KEY=xxxxxxxxxxxxxxxx
+
+S3_COMPATIBLE_SECRET_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+S3_COMPATIBLE_BUCKET=usesend
+
+# CDN / Public URL
+# contoh:
+# https://cdn.example.com
+# atau
+# https://pub-xxxxxxxx.r2.dev
+
+S3_COMPATIBLE_PUBLIC_URL=https://cdn.example.com
+
+#################################################
+# GitHub OAuth
+#################################################
+
+GITHUB_ID=xxxxxxxxxxxxxxxx
+GITHUB_SECRET=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+#################################################
+# Google OAuth (optional)
+#################################################
+
+# Optional — enables Google login. Leave empty to disable.
+# Add the redirect URL below to your Google Cloud Console (Authorized redirect URIs):
+# https://mail.example.com/api/auth/callback/google
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+
+#################################################
+# SMTP Proxy
+#################################################
+
+SMTP_USER=usesend
+
+#################################################
+# API & Rate Limits
+#################################################
+
+API_RATE_LIMIT=1
+
+# Max magic-link/OTP login requests per IP per 60s (0 = unlimited).
+# Recommended when email login is enabled to prevent abuse.
+AUTH_EMAIL_RATE_LIMIT=5
+
+#################################################
+# Admin, Notifications & Maintenance
+#################################################
+
+# Email of the dashboard admin (user with this email becomes isAdmin).
+ADMIN_EMAIL=admin@example.com
+
+# Founder email for waitlist/feedback/subscription notifications (optional).
+FOUNDER_EMAIL=
+
+# Discord webhook for error notifications (optional).
+DISCORD_WEBHOOK_URL=
+
+# Self-hosted only: daily job nulls text/html of emails older than N days.
+# Disabled when unset or 0. Useful to keep the database from growing.
+EMAIL_CLEANUP_DAYS=30
+
+#################################################
+# Build-time only (NOT read at runtime for prebuilt images)
+#################################################
+
+# SKIP_ENV_VALIDATION=true is only used when building the Docker image yourself,
+# to skip env validation during build. Do NOT set it at runtime for this compose
+# (it would also skip validation at startup, hiding missing required vars).
+# SKIP_ENV_VALIDATION=true
+
+# NEXT_PUBLIC_* vars are inlined at build time. For the prebuilt usesend/usesend
+# image they have no effect at runtime, so set them only in custom builds.
+# NEXT_PUBLIC_APP_VERSION=
+# NEXT_PUBLIC_GIT_SHA=

--- a/docker/prod/compose.saas.yml
+++ b/docker/prod/compose.saas.yml
@@ -1,0 +1,144 @@
+name: usesend
+
+services:
+  usesend:
+    image: usesend/usesend:latest
+    container_name: usesend
+    restart: unless-stopped
+
+    ports:
+      - "${PORT:-3000}:3000"
+
+    environment:
+      #########################################
+      # Application
+      #########################################
+      PORT: 3000
+      NEXT_PUBLIC_IS_CLOUD: "false"
+
+      #########################################
+      # Authentication
+      #########################################
+      NEXTAUTH_URL: ${NEXTAUTH_URL}
+      NEXTAUTH_SECRET: ${NEXTAUTH_SECRET}
+      # Email (magic link / OTP) dashboard login — enabled when FROM_EMAIL is set.
+      # The address domain must match a verified sending domain configured in-app
+      # (self-hosted delivers the OTP via the app's own SES pipeline).
+      FROM_EMAIL: ${FROM_EMAIL}
+
+      #########################################
+      # Mailer Provider (platform notifications)
+      #########################################
+      # Outbound transport for magic-link / invite / billing emails: ses | smtp | usesend.
+      # Unset = backward-compatible default (self-hosted -> SES via app domain; cloud -> useSend API).
+      MAILER_PROVIDER: ${MAILER_PROVIDER}
+      # Required only when MAILER_PROVIDER=smtp. Uses the MAILER_SMTP_ prefix
+      # (NOT SMTP_HOST/SMTP_USER, which are the inbound tenant proxy).
+      MAILER_SMTP_HOST: ${MAILER_SMTP_HOST}
+      MAILER_SMTP_PORT: ${MAILER_SMTP_PORT}
+      MAILER_SMTP_USER: ${MAILER_SMTP_USER}
+      MAILER_SMTP_PASS: ${MAILER_SMTP_PASS}
+      # "true" forces TLS; if unset, derived from port (465 = secure).
+      MAILER_SMTP_SECURE: ${MAILER_SMTP_SECURE}
+
+      #########################################
+      # Database (Neon)
+      #########################################
+      DATABASE_URL: ${DATABASE_URL}
+
+      #########################################
+      # Redis (Upstash)
+      #########################################
+      REDIS_URL: ${REDIS_URL}
+      REDIS_KEY_PREFIX: ${REDIS_KEY_PREFIX}
+
+      #########################################
+      # Amazon SES
+      #########################################
+      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
+      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
+      AWS_DEFAULT_REGION: ${AWS_DEFAULT_REGION}
+
+      #########################################
+      # S3 Compatible Storage (Cloudflare R2)
+      #########################################
+      S3_COMPATIBLE_API_URL: ${S3_COMPATIBLE_API_URL}
+      S3_COMPATIBLE_ACCESS_KEY: ${S3_COMPATIBLE_ACCESS_KEY}
+      S3_COMPATIBLE_SECRET_KEY: ${S3_COMPATIBLE_SECRET_KEY}
+      S3_COMPATIBLE_BUCKET: ${S3_COMPATIBLE_BUCKET}
+      S3_COMPATIBLE_PUBLIC_URL: ${S3_COMPATIBLE_PUBLIC_URL}
+
+      #########################################
+      # OAuth Providers (at least one provider is required)
+      #########################################
+      GITHUB_ID: ${GITHUB_ID}
+      GITHUB_SECRET: ${GITHUB_SECRET}
+      GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID}
+      GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET}
+
+      #########################################
+      # SMTP Proxy
+      #########################################
+      SMTP_HOST: smtp
+      SMTP_USER: ${SMTP_USER}
+
+      #########################################
+      # API & Rate Limits
+      #########################################
+      API_RATE_LIMIT: ${API_RATE_LIMIT}
+      # Max magic-link/OTP requests per IP per 60s (0 = unlimited). Recommended when email login is on.
+      AUTH_EMAIL_RATE_LIMIT: ${AUTH_EMAIL_RATE_LIMIT}
+
+      #########################################
+      # Admin, Notifications & Maintenance
+      #########################################
+      # Email of the dashboard admin (isAdmin = user.email === ADMIN_EMAIL).
+      ADMIN_EMAIL: ${ADMIN_EMAIL}
+      # Founder email for waitlist/feedback/subscription notifications (optional).
+      FOUNDER_EMAIL: ${FOUNDER_EMAIL}
+      # Discord webhook for error notifications (optional).
+      DISCORD_WEBHOOK_URL: ${DISCORD_WEBHOOK_URL}
+      # Self-hosted only: daily job nulls text/html of emails older than N days (disabled if unset/0).
+      EMAIL_CLEANUP_DAYS: ${EMAIL_CLEANUP_DAYS}
+
+      #########################################
+      # Timezone
+      #########################################
+      TZ: ${TZ}
+
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://127.0.0.1:3000"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+
+    depends_on:
+      - smtp
+
+    networks:
+      - usesend
+
+  smtp:
+    image: usesend/smtp-proxy:latest
+    container_name: usesend-smtp
+    restart: unless-stopped
+
+    environment:
+      SMTP_AUTH_USERNAME: ${SMTP_USER}
+      USESEND_BASE_URL: http://usesend:3000
+      USESEND_API_KEY_PATH: "/certs/key.pem"
+      USESEND_API_CERT_PATH: "/certs/cert.pem"
+
+    volumes:
+      - /etc/letsencrypt/live/pintesia.com/key.pem:/certs/key.pem:ro
+      - /etc/letsencrypt/live/pintesia.com/cert.pem:/certs/cert.pem:ro
+    ports:
+      - "465:465"
+      - "587:587"
+
+    networks:
+      - usesend
+
+networks:
+  usesend:
+    driver: bridge

--- a/docs/superpowers/plans/2026-07-30-mailer-smtp-provider.md
+++ b/docs/superpowers/plans/2026-07-30-mailer-smtp-provider.md
@@ -1,0 +1,1287 @@
+# Mailer Provider Abstraction + Outbound SMTP Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an outbound SMTP transport and an env-driven direct SES transport to `mailer.ts` platform notifications, selected by an explicit `MAILER_PROVIDER` flag, with full backward compatibility when unset.
+
+**Architecture:** Extract a `MailerTransport` interface behind which `ses` / `smtp` / `usesend` / legacy-self-hosted implementations live. `sendMail` resolves one transport via `MAILER_PROVIDER` and delegates. Transports are config-injected (constructor deps) so they are unit-testable in isolation without env or module mocking; `resolveMailerTransport` is a pure function over `(provider, isCloud)`.
+
+**Tech Stack:** TypeScript, Next.js (`apps/web`), `@aws-sdk/client-sesv2`, `nodemailer`, `usesend-js`, `vitest`, `@t3-oss/env-nextjs` + `zod`.
+
+## Global Constraints
+
+- Env-driven and mode-agnostic: `ses`/`smtp`/`usesend` work in any mode; only the unset default branches on mode.
+- Backward compatibility: `MAILER_PROVIDER` unset keeps exact current behavior (self-hosted → legacy team-based SES path; cloud → useSend API).
+- SMTP env vars use the `MAILER_SMTP_` prefix to avoid collision with the existing `SMTP_HOST` / `SMTP_USER` (inbound tenant proxy).
+- No database migration; no Prisma schema change.
+- Unit tests only (no infra). Test file convention: `*.unit.test.ts`, matched by `vitest.unit.config.ts` (`src/**/*.unit.test.ts`).
+- Test defaults are cloud mode (`NEXT_PUBLIC_IS_CLOUD=true` in `src/test/setup/setup-env.ts`).
+- Imports: always top-level, no dynamic imports. Web imports use the `~/` alias for `src`.
+- Run a single unit test file: `pnpm --filter=web test:unit <path-under-apps/web>`.
+- Conventional Commits (`feat:`, `fix:`, etc.). Never run build/migration commands unless asked.
+
+---
+
+## File Structure
+
+New (`apps/web/src/server/mailer/providers/`):
+- `types.ts` — `MailerSendOptions` + `MailerTransport` interfaces.
+- `ses.ts` — `SesMailerTransport` (direct SES via injected `getSesClient` + nodemailer `streamTransport`).
+- `smtp.ts` — `SmtpMailerTransport` (nodemailer SMTP via injected `createTransport`).
+- `usesend.ts` — `UseSendMailerTransport` (useSend HTTP API via injected client).
+- `legacy-ses.ts` — `LegacySesTransport` (verbatim move of the current self-hosted `sendMail` path).
+- `resolve.ts` — `resolveMailerTransport(provider, isCloud)` (pure) + `getMailerTransport()` (cached) + test reset helper.
+- `ses.unit.test.ts`, `smtp.unit.test.ts`, `usesend.unit.test.ts`, `legacy-ses.unit.test.ts`, `resolve.unit.test.ts`.
+
+Modified:
+- `apps/web/src/env.js` — add `MAILER_PROVIDER` + `MAILER_SMTP_*` to server schema and `runtimeEnv`.
+- `apps/web/src/server/aws/ses.ts` — `export` the existing `getSesClient` (one keyword) so `resolve.ts` can reuse it.
+- `apps/web/src/server/mailer.ts` — `sendMail` delegates to `getMailerTransport()`; drop now-unused imports; high-level functions unchanged. New `mailer.unit.test.ts`.
+
+Optional (deploy config, not required for the code change):
+- `docker/prod/compose.saas.yml` + `docker/prod/.env.example-saas` — expose `MAILER_PROVIDER` + `MAILER_SMTP_*`.
+
+---
+
+### Task 1: MailerTransport interface + SES transport
+
+**Files:**
+- Create: `apps/web/src/server/mailer/providers/types.ts`
+- Create: `apps/web/src/server/mailer/providers/ses.ts`
+- Test: `apps/web/src/server/mailer/providers/ses.unit.test.ts`
+
+**Interfaces:**
+- Produces: `MailerSendOptions` and `MailerTransport` in `types.ts` (consumed by every later task); `SesMailerTransport` class in `ses.ts` with constructor `new SesMailerTransport({ getSesClient, createTransport, region, fromDefault })` and `send(opts: MailerSendOptions): Promise<void>`.
+
+- [ ] **Step 1: Write the failing test**
+
+`apps/web/src/server/mailer/providers/ses.unit.test.ts`:
+```ts
+import { describe, expect, it, vi } from "vitest";
+import { SendEmailCommand } from "@aws-sdk/client-sesv2";
+import { SesMailerTransport } from "~/server/mailer/providers/ses";
+
+function fakeMessage(...chunks: Buffer[]) {
+  return {
+    async *[Symbol.asyncIterator]() {
+      for (const c of chunks) yield c;
+    },
+  };
+}
+
+describe("SesMailerTransport", () => {
+  it("sends raw email via SES client with resolved from", async () => {
+    const send = vi.fn().mockResolvedValue({});
+    const getSesClient = vi.fn(() => ({ send }));
+    const sendMail = vi
+      .fn()
+      .mockResolvedValue({ message: fakeMessage(Buffer.from("RAW")) });
+    const createTransport = vi.fn(() => ({ sendMail }));
+
+    const transport = new SesMailerTransport({
+      getSesClient,
+      createTransport,
+      region: "us-east-1",
+      fromDefault: "hello@example.com",
+    });
+
+    await transport.send({
+      to: "to@x.com",
+      subject: "s",
+      text: "t",
+      html: "<b>h</b>",
+    });
+
+    expect(createTransport).toHaveBeenCalledWith({ streamTransport: true });
+    expect(sendMail).toHaveBeenCalledWith(
+      expect.objectContaining({ from: "hello@example.com", to: "to@x.com" }),
+    );
+    expect(getSesClient).toHaveBeenCalledWith("us-east-1");
+    expect(send).toHaveBeenCalledTimes(1);
+    const command = send.mock.calls[0]?.[0];
+    expect(command).toBeInstanceOf(SendEmailCommand);
+    expect((command as SendEmailCommand).input.Content?.Raw?.Data).toBeInstanceOf(
+      Buffer,
+    );
+  });
+
+  it("uses fromOverride when provided", async () => {
+    const sendMail = vi
+      .fn()
+      .mockResolvedValue({ message: fakeMessage(Buffer.from("R")) });
+    const transport = new SesMailerTransport({
+      getSesClient: () => ({ send: vi.fn().mockResolvedValue({}) }),
+      createTransport: () => ({ sendMail }),
+      region: "us-east-1",
+      fromDefault: "hello@example.com",
+    });
+
+    await transport.send({
+      to: "to@x.com",
+      subject: "s",
+      text: "t",
+      html: "h",
+      fromOverride: "other@example.com",
+    });
+
+    expect(sendMail).toHaveBeenCalledWith(
+      expect.objectContaining({ from: "other@example.com" }),
+    );
+  });
+
+  it("throws when no from address is available", async () => {
+    const transport = new SesMailerTransport({
+      getSesClient: () => ({ send: vi.fn() }),
+      createTransport: () => ({ sendMail: vi.fn() }),
+      region: "us-east-1",
+    });
+
+    await expect(
+      transport.send({ to: "to@x.com", subject: "s", text: "t", html: "h" }),
+    ).rejects.toThrow("FROM_EMAIL is required for mailer");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter=web test:unit src/server/mailer/providers/ses.unit.test.ts`
+Expected: FAIL — `Cannot find module '~/server/mailer/providers/ses'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+`apps/web/src/server/mailer/providers/types.ts`:
+```ts
+export interface MailerSendOptions {
+  to: string;
+  subject: string;
+  text: string;
+  html: string;
+  replyTo?: string;
+  fromOverride?: string;
+}
+
+export interface MailerTransport {
+  send(opts: MailerSendOptions): Promise<void>;
+}
+```
+
+`apps/web/src/server/mailer/providers/ses.ts`:
+```ts
+import { SendEmailCommand } from "@aws-sdk/client-sesv2";
+import type { MailerSendOptions, MailerTransport } from "./types";
+
+interface SesSender {
+  send(command: SendEmailCommand): Promise<unknown>;
+}
+
+interface SesMailerConfig {
+  getSesClient: (region: string) => SesSender;
+  createTransport: (opts: { streamTransport: boolean }) => {
+    sendMail: (mail: {
+      from: string;
+      to: string;
+      subject: string;
+      text: string;
+      html: string;
+      replyTo?: string;
+    }) => Promise<{ message: AsyncIterable<Buffer | string> }>;
+  };
+  region: string;
+  fromDefault?: string;
+}
+
+export class SesMailerTransport implements MailerTransport {
+  constructor(private readonly cfg: SesMailerConfig) {}
+
+  async send({
+    to,
+    subject,
+    text,
+    html,
+    replyTo,
+    fromOverride,
+  }: MailerSendOptions): Promise<void> {
+    const from = fromOverride ?? this.cfg.fromDefault;
+    if (!from) {
+      throw new Error("FROM_EMAIL is required for mailer");
+    }
+
+    const { message } = await this.cfg
+      .createTransport({ streamTransport: true })
+      .sendMail({ from, to, subject, text, html, replyTo });
+
+    const chunks: Buffer[] = [];
+    for await (const chunk of message) {
+      chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
+    }
+    const data = Buffer.concat(chunks);
+
+    await this.cfg
+      .getSesClient(this.cfg.region)
+      .send(new SendEmailCommand({ Content: { Raw: { Data: data } } }));
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter=web test:unit src/server/mailer/providers/ses.unit.test.ts`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/server/mailer/providers/types.ts apps/web/src/server/mailer/providers/ses.ts apps/web/src/server/mailer/providers/ses.unit.test.ts
+git commit -m "feat(mail): add SES mailer transport"
+```
+
+---
+
+### Task 2: SMTP transport
+
+**Files:**
+- Create: `apps/web/src/server/mailer/providers/smtp.ts`
+- Test: `apps/web/src/server/mailer/providers/smtp.unit.test.ts`
+
+**Interfaces:**
+- Consumes: `MailerSendOptions`, `MailerTransport` from `./types`.
+- Produces: `SmtpMailerTransport` with constructor `new SmtpMailerTransport({ createTransport, host, port, secure, user?, pass?, fromDefault? })` and `send(opts)`.
+
+- [ ] **Step 1: Write the failing test**
+
+`apps/web/src/server/mailer/providers/smtp.unit.test.ts`:
+```ts
+import { describe, expect, it, vi } from "vitest";
+import { SmtpMailerTransport } from "~/server/mailer/providers/smtp";
+
+describe("SmtpMailerTransport", () => {
+  it("creates transport with host/port/secure/auth and sends", async () => {
+    const sendMail = vi.fn().mockResolvedValue({});
+    const createTransport = vi.fn(() => ({ sendMail }));
+
+    const transport = new SmtpMailerTransport({
+      createTransport,
+      host: "smtp.example.com",
+      port: 465,
+      secure: true,
+      user: "u",
+      pass: "p",
+      fromDefault: "hello@example.com",
+    });
+
+    await transport.send({ to: "to@x.com", subject: "s", text: "t", html: "h" });
+
+    expect(createTransport).toHaveBeenCalledWith({
+      host: "smtp.example.com",
+      port: 465,
+      secure: true,
+      auth: { user: "u", pass: "p" },
+    });
+    expect(sendMail).toHaveBeenCalledWith(
+      expect.objectContaining({ from: "hello@example.com", to: "to@x.com" }),
+    );
+  });
+
+  it("omits auth when no user provided", async () => {
+    const createTransport = vi.fn(() => ({
+      sendMail: vi.fn().mockResolvedValue({}),
+    }));
+
+    const transport = new SmtpMailerTransport({
+      createTransport,
+      host: "h",
+      port: 587,
+      secure: false,
+      fromDefault: "hello@example.com",
+    });
+
+    await transport.send({ to: "to@x.com", subject: "s", text: "t", html: "h" });
+
+    expect(createTransport).toHaveBeenCalledWith(
+      expect.objectContaining({ auth: undefined }),
+    );
+  });
+
+  it("throws when no from address is available", async () => {
+    const transport = new SmtpMailerTransport({
+      createTransport: () => ({ sendMail: vi.fn() }),
+      host: "h",
+      port: 587,
+      secure: false,
+    });
+
+    await expect(
+      transport.send({ to: "to@x.com", subject: "s", text: "t", html: "h" }),
+    ).rejects.toThrow("FROM_EMAIL is required for mailer");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter=web test:unit src/server/mailer/providers/smtp.unit.test.ts`
+Expected: FAIL — `Cannot find module '~/server/mailer/providers/smtp'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+`apps/web/src/server/mailer/providers/smtp.ts`:
+```ts
+import type { MailerSendOptions, MailerTransport } from "./types";
+
+interface SmtpTransporter {
+  sendMail(mail: {
+    from: string;
+    to: string;
+    subject: string;
+    text: string;
+    html: string;
+    replyTo?: string;
+  }): Promise<unknown>;
+}
+
+interface SmtpMailerConfig {
+  createTransport: (opts: {
+    host: string;
+    port: number;
+    secure: boolean;
+    auth?: { user: string; pass: string };
+  }) => SmtpTransporter;
+  host: string;
+  port: number;
+  secure: boolean;
+  user?: string;
+  pass?: string;
+  fromDefault?: string;
+}
+
+export class SmtpMailerTransport implements MailerTransport {
+  private readonly transporter: SmtpTransporter;
+
+  constructor(private readonly cfg: SmtpMailerConfig) {
+    this.transporter = cfg.createTransport({
+      host: cfg.host,
+      port: cfg.port,
+      secure: cfg.secure,
+      auth: cfg.user ? { user: cfg.user, pass: cfg.pass ?? "" } : undefined,
+    });
+  }
+
+  async send({
+    to,
+    subject,
+    text,
+    html,
+    replyTo,
+    fromOverride,
+  }: MailerSendOptions): Promise<void> {
+    const from = fromOverride ?? this.cfg.fromDefault;
+    if (!from) {
+      throw new Error("FROM_EMAIL is required for mailer");
+    }
+    await this.transporter.sendMail({ from, to, subject, text, html, replyTo });
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter=web test:unit src/server/mailer/providers/smtp.unit.test.ts`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/server/mailer/providers/smtp.ts apps/web/src/server/mailer/providers/smtp.unit.test.ts
+git commit -m "feat(mail): add SMTP mailer transport"
+```
+
+---
+
+### Task 3: UseSend transport
+
+**Files:**
+- Create: `apps/web/src/server/mailer/providers/usesend.ts`
+- Test: `apps/web/src/server/mailer/providers/usesend.unit.test.ts`
+
+**Interfaces:**
+- Consumes: `MailerSendOptions`, `MailerTransport` from `./types`.
+- Produces: `UseSendMailerTransport` with constructor `new UseSendMailerTransport({ client, fromDefault? })` and `send(opts)`. `client.emails.send(args)` returns `{ data?, error? }`.
+
+- [ ] **Step 1: Write the failing test**
+
+`apps/web/src/server/mailer/providers/usesend.unit.test.ts`:
+```ts
+import { describe, expect, it, vi } from "vitest";
+import { UseSendMailerTransport } from "~/server/mailer/providers/usesend";
+
+describe("UseSendMailerTransport", () => {
+  it("sends via useSend client with resolved from", async () => {
+    const send = vi.fn().mockResolvedValue({ data: { id: "1" } });
+
+    const transport = new UseSendMailerTransport({
+      client: { emails: { send } },
+      fromDefault: "hello@example.com",
+    });
+
+    await transport.send({ to: "to@x.com", subject: "s", text: "t", html: "h" });
+
+    expect(send).toHaveBeenCalledWith(
+      expect.objectContaining({ to: "to@x.com", from: "hello@example.com" }),
+    );
+  });
+
+  it("throws on useSend failure with error details", async () => {
+    const send = vi.fn().mockResolvedValue({
+      error: { code: "ERR", message: "boom" },
+    });
+
+    const transport = new UseSendMailerTransport({
+      client: { emails: { send } },
+      fromDefault: "hello@example.com",
+    });
+
+    await expect(
+      transport.send({ to: "to@x.com", subject: "s", text: "t", html: "h" }),
+    ).rejects.toThrow(/boom/);
+  });
+
+  it("throws when no from address is available", async () => {
+    const transport = new UseSendMailerTransport({
+      client: { emails: { send: vi.fn() } },
+    });
+
+    await expect(
+      transport.send({ to: "to@x.com", subject: "s", text: "t", html: "h" }),
+    ).rejects.toThrow("FROM_EMAIL is required for mailer");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter=web test:unit src/server/mailer/providers/usesend.unit.test.ts`
+Expected: FAIL — `Cannot find module '~/server/mailer/providers/usesend'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+`apps/web/src/server/mailer/providers/usesend.ts`:
+```ts
+import type { MailerSendOptions, MailerTransport } from "./types";
+
+interface UseSendSendResponse {
+  data?: unknown;
+  error?: { code?: string; message?: string };
+}
+
+interface UseSendMailerConfig {
+  client: {
+    emails: {
+      send: (args: {
+        to: string;
+        from: string;
+        subject: string;
+        text: string;
+        html: string;
+        replyTo?: string;
+      }) => Promise<UseSendSendResponse>;
+    };
+  };
+  fromDefault?: string;
+}
+
+export class UseSendMailerTransport implements MailerTransport {
+  constructor(private readonly cfg: UseSendMailerConfig) {}
+
+  async send({
+    to,
+    subject,
+    text,
+    html,
+    replyTo,
+    fromOverride,
+  }: MailerSendOptions): Promise<void> {
+    const from = fromOverride ?? this.cfg.fromDefault;
+    if (!from) {
+      throw new Error("FROM_EMAIL is required for mailer");
+    }
+
+    const resp = await this.cfg.client.emails.send({
+      to,
+      from,
+      subject,
+      text,
+      html,
+      replyTo,
+    });
+
+    if (!resp.data) {
+      throw new Error(
+        `useSend mailer failed: ${resp.error?.code ?? ""} ${resp.error?.message ?? ""}`.trim(),
+      );
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter=web test:unit src/server/mailer/providers/usesend.unit.test.ts`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/server/mailer/providers/usesend.ts apps/web/src/server/mailer/providers/usesend.unit.test.ts
+git commit -m "feat(mail): add useSend mailer transport"
+```
+
+---
+
+### Task 4: Legacy SES transport (move current self-hosted path)
+
+**Files:**
+- Create: `apps/web/src/server/mailer/providers/legacy-ses.ts`
+- Test: `apps/web/src/server/mailer/providers/legacy-ses.unit.test.ts`
+
+**Interfaces:**
+- Consumes: `MailerSendOptions`, `MailerTransport` from `./types`; `env`, `db`, `getDomains`, `sendEmail`, `logger`.
+- Produces: `LegacySesTransport` (no constructor args) with `send(opts)`. Reproduces the current self-hosted `sendMail` block verbatim (team lookup, domain matching, `sendEmail`), including the no-throw-on-missing-team/domain behavior (logs and returns).
+
+- [ ] **Step 1: Write the failing test**
+
+`apps/web/src/server/mailer/providers/legacy-ses.unit.test.ts`:
+```ts
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockDb, mockGetDomains, mockSendEmail, mockLogger, mockEnv } =
+  vi.hoisted(() => ({
+    mockDb: { team: { findFirst: vi.fn() } },
+    mockGetDomains: vi.fn(),
+    mockSendEmail: vi.fn(),
+    mockLogger: { info: vi.fn(), error: vi.fn() },
+    mockEnv: { FROM_EMAIL: "hello@example.com" } as Record<
+      string,
+      string | undefined
+    >,
+  }));
+
+vi.mock("~/server/db", () => ({ db: mockDb }));
+vi.mock("~/server/service/domain-service", () => ({
+  getDomains: mockGetDomains,
+}));
+vi.mock("~/server/service/email-service", () => ({ sendEmail: mockSendEmail }));
+vi.mock("~/server/logger/log", () => ({ logger: mockLogger }));
+vi.mock("~/env", () => ({
+  env: new Proxy(
+    {},
+    { get: (_t, k) => mockEnv[k as string] },
+  ),
+}));
+
+import { LegacySesTransport } from "~/server/mailer/providers/legacy-ses";
+
+describe("LegacySesTransport", () => {
+  beforeEach(() => {
+    mockDb.team.findFirst.mockReset();
+    mockGetDomains.mockReset();
+    mockSendEmail.mockReset();
+    mockLogger.info.mockReset();
+    mockLogger.error.mockReset();
+    mockEnv.FROM_EMAIL = "hello@example.com";
+  });
+
+  it("returns without sending when no team exists", async () => {
+    mockDb.team.findFirst.mockResolvedValue(null);
+
+    await new LegacySesTransport().send({
+      to: "to@x.com",
+      subject: "s",
+      text: "t",
+      html: "h",
+    });
+
+    expect(mockSendEmail).not.toHaveBeenCalled();
+    expect(mockLogger.error).toHaveBeenCalledWith("No team found");
+  });
+
+  it("returns without sending when no domains exist", async () => {
+    mockDb.team.findFirst.mockResolvedValue({ id: 7 });
+    mockGetDomains.mockResolvedValue([]);
+
+    await new LegacySesTransport().send({
+      to: "to@x.com",
+      subject: "s",
+      text: "t",
+      html: "h",
+    });
+
+    expect(mockSendEmail).not.toHaveBeenCalled();
+    expect(mockLogger.error).toHaveBeenCalledWith("No domains found");
+  });
+
+  it("sends via sendEmail with domain-matched from", async () => {
+    mockDb.team.findFirst.mockResolvedValue({ id: 7 });
+    mockGetDomains.mockResolvedValue([{ name: "example.com" }]);
+    mockSendEmail.mockResolvedValue({});
+
+    await new LegacySesTransport().send({
+      to: "to@x.com",
+      subject: "s",
+      text: "t",
+      html: "h",
+    });
+
+    expect(mockSendEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        teamId: 7,
+        to: "to@x.com",
+        from: "hello@example.com",
+      }),
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter=web test:unit src/server/mailer/providers/legacy-ses.unit.test.ts`
+Expected: FAIL — `Cannot find module '~/server/mailer/providers/legacy-ses'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+`apps/web/src/server/mailer/providers/legacy-ses.ts`:
+```ts
+import { env } from "~/env";
+import { db } from "~/server/db";
+import { getDomains } from "~/server/service/domain-service";
+import { sendEmail } from "~/server/service/email-service";
+import { logger } from "~/server/logger/log";
+import type { MailerSendOptions, MailerTransport } from "./types";
+
+export class LegacySesTransport implements MailerTransport {
+  async send({
+    to,
+    subject,
+    text,
+    html,
+    replyTo,
+    fromOverride,
+  }: MailerSendOptions): Promise<void> {
+    logger.info("Sending email using self hosted");
+    /*
+      Self hosted so checking if we can send using one of the available domain
+      Assuming self hosted will have only one team
+    */
+    const team = await db.team.findFirst({});
+    if (!team) {
+      logger.error("No team found");
+      return;
+    }
+
+    const domains = await getDomains(team.id);
+
+    if (domains.length === 0 || !domains[0]) {
+      logger.error("No domains found");
+      return;
+    }
+
+    const availableDomains = domains.map((d) => d.name);
+    const domain = domains[0];
+
+    const candidateFroms = [
+      fromOverride,
+      env.FROM_EMAIL,
+      `hello@${domain.name}`,
+    ].filter((value): value is string => Boolean(value));
+
+    const selectedFrom =
+      candidateFroms.find((address) => {
+        const domainPart = address.split("@")[1];
+        return domainPart ? availableDomains.includes(domainPart) : false;
+      }) ?? `hello@${domain.name}`;
+
+    await sendEmail({
+      teamId: team.id,
+      to,
+      from: selectedFrom,
+      subject,
+      text,
+      html,
+      replyTo,
+    });
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter=web test:unit src/server/mailer/providers/legacy-ses.unit.test.ts`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/server/mailer/providers/legacy-ses.ts apps/web/src/server/mailer/providers/legacy-ses.unit.test.ts
+git commit -m "feat(mail): add legacy self-hosted SES transport"
+```
+
+---
+
+### Task 5: env.js additions, ses.ts export, and resolver
+
+**Files:**
+- Modify: `apps/web/src/env.js` (server schema + `runtimeEnv`)
+- Modify: `apps/web/src/server/aws/ses.ts` (add `export` to `getSesClient`)
+- Create: `apps/web/src/server/mailer/providers/resolve.ts`
+- Test: `apps/web/src/server/mailer/providers/resolve.unit.test.ts`
+
+**Interfaces:**
+- Consumes: `SesMailerTransport`, `SmtpMailerTransport`, `UseSendMailerTransport`, `LegacySesTransport` (Tasks 1-4); `getSesClient` from `~/server/aws/ses`; `nodemailer.createTransport`; `UseSend` from `usesend-js`; `env`.
+- Produces: `resolveMailerTransport(provider: string | undefined, isCloud: boolean): MailerTransport` (pure); `getMailerTransport(): MailerTransport` (cached); `__resetMailerTransportForTests()`.
+
+- [ ] **Step 1: Write the failing test**
+
+`apps/web/src/server/mailer/providers/resolve.unit.test.ts`:
+```ts
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockEnv,
+  SesMailerTransport,
+  SmtpMailerTransport,
+  UseSendMailerTransport,
+  LegacySesTransport,
+  mockGetSesClient,
+  mockCreateTransport,
+  MockUseSend,
+} = vi.hoisted(() => ({
+  mockEnv: {} as Record<string, string | boolean | undefined>,
+  SesMailerTransport: vi.fn(),
+  SmtpMailerTransport: vi.fn(),
+  UseSendMailerTransport: vi.fn(),
+  LegacySesTransport: vi.fn(),
+  mockGetSesClient: vi.fn(),
+  mockCreateTransport: vi.fn(),
+  MockUseSend: vi.fn(),
+}));
+
+vi.mock("~/env", () => ({
+  env: new Proxy({}, { get: (_t, k) => mockEnv[k as string] }),
+}));
+vi.mock("~/server/aws/ses", () => ({ getSesClient: mockGetSesClient }));
+vi.mock("nodemailer", () => ({ default: { createTransport: mockCreateTransport } }));
+vi.mock("usesend-js", () => ({ UseSend: MockUseSend }));
+vi.mock("~/server/mailer/providers/ses", () => ({ SesMailerTransport }));
+vi.mock("~/server/mailer/providers/smtp", () => ({ SmtpMailerTransport }));
+vi.mock("~/server/mailer/providers/usesend", () => ({
+  UseSendMailerTransport,
+}));
+vi.mock("~/server/mailer/providers/legacy-ses", () => ({ LegacySesTransport }));
+
+import { resolveMailerTransport } from "~/server/mailer/providers/resolve";
+
+beforeEach(() => {
+  SesMailerTransport.mockClear();
+  SmtpMailerTransport.mockClear();
+  UseSendMailerTransport.mockClear();
+  LegacySesTransport.mockClear();
+  MockUseSend.mockClear();
+  for (const k of Object.keys(mockEnv)) delete mockEnv[k];
+  mockEnv.AWS_DEFAULT_REGION = "us-east-1";
+  mockEnv.FROM_EMAIL = "hello@example.com";
+});
+
+describe("resolveMailerTransport", () => {
+  it("returns SesMailerTransport for provider=ses", () => {
+    resolveMailerTransport("ses", true);
+    expect(SesMailerTransport).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns SmtpMailerTransport for provider=smtp with creds and secure port", () => {
+    mockEnv.MAILER_SMTP_HOST = "smtp.example.com";
+    mockEnv.MAILER_SMTP_USER = "u";
+    mockEnv.MAILER_SMTP_PASS = "p";
+    mockEnv.MAILER_SMTP_PORT = "465";
+
+    resolveMailerTransport("smtp", true);
+
+    expect(SmtpMailerTransport).toHaveBeenCalledWith(
+      expect.objectContaining({
+        host: "smtp.example.com",
+        port: 465,
+        secure: true,
+        user: "u",
+        pass: "p",
+      }),
+    );
+  });
+
+  it("defaults smtp port to 587 and secure false when not 465", () => {
+    mockEnv.MAILER_SMTP_HOST = "h";
+    mockEnv.MAILER_SMTP_USER = "u";
+    mockEnv.MAILER_SMTP_PASS = "p";
+
+    resolveMailerTransport("smtp", true);
+
+    expect(SmtpMailerTransport).toHaveBeenCalledWith(
+      expect.objectContaining({ port: 587, secure: false }),
+    );
+  });
+
+  it("throws for provider=smtp missing creds", () => {
+    expect(() => resolveMailerTransport("smtp", true)).toThrow(/MAILER_SMTP_HOST/);
+  });
+
+  it("returns UseSendMailerTransport for provider=usesend with key", () => {
+    mockEnv.UNSEND_API_KEY = "key";
+
+    resolveMailerTransport("usesend", true);
+
+    expect(MockUseSend).toHaveBeenCalledWith("key");
+    expect(UseSendMailerTransport).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws for provider=usesend missing key", () => {
+    expect(() => resolveMailerTransport("usesend", true)).toThrow(/USESEND_API_KEY/);
+  });
+
+  it("returns LegacySesTransport when unset and self-hosted", () => {
+    resolveMailerTransport(undefined, false);
+    expect(LegacySesTransport).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns UseSendMailerTransport when unset and cloud with key", () => {
+    mockEnv.UNSEND_API_KEY = "key";
+    resolveMailerTransport(undefined, true);
+    expect(UseSendMailerTransport).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws when unset, cloud, and no useSend key", () => {
+    expect(() => resolveMailerTransport(undefined, true)).toThrow(/USESEND_API_KEY/);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter=web test:unit src/server/mailer/providers/resolve.unit.test.ts`
+Expected: FAIL — `Cannot find module '~/server/mailer/providers/resolve'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+First, export `getSesClient` in `apps/web/src/server/aws/ses.ts`. Change:
+```ts
+function getSesClient(region: string) {
+```
+to:
+```ts
+export function getSesClient(region: string) {
+```
+
+Then add env vars to `apps/web/src/env.js`. In the `server` object, after the `EMAIL_CLEANUP_DAYS` entry:
+```js
+    MAILER_PROVIDER: z.enum(["ses", "smtp", "usesend"]).optional(),
+    MAILER_SMTP_HOST: z.string().optional(),
+    MAILER_SMTP_PORT: z.string().optional(),
+    MAILER_SMTP_USER: z.string().optional(),
+    MAILER_SMTP_PASS: z.string().optional(),
+    MAILER_SMTP_SECURE: z.string().optional(),
+```
+In the `runtimeEnv` object, after the `EMAIL_CLEANUP_DAYS` entry:
+```js
+    MAILER_PROVIDER: process.env.MAILER_PROVIDER,
+    MAILER_SMTP_HOST: process.env.MAILER_SMTP_HOST,
+    MAILER_SMTP_PORT: process.env.MAILER_SMTP_PORT,
+    MAILER_SMTP_USER: process.env.MAILER_SMTP_USER,
+    MAILER_SMTP_PASS: process.env.MAILER_SMTP_PASS,
+    MAILER_SMTP_SECURE: process.env.MAILER_SMTP_SECURE,
+```
+
+`apps/web/src/server/mailer/providers/resolve.ts`:
+```ts
+import nodemailer from "nodemailer";
+import { UseSend } from "usesend-js";
+import { env } from "~/env";
+import { getSesClient } from "~/server/aws/ses";
+import { SesMailerTransport } from "./ses";
+import { SmtpMailerTransport } from "./smtp";
+import { UseSendMailerTransport } from "./usesend";
+import { LegacySesTransport } from "./legacy-ses";
+import type { MailerTransport } from "./types";
+
+export function resolveMailerTransport(
+  provider: string | undefined,
+  isCloud: boolean,
+): MailerTransport {
+  if (provider === "ses") {
+    return new SesMailerTransport({
+      getSesClient,
+      createTransport: nodemailer.createTransport,
+      region: env.AWS_DEFAULT_REGION,
+      fromDefault: env.FROM_EMAIL,
+    });
+  }
+
+  if (provider === "smtp") {
+    if (!env.MAILER_SMTP_HOST || !env.MAILER_SMTP_USER || !env.MAILER_SMTP_PASS) {
+      throw new Error(
+        "MAILER_PROVIDER=smtp requires MAILER_SMTP_HOST, MAILER_SMTP_USER, MAILER_SMTP_PASS",
+      );
+    }
+    const port = env.MAILER_SMTP_PORT ? Number(env.MAILER_SMTP_PORT) : 587;
+    const secure = env.MAILER_SMTP_SECURE === "true" || port === 465;
+    return new SmtpMailerTransport({
+      createTransport: nodemailer.createTransport,
+      host: env.MAILER_SMTP_HOST,
+      port,
+      secure,
+      user: env.MAILER_SMTP_USER,
+      pass: env.MAILER_SMTP_PASS,
+      fromDefault: env.FROM_EMAIL,
+    });
+  }
+
+  if (provider === "usesend") {
+    const apiKey = env.USESEND_API_KEY ?? env.UNSEND_API_KEY;
+    if (!apiKey) {
+      throw new Error(
+        "MAILER_PROVIDER=usesend requires USESEND_API_KEY or UNSEND_API_KEY",
+      );
+    }
+    return new UseSendMailerTransport({
+      client: new UseSend(apiKey),
+      fromDefault: env.FROM_EMAIL,
+    });
+  }
+
+  // MAILER_PROVIDER unset -> backward-compatible default
+  if (!isCloud) {
+    return new LegacySesTransport();
+  }
+
+  const apiKey = env.USESEND_API_KEY ?? env.UNSEND_API_KEY;
+  if (!apiKey) {
+    throw new Error(
+      "MAILER_PROVIDER=usesend requires USESEND_API_KEY or UNSEND_API_KEY",
+    );
+  }
+  return new UseSendMailerTransport({
+    client: new UseSend(apiKey),
+    fromDefault: env.FROM_EMAIL,
+  });
+}
+
+let cached: MailerTransport | undefined;
+
+export function getMailerTransport(): MailerTransport {
+  if (!cached) {
+    cached = resolveMailerTransport(env.MAILER_PROVIDER, env.NEXT_PUBLIC_IS_CLOUD);
+  }
+  return cached;
+}
+
+export function __resetMailerTransportForTests(): void {
+  cached = undefined;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter=web test:unit src/server/mailer/providers/resolve.unit.test.ts`
+Expected: PASS (9 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/env.js apps/web/src/server/aws/ses.ts apps/web/src/server/mailer/providers/resolve.ts apps/web/src/server/mailer/providers/resolve.unit.test.ts
+git commit -m "feat(mail): add MAILER_PROVIDER resolver and env vars"
+```
+
+---
+
+### Task 6: Refactor mailer.ts to delegate
+
+**Files:**
+- Modify: `apps/web/src/server/mailer.ts`
+- Test: `apps/web/src/server/mailer.unit.test.ts`
+
+**Interfaces:**
+- Consumes: `getMailerTransport()` from `./mailer/providers/resolve` (Task 5).
+- Produces: unchanged public API `sendMail(email, subject, text, html, replyTo?, fromOverride?)`, `sendSignUpEmail`, `sendTeamInviteEmail`, `sendSubscriptionConfirmationEmail`.
+
+- [ ] **Step 1: Write the failing test**
+
+`apps/web/src/server/mailer.unit.test.ts`:
+```ts
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockTransport,
+  mockGetMailerTransport,
+  mockRenderOtp,
+  mockRenderInvite,
+  mockEnv,
+  mockLogger,
+} = vi.hoisted(() => ({
+  mockTransport: { send: vi.fn() },
+  mockGetMailerTransport: vi.fn(() => mockTransport),
+  mockRenderOtp: vi.fn(),
+  mockRenderInvite: vi.fn(),
+  mockEnv: {
+    NODE_ENV: "test",
+    FOUNDER_EMAIL: "founder@example.com",
+    FROM_EMAIL: "hello@example.com",
+  } as Record<string, string | undefined>,
+  mockLogger: { info: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("~/server/mailer/providers/resolve", () => ({
+  getMailerTransport: mockGetMailerTransport,
+}));
+vi.mock("~/email-templates", () => ({
+  renderOtpEmail: mockRenderOtp,
+  renderTeamInviteEmail: mockRenderInvite,
+}));
+vi.mock("~/env", () => ({
+  env: new Proxy({}, { get: (_t, k) => mockEnv[k as string] }),
+}));
+vi.mock("~/server/logger/log", () => ({ logger: mockLogger }));
+
+import {
+  sendMail,
+  sendSignUpEmail,
+  sendSubscriptionConfirmationEmail,
+} from "~/server/mailer";
+
+describe("mailer", () => {
+  beforeEach(() => {
+    mockTransport.send.mockReset();
+    mockGetMailerTransport.mockClear();
+    mockRenderOtp.mockReset();
+    mockRenderInvite.mockReset();
+  });
+
+  it("sendMail delegates to the resolved transport", async () => {
+    await sendMail("to@x.com", "s", "t", "h", "r@x.com", "from@x.com");
+
+    expect(mockTransport.send).toHaveBeenCalledWith({
+      to: "to@x.com",
+      subject: "s",
+      text: "t",
+      html: "h",
+      replyTo: "r@x.com",
+      fromOverride: "from@x.com",
+    });
+  });
+
+  it("sendSignUpEmail renders OTP and sends via transport", async () => {
+    mockRenderOtp.mockResolvedValue("<p>otp</p>");
+
+    await sendSignUpEmail("to@x.com", "ABCDE", "https://app.example.com/verify");
+
+    expect(mockRenderOtp).toHaveBeenCalled();
+    expect(mockTransport.send).toHaveBeenCalledTimes(1);
+    expect(mockTransport.send.mock.calls[0]?.[0].to).toBe("to@x.com");
+  });
+
+  it("sendSubscriptionConfirmationEmail sends with founder fromOverride", async () => {
+    await sendSubscriptionConfirmationEmail("sub@x.com");
+
+    expect(mockTransport.send).toHaveBeenCalledTimes(1);
+    expect(mockTransport.send.mock.calls[0]?.[0].fromOverride).toBe(
+      "founder@example.com",
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter=web test:unit src/server/mailer.unit.test.ts`
+Expected: FAIL — `sendMail` still runs the old branches and does not call `mockTransport.send`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `apps/web/src/server/mailer.ts`, replace the imports and `sendMail`. Remove the now-unused imports (`UseSend`, `isSelfHosted`, `db`, `getDomains`, `sendEmail`) and the `getClient` helper. Add the resolver import. The new top of the file and `sendMail`:
+
+```ts
+import { env } from "~/env";
+import { logger } from "./logger/log";
+import { renderOtpEmail, renderTeamInviteEmail } from "./email-templates";
+import { getMailerTransport } from "./mailer/providers/resolve";
+
+export async function sendSignUpEmail(
+  email: string,
+  token: string,
+  url: string
+) {
+  const { host } = new URL(url);
+
+  if (env.NODE_ENV === "development") {
+    logger.info({ email, url, token }, "Sending sign in email");
+    return;
+  }
+
+  const subject = "Sign in to useSend";
+
+  const html = await renderOtpEmail({
+    otpCode: token.toUpperCase(),
+    loginUrl: url,
+    hostName: host,
+  });
+
+  const text = `Hey,\n\nYou can sign in to useSend by clicking the below URL:\n${url}\n\nYou can also use this OTP: ${token}\n\nThanks,\nuseSend Team`;
+
+  await sendMail(email, subject, text, html);
+}
+
+export async function sendTeamInviteEmail(
+  email: string,
+  url: string,
+  teamName: string
+) {
+  const { host } = new URL(url);
+
+  if (env.NODE_ENV === "development") {
+    logger.info({ email, url, teamName }, "Sending team invite email");
+    return;
+  }
+
+  const subject = "You have been invited to join useSend";
+
+  const html = await renderTeamInviteEmail({
+    teamName,
+    inviteUrl: url,
+  });
+
+  const text = `Hey,\n\nYou have been invited to join the team ${teamName} on useSend.\n\nYou can accept the invitation by clicking the below URL:\n${url}\n\nThanks,\nuseSend Team`;
+
+  await sendMail(email, subject, text, html);
+}
+
+export async function sendSubscriptionConfirmationEmail(email: string) {
+  if (!env.FOUNDER_EMAIL) {
+    logger.error("FOUNDER_EMAIL not configured");
+    return;
+  }
+
+  const subject = "Thanks for subscribing to useSend";
+  const text = `Hey,\n\nThanks for subscribing to useSend, just wanted to let you know you can join the discord server to have a dedicated support channel for your team. So that we can address your queries / bugs asap.\n\nYou can join over using the link: https://discord.com/invite/BU8n8pJv8S\n\nIf you prefer slack, please let me know\n\ncheers,\nkoushik - useSend`;
+  const html = text.replace(/\n/g, "<br />");
+
+  await sendMail(email, subject, text, html, undefined, env.FOUNDER_EMAIL);
+}
+
+export async function sendMail(
+  email: string,
+  subject: string,
+  text: string,
+  html: string,
+  replyTo?: string,
+  fromOverride?: string
+) {
+  await getMailerTransport().send({
+    to: email,
+    subject,
+    text,
+    html,
+    replyTo,
+    fromOverride,
+  });
+}
+```
+
+Keep `sendSignUpEmail`, `sendTeamInviteEmail`, and `sendSubscriptionConfirmationEmail` byte-for-byte identical to the originals (only the imports above and `sendMail` change).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter=web test:unit src/server/mailer.unit.test.ts`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Run the full mailer provider suite**
+
+Run: `pnpm --filter=web test:unit src/server/mailer`
+Expected: PASS — all provider + mailer tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/server/mailer.ts apps/web/src/server/mailer.unit.test.ts
+git commit -m "refactor(mail): delegate sendMail to resolved transport"
+```
+
+---
+
+### Task 7 (optional): Expose mailer env in SaaS deploy config
+
+**Files:**
+- Modify: `docker/prod/compose.saas.yml`
+- Modify: `docker/prod/.env.example-saas`
+
+This task has no automated test; it is deploy documentation. Skip if not deploying via these files.
+
+- [ ] **Step 1: Add to compose.saas.yml**
+
+In the `usesend` service `environment`, add (e.g. after the `FROM_EMAIL` line in the Authentication section):
+```yaml
+      # Outbound transport for platform notifications: ses | smtp | usesend.
+      # Unset = backward-compatible default (self-hosted -> SES via app; cloud -> useSend API).
+      MAILER_PROVIDER: ${MAILER_PROVIDER}
+      # Required only when MAILER_PROVIDER=smtp. Prefixed to avoid clashing with the inbound SMTP_HOST/SMTP_USER.
+      MAILER_SMTP_HOST: ${MAILER_SMTP_HOST}
+      MAILER_SMTP_PORT: ${MAILER_SMTP_PORT}
+      MAILER_SMTP_USER: ${MAILER_SMTP_USER}
+      MAILER_SMTP_PASS: ${MAILER_SMTP_PASS}
+      MAILER_SMTP_SECURE: ${MAILER_SMTP_SECURE}
+```
+
+- [ ] **Step 2: Add to .env.example-saas**
+
+Add a new section (e.g. after the Email Login section):
+```ini
+#################################################
+# Mailer Provider (platform notifications)
+#################################################
+
+# Outbound transport for magic-link / invite / billing emails.
+# ses | smtp | usesend. Unset = backward-compatible default
+# (self-hosted -> SES via app domain; cloud -> useSend API).
+MAILER_PROVIDER=
+
+# Required only when MAILER_PROVIDER=smtp.
+# Uses MAILER_SMTP_ prefix (NOT SMTP_HOST/SMTP_USER, which are the inbound tenant proxy).
+MAILER_SMTP_HOST=
+MAILER_SMTP_PORT=587
+MAILER_SMTP_USER=
+MAILER_SMTP_PASS=
+# "true" forces TLS; if unset, derived from port (465 = secure).
+MAILER_SMTP_SECURE=
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docker/prod/compose.saas.yml docker/prod/.env.example-saas
+git commit -m "docs(saas): expose MAILER_PROVIDER and MAILER_SMTP env"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Outbound SMTP for `mailer.ts` -> Task 2 (transport) + Task 5 (resolve) + Task 6 (delegation). ✓
+- Explicit `MAILER_PROVIDER=ses|smtp|usesend` -> Task 5 env + resolve. ✓
+- SES direct via env, mode-agnostic -> Task 1 (transport) + Task 5 (resolve constructs from `AWS_*`/`FROM_EMAIL`). ✓
+- Backward-compat default (unset -> current behavior) -> Task 5 resolve `default` branch + Task 4 legacy transport. ✓
+- `MAILER_SMTP_*` prefix avoiding `SMTP_HOST` collision -> Task 5 env + Task 7 docs. ✓
+- Error handling (missing creds, missing FROM_EMAIL, useSend failure) -> Tasks 1-3 send throws + Task 5 resolve throws. ✓
+- Unit tests per transport + resolve -> Tasks 1-5 tests. ✓
+- Files list matches spec. ✓
+
+**Placeholder scan:** No TBD/TODO/placeholder text. All steps contain complete code and exact commands.
+
+**Type consistency:** `MailerSendOptions` fields (`to`, `subject`, `text`, `html`, `replyTo?`, `fromOverride?`) are identical across `types.ts`, every transport `send` signature, `resolve.ts` construction, and `mailer.ts` delegation. Constructor config field names (`getSesClient`, `createTransport`, `region`, `fromDefault` for SES; `createTransport`, `host`, `port`, `secure`, `user`, `pass`, `fromDefault` for SMTP; `client`, `fromDefault` for useSend) match between transport classes and `resolve.ts`. `resolveMailerTransport(provider, isCloud)` signature matches the test calls.
+
+No issues found.

--- a/docs/superpowers/specs/2026-07-30-mailer-smtp-provider-design.md
+++ b/docs/superpowers/specs/2026-07-30-mailer-smtp-provider-design.md
@@ -1,0 +1,204 @@
+# Mailer Provider Abstraction + Outbound SMTP Support
+
+- **Date:** 2026-07-30
+- **Status:** Approved (design)
+- **Scope:** `apps/web` — `src/server/mailer.ts` and new `src/server/mailer/providers/`
+
+## Background
+
+`src/server/mailer.ts` sends the platform's own transactional notifications: sign-up
+magic-link OTPs, team invites, and billing/limit notifications. Today the transport is chosen
+implicitly by deployment mode:
+
+- **Self-hosted** (`NEXT_PUBLIC_IS_CLOUD=false`): `sendMail` calls `email-service.sendEmail`,
+  which requires a team and a verified sending domain configured in-app, then routes through the
+  email queue to SES using the global `AWS_*` credentials. This path assumes a single team
+  (`db.team.findFirst({})`) and only fits self-hosted.
+- **Cloud** (`NEXT_PUBLIC_IS_CLOUD=true`): `sendMail` is hardcoded to the useSend HTTP API via
+  `UNSEND_API_KEY`/`USESEND_API_KEY` + `FROM_EMAIL`. It never uses SES, even when `AWS_*` env is
+  set. There is no env toggle to change this.
+
+Two problems follow: (1) cloud-mode operators cannot send platform notifications through their own
+SES without depending on the useSend service, and (2) there is no way to send platform
+notifications through a generic SMTP server (e.g. a self-hosted relay, Mailgun SMTP, Gmail).
+
+Note: the existing `apps/smtp-server` + `SMTP_HOST`/`SMTP_USER` are an **inbound** SMTP interface
+for tenants (tenants connect with their API key as password; emails are relayed to the API). This
+spec is **not** about that. It adds an **outbound** transport for `mailer.ts` only.
+
+## Goals
+
+- Add SMTP as an outbound transport for `mailer.ts` platform notifications.
+- Make SES usable as a direct, env-driven transport in any mode (decouples cloud from the useSend API).
+- Introduce an explicit `MAILER_PROVIDER` selection so operators choose the transport predictably.
+- Preserve existing behavior when `MAILER_PROVIDER` is unset (zero change for current deployments).
+
+## Non-Goals
+
+- Changing tenant email sending (`email-service.sendEmail`), which already uses SES via `AWS_*`.
+- Changing the inbound tenant SMTP proxy (`apps/smtp-server`).
+- Per-team/per-domain mailer configuration. The mailer is platform-level and configured via env.
+- Changing the high-level notification functions (`sendSignUpEmail`, etc.) beyond delegating to the
+  new `sendMail`.
+
+## Key Decisions
+
+1. **Scope:** outbound SMTP for `mailer.ts` platform notifications only.
+2. **Selection:** explicit env flag `MAILER_PROVIDER=ses|smtp|usesend`.
+3. **SES path:** a new direct SES send via `AWS_*` + `FROM_EMAIL` (no team/domain dependency),
+   usable in any mode. The current team-based `sendEmail` path is retained only as the
+   backward-compat default when `MAILER_PROVIDER` is unset in self-hosted mode.
+4. **Structure:** provider abstraction (Approach 2), not inline branches in `sendMail`.
+
+## Architecture
+
+Introduce a `MailerTransport` interface. `sendMail` resolves a single transport from
+`MAILER_PROVIDER` and delegates. Each transport owns its own `from` resolution (rules differ
+between env-driven transports and the legacy domain-matching path).
+
+```
+sendSignUpEmail / sendTeamInviteEmail / sendSubscriptionConfirmationEmail
+        |
+        v
+   sendMail(to, subject, text, html, replyTo?, fromOverride?)        # mailer.ts
+        |
+        v
+   getMailerTransport()  (cached singleton)                          # providers/resolve.ts
+        |
+        v
+   MailerTransport.send({ to, subject, text, html, replyTo, fromOverride })
+```
+
+### Components (`src/server/mailer/providers/`)
+
+- `types.ts`
+  ```ts
+  export interface MailerSendOptions {
+    to: string;
+    subject: string;
+    text: string;
+    html: string;
+    replyTo?: string;
+    fromOverride?: string;
+  }
+  export interface MailerTransport {
+    send(opts: MailerSendOptions): Promise<void>;
+  }
+  ```
+
+- `ses.ts` — `SesMailerTransport`. Direct SES send using `getSesClient(env.AWS_DEFAULT_REGION)`
+  (reuses `getAwsCredentialOptions()` from `server/aws/credentials.ts`, which reads `AWS_*` env).
+  Builds raw MIME via `nodemailer.createTransport({ streamTransport: true })` (the pattern already
+  used in `server/aws/ses.ts`) and sends with `SendEmailCommand`. No configuration set, no
+  team/domain lookup, no queue. `from = fromOverride ?? env.FROM_EMAIL`. Works in any mode.
+
+- `smtp.ts` — `SmtpMailerTransport`. `nodemailer.createTransport({ host, port, secure, auth })`
+  built from `MAILER_SMTP_*` env. `from = fromOverride ?? env.FROM_EMAIL`. Works in any mode.
+
+- `usesend.ts` — `UseSendMailerTransport`. Extracts the current `getClient()` + `client.emails.send`
+  logic from `mailer.ts`. `from = fromOverride ?? env.FROM_EMAIL`.
+
+- `legacy-ses.ts` — `LegacySesTransport`. Wraps the current self-hosted path: `db.team.findFirst`,
+  `getDomains`, the `candidateFroms` domain-matching `from` resolution, and `email-service.sendEmail`
+  (queue + suppression). Used only for backward-compat when `MAILER_PROVIDER` is unset in
+  self-hosted mode.
+
+- `resolve.ts` — `getMailerTransport(): MailerTransport` (cached singleton). Reads
+  `env.MAILER_PROVIDER` and returns the matching transport; on unset, returns the backward-compat
+  transport.
+
+### `mailer.ts` refactor
+
+`sendMail` becomes: resolve transport, call `transport.send({ to: email, subject, text, html,
+replyTo, fromOverride })`. The high-level functions (`sendSignUpEmail`,
+`sendTeamInviteEmail`, `sendSubscriptionConfirmationEmail`) are unchanged except they keep
+calling `sendMail`. The `NODE_ENV === "development"` short-circuit in `sendSignUpEmail` (log only,
+no send) is preserved.
+
+## Environment Variables
+
+New (added to `src/env.js`, all optional):
+
+| Variable | Schema | Purpose |
+|---|---|---|
+| `MAILER_PROVIDER` | `z.enum(["ses","smtp","usesend"]).optional()` | Selects the transport. Unset = backward-compat default. |
+| `MAILER_SMTP_HOST` | `z.string().optional()` | SMTP server host. |
+| `MAILER_SMTP_PORT` | `z.string().optional()` | SMTP port (parsed to number; default 587). |
+| `MAILER_SMTP_USER` | `z.string().optional()` | SMTP auth user. |
+| `MAILER_SMTP_PASS` | `z.string().optional()` | SMTP auth password. |
+| `MAILER_SMTP_SECURE` | `z.string().optional()` | `"true"` forces TLS; if unset, derived from port (465 = secure). |
+
+The `MAILER_SMTP_` prefix is intentional to avoid collision with the existing `SMTP_HOST` /
+`SMTP_USER` (inbound tenant proxy).
+
+Reused (no schema change): `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_DEFAULT_REGION`
+(ses), `UNSEND_API_KEY` / `USESEND_API_KEY` (usesend), `FROM_EMAIL` (all).
+
+## Resolution & Default
+
+```
+MAILER_PROVIDER=ses      -> SesMailerTransport
+MAILER_PROVIDER=smtp     -> SmtpMailerTransport
+MAILER_PROVIDER=usesend  -> UseSendMailerTransport
+unset                    -> self-hosted: LegacySesTransport (current behavior)
+                          cloud:      UseSendMailerTransport (current behavior)
+```
+
+Unset = zero behavior change for existing deployments. Operators opt in by setting
+`MAILER_PROVIDER`.
+
+## Error Handling
+
+- Missing required env for the chosen provider throws a descriptive error, e.g.
+  `MAILER_PROVIDER=smtp requires MAILER_SMTP_HOST, MAILER_SMTP_USER, MAILER_SMTP_PASS`.
+- `FROM_EMAIL` empty and no `fromOverride` for `ses`/`smtp`/`usesend` throws
+  `FROM_EMAIL is required for mailer`.
+- SMTP/SES send failures are logged and re-thrown with the original error. This also fixes the
+  current misleading `"USESEND_API_KEY/UNSEND_API_KEY not found"` message that surfaces when a
+  useSend send fails (today a failed `client.emails.send` falls through to that generic throw).
+- `LegacySesTransport` preserves the current no-throw-on-missing-team/domain behavior (logs and
+  returns) to avoid changing self-hosted default semantics.
+
+## Testing
+
+Unit tests only (no infra required), following repo convention `*.unit.test.ts`:
+
+- `providers/ses.unit.test.ts` — mock the SES client; assert `SendEmailCommand` is called with the
+  resolved `from` and `AWS_DEFAULT_REGION`; assert `FROM_EMAIL`-missing throws.
+- `providers/smtp.unit.test.ts` — mock `nodemailer.createTransport`; assert transport options
+  come from `MAILER_SMTP_*`; assert send is called; assert missing creds throws.
+- `providers/usesend.unit.test.ts` — mock the useSend client; assert `emails.send` is called; assert
+  failure throws a proper error.
+- `providers/resolve.unit.test.ts` — for each `MAILER_PROVIDER` value and for unset in both modes,
+  assert the correct transport class is returned; assert the singleton is cached.
+
+## Files
+
+New:
+- `apps/web/src/server/mailer/providers/types.ts`
+- `apps/web/src/server/mailer/providers/ses.ts`
+- `apps/web/src/server/mailer/providers/smtp.ts`
+- `apps/web/src/server/mailer/providers/usesend.ts`
+- `apps/web/src/server/mailer/providers/legacy-ses.ts`
+- `apps/web/src/server/mailer/providers/resolve.ts`
+- matching `*.unit.test.ts` for each above
+
+Modified:
+- `apps/web/src/server/mailer.ts` — refactor `sendMail` to delegate; keep high-level functions.
+- `apps/web/src/env.js` — add `MAILER_PROVIDER` and `MAILER_SMTP_*` to the server schema and
+  `runtimeEnv`.
+
+Optional follow-up (not required for the code change):
+- Expose `MAILER_PROVIDER` and `MAILER_SMTP_*` in `docker/prod/compose.saas.yml` and
+  `docker/prod/.env.example-saas`.
+
+## Backward Compatibility
+
+- `MAILER_PROVIDER` unset keeps exact current behavior in both modes.
+- `LegacySesTransport` reproduces the current self-hosted `sendMail` path verbatim, so self-hosted
+  deployments that rely on the in-app domain + queue continue to work unchanged.
+- No database migration; no schema change.
+
+## Open Questions
+
+None. All design decisions resolved during brainstorming.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Introduced a pluggable mailer with MAILER_PROVIDER (`ses`, `smtp`, `usesend`) and refactored platform emails to use it. Default behavior is preserved: self-hosted stays on legacy SES; cloud continues using useSend.

- **New Features**
  - Added `resolveMailerTransport` with cached `getMailerTransport()` and transports for SES, SMTP, and useSend.
  - New env vars for SMTP: MAILER_SMTP_HOST, MAILER_SMTP_PORT, MAILER_SMTP_USER, MAILER_SMTP_PASS, MAILER_SMTP_SECURE.
  - Exported `getSesClient` and implemented direct SES sending via `@aws-sdk/client-sesv2` + `nodemailer`.
  - Unit tests for all transports and resolver; Docker SaaS env examples updated.

- **Migration**
  - Set MAILER_PROVIDER to `ses`, `smtp`, or `usesend`.
  - Ensure FROM_EMAIL is set for all providers.
  - For SMTP, set MAILER_SMTP_HOST, MAILER_SMTP_USER, MAILER_SMTP_PASS (PORT defaults to 587; SECURE true if 465 or explicitly "true").
  - For SES, configure AWS_* and AWS_DEFAULT_REGION.
  - For useSend, provide USESEND_API_KEY or UNSEND_API_KEY.
  - If MAILER_PROVIDER is unset, no changes required (backward-compatible defaults).

<sup>Written for commit e260105fd6fda90de938c4b2c0a77c719b44c319. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usesend/useSend/pull/437?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable email delivery through Amazon SES, SMTP, UseSend, or legacy delivery.
  - Added SMTP settings for host, port, security mode, username, and password.
  - Supports selecting the email provider through environment configuration.
  - Preserves existing delivery behavior when no provider is specified.
- **Documentation**
  - Added production configuration templates and deployment settings for email providers.
  - Documented SaaS deployment support for SMTP and UseSend services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->