### PR TITLE
fix: send scheduled campaigns on BullMQ 5

### DIFF
--- a/apps/web/src/server/service/campaign-service.ts
+++ b/apps/web/src/server/service/campaign-service.ts
@@ -1249,7 +1249,7 @@ export class CampaignBatchService {
     await this.batchQueue.add(
       `campaign-${campaignId}`,
       { campaignId, teamId },
-      { jobId: `campaign-batch:${campaignId}`, ...DEFAULT_QUEUE_OPTIONS },
+      { jobId: `campaign-batch-${campaignId}`, ...DEFAULT_QUEUE_OPTIONS },
     );
   }
 }

--- a/apps/web/src/server/service/campaign-service.unit.test.ts
+++ b/apps/web/src/server/service/campaign-service.unit.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createHash } from "crypto";
 import { UnsubscribeReason } from "@prisma/client";
 
-const { mockDb, mockTx, mockUpdateContactSubscription } = vi.hoisted(() => {
+const { mockDb, mockTx, mockQueueAdd, mockContactUpdate } = vi.hoisted(() => {
   const mockTx = {
     campaignEmail: {
       findUnique: vi.fn(),
@@ -28,10 +28,12 @@ const { mockDb, mockTx, mockUpdateContactSubscription } = vi.hoisted(() => {
         findUnique: vi.fn(),
       },
       campaign: {
+        findUnique: vi.fn(),
         update: vi.fn(),
       },
     },
-    mockUpdateContactSubscription: vi.fn(),
+    mockQueueAdd: vi.fn(),
+    mockContactUpdate: vi.fn(),
   };
 });
 
@@ -50,12 +52,12 @@ vi.mock("~/env", () => ({
 }));
 
 vi.mock("~/server/service/contact-service", () => ({
-  updateContactSubscription: mockUpdateContactSubscription,
+  updateContactSubscription: mockContactUpdate,
 }));
 
 vi.mock("bullmq", () => ({
   Queue: class {
-    add = vi.fn();
+    add = mockQueueAdd;
   },
   Worker: class {},
 }));
@@ -92,6 +94,7 @@ vi.mock("~/server/logger/log", () => ({
 }));
 
 import {
+  CampaignBatchService,
   recordCampaignContactFailure,
   subscribeContact,
   unsubscribeContact,
@@ -118,6 +121,31 @@ const input = {
   },
   error: new Error("Queue for region ap-southeast-2 not found"),
 };
+
+describe("CampaignBatchService.queueBatch", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("uses a BullMQ-compatible custom job ID", async () => {
+    mockDb.campaign.findUnique.mockResolvedValue({
+      lastSentAt: null,
+      batchWindowMinutes: 0,
+      status: "SCHEDULED",
+    });
+
+    await CampaignBatchService.queueBatch({
+      campaignId: "campaign_1",
+      teamId: 7,
+    });
+
+    expect(mockQueueAdd).toHaveBeenCalledWith(
+      "campaign-campaign_1",
+      { campaignId: "campaign_1", teamId: 7 },
+      expect.objectContaining({ jobId: "campaign-batch-campaign_1" }),
+    );
+  });
+});
 
 describe("recordCampaignContactFailure", () => {
   beforeEach(() => {
@@ -210,7 +238,7 @@ describe("campaign contact subscription changes", () => {
     };
     const updatedContact = { ...contact, subscribed: false };
     mockDb.contact.findUnique.mockResolvedValue(contact);
-    mockUpdateContactSubscription.mockResolvedValue(updatedContact);
+    mockContactUpdate.mockResolvedValue(updatedContact);
 
     const result = await unsubscribeContact({
       contactId: "contact_1",
@@ -218,7 +246,7 @@ describe("campaign contact subscription changes", () => {
       reason: UnsubscribeReason.UNSUBSCRIBED,
     });
 
-    expect(mockUpdateContactSubscription).toHaveBeenCalledWith({
+    expect(mockContactUpdate).toHaveBeenCalledWith({
       contactId: "contact_1",
       subscribed: false,
       unsubscribeReason: UnsubscribeReason.UNSUBSCRIBED,
@@ -242,7 +270,7 @@ describe("campaign contact subscription changes", () => {
 
     await subscribeContact(id, hash);
 
-    expect(mockUpdateContactSubscription).toHaveBeenCalledWith({
+    expect(mockContactUpdate).toHaveBeenCalledWith({
       contactId: "contact_1",
       subscribed: true,
       unsubscribeReason: null,


### PR DESCRIPTION
Scheduled campaigns never leave SCHEDULED on BullMQ 5. The batch queue uses a custom job ID containing a colon, which BullMQ rejects with "Custom Id cannot contain :".

This changes the separator to a hyphen and adds a regression test at the CampaignBatchService.queueBatch call site.

Verification:
- Reproduced against a deployed self-hosted instance
- Confirmed the new test fails before the fix
- Focused campaign service tests: 6 passed
- Full web unit suite: 121 passed
- Web typecheck passed
- Focused ESLint passed
- Production verification after the same fix: a scheduled campaign completed 1/1

Migration notes: none. No schema, configuration, or dependency changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scheduled campaigns on `bullmq` 5 were stuck in SCHEDULED because the batch queue used a custom job ID with a colon, which `bullmq` rejects. We now use a hyphenated job ID, so campaigns enqueue and execute.

- CampaignBatchService.queueBatch sets jobId to "campaign-batch-<campaignId>" (was "campaign-batch:<campaignId>"); preserves deterministic idempotency.
- Adds a regression test that asserts a BullMQ-compatible job ID and verifies `Queue.add` receives the expected arguments; adjusts test mocks to spy on queue and contact updates.
- No schema, configuration, or dependency changes; no migration actions.

<sup>Written for commit dc0bdaed6572becdae25ee6fe1b5e8fbcdeefcf8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usesend/useSend/pull/445?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved campaign batch processing by ensuring queued jobs use compatible identifiers.
* **Tests**
  * Expanded coverage for campaign batch queuing and contact subscription updates.
  * Updated test scenarios to verify queued job details and webhook-related behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->