### PR TITLE
fix: derive SMTP proxy Bcc recipients from the envelope

### DIFF
--- a/apps/smtp-server/src/recipients.ts
+++ b/apps/smtp-server/src/recipients.ts
@@ -1,0 +1,65 @@
+import type { AddressObject, ParsedMail } from 'mailparser'
+
+type RecipientField = AddressObject | AddressObject[] | undefined
+
+function toList(field: RecipientField): AddressObject[] {
+  if (!field) return []
+  return Array.isArray(field) ? field : [field]
+}
+
+function fieldText(field: RecipientField): string | undefined {
+  const list = toList(field)
+  return list.length > 0 ? list.map((addr) => addr.text).join(', ') : undefined
+}
+
+function fieldAddresses(field: RecipientField): string[] {
+  return toList(field).flatMap((addr) =>
+    addr.value.flatMap((entry) => {
+      if (entry.address) return [entry.address]
+      // Address groups keep their members nested one level deeper.
+      return (entry.group ?? [])
+        .map((member) => member.address)
+        .filter((address): address is string => Boolean(address))
+    })
+  )
+}
+
+function normalize(address: string): string {
+  return address.trim().toLowerCase()
+}
+
+/**
+ * Resolves the To/Cc/Bcc fields for the useSend API from a parsed message and
+ * the SMTP envelope.
+ *
+ * RFC 5322 tells sending clients to strip the `Bcc:` header before
+ * transmission, so for a compliant client the Bcc recipients only survive in
+ * the SMTP envelope (`RCPT TO`). Every envelope recipient that is not already
+ * named in To or Cc is therefore treated as Bcc. A leaked `Bcc:` header is
+ * still honored so non-compliant clients keep working.
+ */
+export function resolveRecipients(
+  parsed: ParsedMail,
+  envelopeRecipients: string[]
+): { to?: string; cc?: string; bcc?: string } {
+  const to = fieldText(parsed.to)
+  const cc = fieldText(parsed.cc)
+
+  const visible = new Set(
+    [...fieldAddresses(parsed.to), ...fieldAddresses(parsed.cc)].map(normalize)
+  )
+
+  const bcc: string[] = []
+  const seen = new Set<string>()
+  const addBcc = (address: string) => {
+    const key = normalize(address)
+    if (visible.has(key) || seen.has(key)) return
+    seen.add(key)
+    bcc.push(address)
+  }
+
+  fieldAddresses(parsed.bcc).forEach(addBcc)
+  envelopeRecipients.forEach(addBcc)
+
+  return { to, cc, bcc: bcc.length > 0 ? bcc.join(', ') : undefined }
+}

--- a/apps/smtp-server/src/recipients.unit.test.ts
+++ b/apps/smtp-server/src/recipients.unit.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest'
+import { simpleParser } from 'mailparser'
+import { resolveRecipients } from './recipients'
+
+async function parse(lines: string[]) {
+  return simpleParser(lines.join('\r\n'))
+}
+
+describe('resolveRecipients', () => {
+  it('derives bcc from envelope recipients missing from To and Cc', async () => {
+    const parsed = await parse([
+      'From: sender@example.com',
+      'To: "Recipient One" <recipient@example.com>',
+      'Cc: copy@example.com',
+      'Subject: Invoice',
+      '',
+      'Hello',
+    ])
+
+    const result = resolveRecipients(parsed, [
+      'recipient@example.com',
+      'copy@example.com',
+      'hidden@example.com',
+    ])
+
+    expect(result).toEqual({
+      to: '"Recipient One" <recipient@example.com>',
+      cc: 'copy@example.com',
+      bcc: 'hidden@example.com',
+    })
+  })
+
+  it('compares addresses case-insensitively', async () => {
+    const parsed = await parse([
+      'From: sender@example.com',
+      'To: Recipient@Example.com',
+      'Subject: Invoice',
+      '',
+      'Hello',
+    ])
+
+    const result = resolveRecipients(parsed, ['recipient@example.com'])
+
+    expect(result).toEqual({
+      to: 'Recipient@Example.com',
+      cc: undefined,
+      bcc: undefined,
+    })
+  })
+
+  it('merges a leaked Bcc header with envelope-only recipients', async () => {
+    const parsed = await parse([
+      'From: sender@example.com',
+      'To: recipient@example.com',
+      'Bcc: header-hidden@example.com',
+      'Subject: Invoice',
+      '',
+      'Hello',
+    ])
+
+    const result = resolveRecipients(parsed, [
+      'recipient@example.com',
+      'header-hidden@example.com',
+      'envelope-hidden@example.com',
+    ])
+
+    expect(result.bcc).toBe(
+      'header-hidden@example.com, envelope-hidden@example.com'
+    )
+  })
+
+  it('keeps the header Bcc when the envelope is unavailable', async () => {
+    const parsed = await parse([
+      'From: sender@example.com',
+      'To: recipient@example.com',
+      'Bcc: hidden@example.com',
+      'Subject: Invoice',
+      '',
+      'Hello',
+    ])
+
+    expect(resolveRecipients(parsed, []).bcc).toBe('hidden@example.com')
+  })
+
+  it('returns undefined bcc when the envelope matches the headers', async () => {
+    const parsed = await parse([
+      'From: sender@example.com',
+      'To: a@example.com, b@example.com',
+      'Subject: Invoice',
+      '',
+      'Hello',
+    ])
+
+    const result = resolveRecipients(parsed, ['a@example.com', 'b@example.com'])
+
+    expect(result).toEqual({
+      to: 'a@example.com, b@example.com',
+      cc: undefined,
+      bcc: undefined,
+    })
+  })
+})

