### PR TITLE
fix: render text-only emails in the email preview

### DIFF
--- a/apps/web/src/app/(dashboard)/emails/email-details.tsx
+++ b/apps/web/src/app/(dashboard)/emails/email-details.tsx
@@ -20,6 +20,7 @@ import {
   COMPLAINT_ERROR_MESSAGES,
   DELIVERY_DELAY_ERRORS,
 } from "@usesend/lib/src/constants/ses-errors";
+import { getEmailPreviewSrcDoc } from "~/lib/email-preview";
 import CancelEmail from "./cancel-email";
 import { useEffect } from "react";
 import { useState } from "react";
@@ -90,7 +91,10 @@ export default function EmailDetails({ emailId }: { emailId: string }) {
             animate={{ opacity: 1 }}
             transition={{ duration: 0.2, delay: 0.3 }}
           >
-            <EmailPreview html={emailQuery.data?.html ?? ""} />
+            <EmailPreview
+              html={emailQuery.data?.html}
+              text={emailQuery.data?.text}
+            />
           </motion.div>
         </div>
         {emailQuery.data?.latestStatus !== "SCHEDULED" ? (
@@ -134,7 +138,13 @@ export default function EmailDetails({ emailId }: { emailId: string }) {
   );
 }
 
-const EmailPreview = ({ html }: { html: string }) => {
+const EmailPreview = ({
+  html,
+  text,
+}: {
+  html: string | null | undefined;
+  text: string | null | undefined;
+}) => {
   const [show, setShow] = useState(false);
 
   useEffect(() => {
@@ -145,9 +155,21 @@ const EmailPreview = ({ html }: { html: string }) => {
     return () => clearTimeout(timer);
   }, []);
 
+  const srcDoc = getEmailPreviewSrcDoc(html, text);
+
   if (!show) {
     return (
       <div className="dark:bg-slate-200 h-[350px] overflow-visible rounded border-t"></div>
+    );
+  }
+
+  if (!srcDoc) {
+    return (
+      <div className="dark:bg-slate-200 h-[350px] overflow-visible rounded border-t flex items-center justify-center">
+        <span className="text-sm text-muted-foreground dark:text-slate-500">
+          No content to preview
+        </span>
+      </div>
     );
   }
 
@@ -155,7 +177,7 @@ const EmailPreview = ({ html }: { html: string }) => {
     <div className="dark:bg-slate-200 h-[350px] overflow-visible rounded border-t">
       <iframe
         className="w-full h-full"
-        srcDoc={html}
+        srcDoc={srcDoc}
         sandbox="allow-same-origin"
       />
     </div>

--- a/apps/web/src/lib/email-preview.ts
+++ b/apps/web/src/lib/email-preview.ts
@@ -1,0 +1,27 @@
+const escapeHtml = (value: string) =>
+  value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+
+/**
+ * Builds the srcDoc for the sandboxed email preview iframe. Emails sent with
+ * only a `text` body have no html, so the plain text is escaped and wrapped
+ * in a minimal document instead of rendering an empty preview.
+ */
+export function getEmailPreviewSrcDoc(
+  html: string | null | undefined,
+  text: string | null | undefined,
+): string | null {
+  if (html) {
+    return html;
+  }
+
+  if (text) {
+    return `<!doctype html><html><head><meta charset="utf-8"></head><body style="margin:0"><pre style="margin:0;padding:16px;font-family:ui-sans-serif,system-ui,sans-serif;font-size:14px;line-height:1.5;white-space:pre-wrap;word-break:break-word;color:#0f172a">${escapeHtml(text)}</pre></body></html>`;
+  }
+
+  return null;
+}

--- a/apps/web/src/lib/email-preview.unit.test.ts
+++ b/apps/web/src/lib/email-preview.unit.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import { getEmailPreviewSrcDoc } from "./email-preview";
+
+describe("getEmailPreviewSrcDoc", () => {
+  it("returns the html body unchanged when present", () => {
+    const html = "<html><body><h1>Hello</h1></body></html>";
+    expect(getEmailPreviewSrcDoc(html, "ignored text")).toBe(html);
+  });
+
+  it("wraps a text-only body in a plain-text document", () => {
+    const srcDoc = getEmailPreviewSrcDoc(null, "Hello\n\nworld");
+    expect(srcDoc).toContain("<pre");
+    expect(srcDoc).toContain("Hello\n\nworld");
+  });
+
+  it("escapes html inside a text body instead of rendering it", () => {
+    const srcDoc = getEmailPreviewSrcDoc(null, 'Use <b> & "quotes" wisely');
+    expect(srcDoc).not.toContain("<b>");
+    expect(srcDoc).toContain("&lt;b&gt; &amp; &quot;quotes&quot; wisely");
+  });
+
+  it("treats an empty html string as absent and falls back to text", () => {
+    const srcDoc = getEmailPreviewSrcDoc("", "plain body");
+    expect(srcDoc).toContain("plain body");
+    expect(srcDoc).toContain("<pre");
+  });
+
+  it("returns null when neither html nor text is present", () => {
+    expect(getEmailPreviewSrcDoc(null, null)).toBeNull();
+    expect(getEmailPreviewSrcDoc("", "")).toBeNull();
+    expect(getEmailPreviewSrcDoc(undefined, undefined)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Problem

Emails sent with only a `text` body show an empty preview in the email details view. `EmailPreview` always feeds `email.html ?? ""` into the sandboxed iframe, so when `html` is null the preview box renders blank even though the API already returns the text body.

Easy to reproduce: send an email through the API with `text` and no `html`, then open it under Emails in the dashboard.

## Fix

- New helper `getEmailPreviewSrcDoc(html, text)` in `apps/web/src/lib/email-preview.ts`: returns the html body unchanged when present, otherwise wraps the escaped text body in a minimal `<pre>` document for the same sandboxed iframe, or `null` when the email has neither.
- `email-details.tsx` passes both fields and shows a "No content to preview" placeholder for the `null` case (previously also a silent blank box).

The text body is HTML-escaped before being placed in the srcDoc, so text content can never execute as markup, and the existing iframe sandbox is untouched.

## Tests

Unit tests for the helper in `apps/web/src/lib/email-preview.unit.test.ts` (html passthrough, text fallback, escaping, empty-string handling, no-content case). `pnpm test:unit` passes. Also verified in the running dashboard against a seeded text-only email: preview was blank before, renders the body with line breaks preserved after.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render text-only emails in the email details preview to fix blank previews. Previously the preview always used `email.html ?? ""`; now it falls back to `text` and shows a placeholder when both bodies are absent.

- Add `getEmailPreviewSrcDoc(html, text)` to build the iframe `srcDoc`: returns HTML as-is; otherwise wraps escaped text in a minimal `<pre>` document; returns null when neither is present.
- Update `EmailPreview` to pass both fields, use the computed `srcDoc`, and render "No content to preview" when null.
- Treat empty-string HTML as absent; behavior for HTML emails is unchanged.
- Text is HTML-escaped; the iframe sandbox remains unchanged.
- Unit tests cover HTML passthrough, text fallback, escaping, empty-string handling, and no-content cases.

<sup>Written for commit b3555876a0d8722ae99cbad441193b3e088a3c4e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usesend/useSend/pull/442?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Email previews now support both HTML and plain-text content.
  * Plain-text emails are converted into safely formatted previews.
  * A clear “No content to preview” state appears when no email content is available.
* **Bug Fixes**
  * Special characters in plain-text email previews are safely escaped.
  * Empty HTML content now falls back appropriately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->