### PR TITLE
fix: restore broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,11 +107,11 @@ Railway provides the quickest way to spin up useSend. Read the [Railway self-hos
 
 ## Star History
 
-<a href="https://star-history.com/#usesend/usesend&Date">
+<a href="https://star-history.dera.page/#usesend/usesend&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=usesend/usesend&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=usesend/usesend&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=usesend/usesend&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=usesend/usesend&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=usesend/usesend&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=usesend/usesend&type=Date" />
  </picture>
 </a>
 


### PR DESCRIPTION
The star history chart in the README stopped rendering because the underlying GitHub stargazer API can no longer be used without restrictions.

This PR updates the chart to a working alternative that requires no API token, restoring the chart for visitors and contributors. It only touches the Star History section; all other badges are left unchanged.

No migration needed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the README Star History chart by switching to a token-free source after API restrictions broke the previous embed. The chart was not rendering; it now renders for visitors and contributors without an API token.

- Replaces `api.star-history.com` SVG and anchor links with `star-history.dera.page`.
- Preserves dark/light `picture` sources and query parameters.
- README-only change; no migration or build/runtime impact.

<sup>Written for commit 0dd5d1680d37fccaed4965ba8d037afa5b8fef63. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usesend/useSend/pull/441?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Star History embeds to use the current `star-history.dera.page` URLs.
  * Replaced legacy Star History and API links in the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->