--- a/apps/smtp-server/src/server.ts
+++ b/apps/smtp-server/src/server.ts
@@ -4,6 +4,7 @@ import dotenv from "dotenv";
 import { simpleParser } from "mailparser";
 import { readFileSync, watch, FSWatcher } from "fs";
 import { extractForwardedHeaders } from "./email-headers";
+import { resolveRecipients } from "./recipients";
 
 dotenv.config();
 
@@ -90,11 +91,13 @@ const serverOptions: SMTPServerOptions = {
       }
 
       const forwardedHeaders = extractForwardedHeaders(parsed.headerLines);
+      const { to, cc, bcc } = resolveRecipients(
+        parsed,
+        session.envelope.rcptTo.map((recipient) => recipient.address),
+      );
 
       const emailObject = {
-        to: Array.isArray(parsed.to)
-          ? parsed.to.map((addr) => addr.text).join(", ")
-          : parsed.to?.text,
+        to,
         from: Array.isArray(parsed.from)
           ? parsed.from.map((addr) => addr.text).join(", ")
           : parsed.from?.text,
@@ -102,12 +105,8 @@ const serverOptions: SMTPServerOptions = {
         text: parsed.text,
         html: parsed.html,
         replyTo: parsed.replyTo?.text,
-        cc: Array.isArray(parsed.cc)
-          ? parsed.cc.map((addr) => addr.text).join(", ")
-          : parsed.cc?.text,
-        bcc: Array.isArray(parsed.bcc)
-          ? parsed.bcc.map((addr) => addr.text).join(", ")
-          : parsed.bcc?.text,
+        cc,
+        bcc,
         headers: forwardedHeaders,
         attachments:
           parsed.attachments.length > 0


### PR DESCRIPTION
RFC 5322 tells sending clients to strip the Bcc header before transmission, so for a compliant client (nodemailer, PHPMailer, ...) the Bcc recipients only survive in the SMTP envelope as RCPT TO commands. The proxy accepted those recipients but only ever looked at the parsed Bcc header, so envelope-only Bcc recipients were silently dropped and never reached the useSend API or SES.

Treat every envelope recipient that is not already named in To or Cc as Bcc, merge in a leaked Bcc header for non-compliant clients, and compare addresses case-insensitively on the bare address so display names in To don't get misclassified as Bcc.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the SMTP proxy to derive Bcc recipients from the SMTP envelope instead of only the parsed Bcc header.

- Envelope recipients not already present in To or Cc are now treated as Bcc.
- Leaked Bcc headers are merged with envelope-only recipients.
- Address comparisons are case-insensitive on the bare address.

<sup>Written for commit 351450b847f8a7ab3c22d8043de84fdce195bac9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usesend/useSend/pull/447?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recipient detection for sent emails, including recipients specified only through the SMTP envelope.
  * Correctly handles nested address groups, duplicate addresses, and case differences.
  * Prevents Bcc recipients from appearing in visible To or Cc fields while preserving valid Bcc information.

* **Tests**
  * Added coverage for Bcc derivation, merging, filtering, and recipient matching scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->