### PR TITLE
fix: declare SMTP workspace package

### DIFF
--- a/apps/smtp-server/pnpm-workspace.yaml
+++ b/apps/smtp-server/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
+packages:
+  - "."
+
 allowBuilds:
   esbuild: true
 


### PR DESCRIPTION
## Summary

- declare the SMTP server root as a package in its nested pnpm workspace
- allow pnpm 9 to run the SMTP build command in Coolify without `packages field missing or empty`

## Context

After the lockfile compatibility fix, Coolify completed dependency installation but failed when Turborepo invoked `pnpm run build` from `apps/smtp-server`. Its nested `pnpm-workspace.yaml` had settings but no `packages` declaration.

## Verification

- `corepack pnpm@9.15.4 --dir apps/smtp-server run --if-present __workspace_config_check__`
- `CI=true corepack pnpm@9.15.4 install --filter=smtp-server --frozen-lockfile --lockfile-only`
- `git diff --check`

Build not run per repository policy.

## Screenshots

Not applicable.

## Migration notes

No database migrations.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the SMTP server build failure in Coolify under pnpm 9 by adding a `packages` declaration to its nested `pnpm-workspace.yaml`.

<sup>Written for commit 787aeb434ece8eac0dfb44308f6430b5d749eef0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/usesend/useSend/pull/451?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workspace configuration to include the SMTP server’s root package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->