### PR TITLE
fix: prevent variable popover from blocking text selection

### DIFF
--- a/packages/email-editor/src/nodes/variable.tsx
+++ b/packages/email-editor/src/nodes/variable.tsx
@@ -169,9 +169,8 @@ export function getVariableSuggestions(
 export function VariableComponent(props: NodeViewProps) {
   const { name, fallback } = props.node.attrs as VariableOptions;
   const [fallbackValue, setFallbackValue] = useState(fallback);
+  const [open, setOpen] = useState(false);
   const { getPos, editor } = props;
-
-  console.log(props.selected);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -188,7 +187,7 @@ export function VariableComponent(props: NodeViewProps) {
       draggable="false"
       data-drag-handle=""
     >
-      <Popover open={props.selected}>
+      <Popover open={open} onOpenChange={setOpen}>
         <PopoverTrigger asChild>
           <button
             className={cn(
@@ -197,8 +196,11 @@ export function VariableComponent(props: NodeViewProps) {
             )}
             onClick={(e) => {
               e.preventDefault();
+
               const pos = getPos();
               editor.commands.setNodeSelection(pos);
+
+              setOpen(true);
             }}
           >
             <span className="">{`{{${name}}}`}</span>


### PR DESCRIPTION
## Description

Fixes #277.

### Problem

Selecting text across an email variable such as `{{firstName}}` caused the variable's fallback-value popover to open automatically. This interrupted mouse-based text selection and prevented users from copying text containing variables.

### Fix

- Decoupled the variable fallback popover from ProseMirror's `props.selected` state.
- The popover is now controlled locally.
- Selecting text containing a variable no longer opens the fallback editor.
- Clicking the variable still opens the fallback editor.

### Testing

- Verified normal text selection and copy.
- Verified mouse selection across `{{firstName}}`.
- Verified copied text can be pasted successfully.
- Verified clicking `{{firstName}}` still opens the fallback-value editor.
- `@usesend/email-editor` build passes.
- `git diff --check` passes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the variable fallback popover from opening during text selection, so selecting and copying text that contains variables like `{{firstName}}` works normally. Clicking a variable still opens the fallback editor.

<sup>Written for commit eb403e8e0ae04d3a14007888f800058388e97dcc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usesend/useSend/pull/448?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved variable popover behavior so it opens reliably when a variable is selected.
  * Ensured the popover remains synchronized with user interactions and closes correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->