### PR TITLE
fix: restore campaign batch enqueueing

### DIFF
--- a/apps/web/src/server/service/campaign-service.ts
+++ b/apps/web/src/server/service/campaign-service.ts
@@ -1249,7 +1249,7 @@ export class CampaignBatchService {
     await this.batchQueue.add(
       `campaign-${campaignId}`,
       { campaignId, teamId },
-      { jobId: `campaign-batch:${campaignId}`, ...DEFAULT_QUEUE_OPTIONS },
+      { jobId: `campaign-batch-${campaignId}`, ...DEFAULT_QUEUE_OPTIONS },
     );
   }
 }

--- a/apps/web/src/server/service/campaign-service.unit.test.ts
+++ b/apps/web/src/server/service/campaign-service.unit.test.ts
@@ -28,12 +28,17 @@ const { mockDb, mockTx, mockUpdateContactSubscription } = vi.hoisted(() => {
         findUnique: vi.fn(),
       },
       campaign: {
+        findUnique: vi.fn(),
         update: vi.fn(),
       },
     },
     mockUpdateContactSubscription: vi.fn(),
   };
 });
+
+const { mockQueueAdd } = vi.hoisted(() => ({
+  mockQueueAdd: vi.fn(),
+}));
 
 vi.mock("~/server/db", () => ({
   db: mockDb,
@@ -55,7 +60,7 @@ vi.mock("~/server/service/contact-service", () => ({
 
 vi.mock("bullmq", () => ({
   Queue: class {
-    add = vi.fn();
+    add = mockQueueAdd;
   },
   Worker: class {},
 }));
@@ -92,6 +97,7 @@ vi.mock("~/server/logger/log", () => ({
 }));
 
 import {
+  CampaignBatchService,
   recordCampaignContactFailure,
   subscribeContact,
   unsubscribeContact,
@@ -193,6 +199,31 @@ describe("recordCampaignContactFailure", () => {
       where: { id: "email_3" },
       data: { latestStatus: "FAILED" },
     });
+  });
+});
+
+describe("CampaignBatchService", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("queues batches with a BullMQ-safe custom job ID", async () => {
+    mockDb.campaign.findUnique.mockResolvedValue({
+      lastSentAt: null,
+      batchWindowMinutes: 0,
+      status: "SCHEDULED",
+    });
+
+    await CampaignBatchService.queueBatch({
+      campaignId: "campaign_1",
+      teamId: 7,
+    });
+
+    expect(mockQueueAdd).toHaveBeenCalledWith(
+      "campaign-campaign_1",
+      { campaignId: "campaign_1", teamId: 7 },
+      expect.objectContaining({ jobId: "campaign-batch-campaign_1" }),
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

- replace the colon in campaign batch custom job IDs with a BullMQ-safe separator
- add a regression test for the exact queue options passed to BullMQ

## Incident and recovery

BullMQ 5.79 rejects custom job IDs containing `:`, so `campaign-batch:<campaignId>` prevented every due campaign batch from being enqueued and left campaigns in `SCHEDULED` or `RUNNING`.

Existing campaigns are persisted in Postgres and are not lost. After this fix is deployed, the scheduler will discover due `SCHEDULED`/`RUNNING` campaigns again and enqueue them with the valid ID. Campaigns that previously completed batches retain `lastCursor` and `CampaignEmail` recipient links, so processing resumes without restarting completed recipients. The reported campaign never entered batch processing, so it should start its first batch after rollout.

## Verification

- `pnpm --filter web exec vitest run -c vitest.unit.config.ts src/server/service/campaign-service.unit.test.ts -t 'queues batches with a BullMQ-safe custom job ID'`
- `pnpm exec prettier --check apps/web/src/server/service/campaign-service.ts apps/web/src/server/service/campaign-service.unit.test.ts`

## Migration notes

No database migration or data repair is required.

## Screenshots

Not applicable; this is a background queue fix.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores campaign batch enqueueing by switching to a `bullmq`-safe custom job ID. Previously `campaign-batch:<campaignId>` was rejected by `bullmq` v5.79, so due batches were not enqueued and campaigns stayed SCHEDULED/RUNNING; now we use `campaign-batch-<campaignId>` and the scheduler enqueues due campaigns, resuming from existing cursors without resending completed recipients.

- Review notes
  - Replace “:” with “-” in the jobId passed to `bullmq` Queue.add; ID uniqueness semantics are unchanged.
  - Add a unit test that asserts the exact queue options, including the custom jobId.

- Rollout
  - No migration or data repair required.
  - After deploy, the scheduler will discover due SCHEDULED/RUNNING campaigns and enqueue batches automatically.

<sup>Written for commit d1a5b5f4d6c09dc13e22a619ec5ece4f2db8bc5e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usesend/useSend/pull/446?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated campaign batch job identifiers to use a BullMQ-compatible format, improving reliable queue processing.

* **Tests**
  * Added coverage to verify campaign batches are queued with the expected payload and job identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->