### PR TITLE
fix: docker host binding

### DIFF
--- a/docker/prod/compose.yml
+++ b/docker/prod/compose.yml
@@ -50,7 +50,8 @@ services:
     ports:
       - ${PORT:-3000}:${PORT:-3000}
     environment:
-      - PORT=${PORT:-3000}
+      - HOSTNAME=${HOSTNAME:-0.0.0.0}       
+      - PORT=${PORT:-3000}      
       - DATABASE_URL=${DATABASE_URL:?err}
       - NEXTAUTH_URL=${NEXTAUTH_URL:?err}
       - NEXTAUTH_SECRET=${NEXTAUTH_SECRET:?err}


### PR DESCRIPTION
Docker sets the HOSTNAME env variable bound to local name > local network address, making next to exposed to 127.0.0.1. Therefore you are not able to login or do anything else.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bind the Next.js server to 0.0.0.0 in the production Docker setup so it’s reachable via published ports, fixing broken login and other flows when running in Docker.

- **Bug Fixes**
  - Set HOSTNAME to default to 0.0.0.0 in docker/prod/compose.yml to ensure the app listens on all interfaces.

<sup>Written for commit 2c4ff44556959fb76eccdd8a2e5d4d168c6ff31d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usesend/useSend/pull/438?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved production deployment configuration by allowing the service hostname to be customized.
  * Added a default hostname setting to support standard network access while retaining configurable port settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->