### PR TITLE
fix: clear attachments and headers in the email cleanup job

### DIFF
--- a/.env.selfhost.example
+++ b/.env.selfhost.example
@@ -41,5 +41,10 @@ AUTH_EMAIL_RATE_LIMIT=5
 # Optional: prefix all Redis keys (useful for shared Redis with ACL isolation)
 # REDIS_KEY_PREFIX=""
 
+# Optional: delete stored email content (text, html, attachments, headers) from
+# the database after this many days. Runs daily at midnight UTC. Disabled if
+# unset or not a positive number.
+# EMAIL_CLEANUP_DAYS=30
+
 # used to send important error notification - optional
 DISCORD_WEBHOOK_URL=""

--- a/.env.selfhost.example
+++ b/.env.selfhost.example
@@ -41,9 +41,9 @@ AUTH_EMAIL_RATE_LIMIT=5
 # Optional: prefix all Redis keys (useful for shared Redis with ACL isolation)
 # REDIS_KEY_PREFIX=""
 
-# Optional: delete stored email content (text, html, attachments, headers) from
-# the database after this many days. Runs daily at midnight UTC. Disabled if
-# unset or not a positive number.
+# Optional: clear stored email content (text, html, attachments, headers) from
+# the database after this many days. Runs daily at midnight UTC. Leave unset to
+# keep email content indefinitely.
 # EMAIL_CLEANUP_DAYS=30
 
 # used to send important error notification - optional

--- a/apps/docs/self-hosting/overview.mdx
+++ b/apps/docs/self-hosting/overview.mdx
@@ -81,6 +81,16 @@ Add the following environment variables.
 ```
 
   </Step>
+  <Step title="Email content retention (optional)">
+  By default, stored email content stays in the database forever. To bound database growth, set `EMAIL_CLEANUP_DAYS` to a positive number of days. A daily job (midnight UTC) then deletes the `text`, `html`, `attachments` and `headers` columns of emails older than the cutoff. Delivery status and event history are kept.
+
+```env
+EMAIL_CLEANUP_DAYS=30
+```
+
+Leave it unset to keep email content indefinitely.
+
+  </Step>
 </Steps>
 
 ## Step 2: Setting up the app

--- a/apps/docs/self-hosting/overview.mdx
+++ b/apps/docs/self-hosting/overview.mdx
@@ -82,7 +82,7 @@ Add the following environment variables.
 
   </Step>
   <Step title="Email content retention (optional)">
-  By default, stored email content stays in the database forever. To bound database growth, set `EMAIL_CLEANUP_DAYS` to a positive number of days. A daily job (midnight UTC) then deletes the `text`, `html`, `attachments` and `headers` columns of emails older than the cutoff. Delivery status and event history are kept.
+  By default, stored email content stays in the database forever. To bound database growth, set `EMAIL_CLEANUP_DAYS` to a positive number of days. A daily job (midnight UTC) then clears the `text`, `html`, `attachments` and `headers` values for emails older than the cutoff. Delivery status and event history are kept.
 
 ```env
 EMAIL_CLEANUP_DAYS=30

--- a/apps/web/src/server/jobs/cleanup-email-bodies.ts
+++ b/apps/web/src/server/jobs/cleanup-email-bodies.ts
@@ -37,11 +37,15 @@ if (isSelfHosted() && isEmailCleanupEnabled()) {
                     OR: [
                         {text: {not: null}},
                         {html: {not: null}},
+                        {attachments: {not: null}},
+                        {headers: {not: null}},
                     ],
                 },
                 data: {
                     text: null,
                     html: null,
+                    attachments: null,
+                    headers: null,
                 },
             });
 


### PR DESCRIPTION
## Problem

The retention cleanup job (`cleanup-email-bodies.ts`, enabled via `EMAIL_CLEANUP_DAYS`) nulls `text` and `html` on old emails but leaves `attachments` and `headers` untouched. Attachments are stored base64-encoded and are typically the largest column on the row.

Successful sends already clear both columns right after sending (`email-queue-service.ts`), so delivered mail is fine. But emails that never complete the send keep their attachments forever, even with cleanup enabled:

- failed sends — the catch path only sets `latestStatus: "FAILED"`
- cancelled scheduled emails
- emails stranded in `QUEUED` (see #407 / #406)

For self-hosters the cleanup job exists precisely to bound DB growth, and these rows are the heaviest ones it currently skips.

## Fix

Include `attachments` and `headers` in the cleanup `updateMany`, and extend the `OR` filter with both columns so already-clean rows are still excluded from the daily run.

Note on behavior: after cleanup, a failed email's attachments are no longer available. That matches the job's existing contract — `text`/`html` are already discarded the same way once a row passes the retention cutoff.

## Docs

`EMAIL_CLEANUP_DAYS` existed in the env schema but wasn't documented anywhere, so this also adds it to the self-hosting overview (as an optional step) and to `.env.selfhost.example`.

## Verification

`pnpm test:unit` passes (20 files, 120 tests). The job change is limited to the where/data shape of the existing query; the diff follows the file's current formatting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional email-content retention settings for self-hosted deployments.
  * Configure the retention period to automatically remove stored email content older than the selected number of days.
  * Delivery status and event history are preserved after cleanup, while leaving the setting unset retains content indefinitely.

* **Bug Fixes**
  * Email cleanup now removes attachment and header data, in addition to message text and HTML, from emails older than the configured retention cutoff.

* **Documentation**
  * Added guidance for configuring email-content retention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->